### PR TITLE
Rename serialize.load_path to resolve_path

### DIFF
--- a/datablock.py
+++ b/datablock.py
@@ -19,7 +19,7 @@ from dxtbx.format.image import ImageBool, ImageDouble
 from dxtbx.format.Registry import Registry
 from dxtbx.model import BeamFactory, DetectorFactory, GoniometerFactory, ScanFactory
 from dxtbx.serialize import load
-from dxtbx.serialize.filename import load_path
+from dxtbx.serialize.filename import resolve_path
 from dxtbx.sweep_filenames import (
     locate_files_matching_template_string,
     template_regex,
@@ -801,7 +801,7 @@ class DataBlockDictImporter(object):
             if ident == "ImageSweep":
                 beam, detector, gonio, scan = load_models(imageset)
                 if "template" in imageset:
-                    template = load_path(imageset["template"], directory=directory)
+                    template = resolve_path(imageset["template"], directory=directory)
                     i0, i1 = scan.get_image_range()
                     iset = dxtbx.imageset.ImageSetFactory.make_sweep(
                         template,
@@ -815,7 +815,7 @@ class DataBlockDictImporter(object):
                         format_kwargs=format_kwargs,
                     )
                     if "mask" in imageset and imageset["mask"] is not None:
-                        imageset["mask"] = load_path(
+                        imageset["mask"] = resolve_path(
                             imageset["mask"], directory=directory
                         )
                         iset.external_lookup.mask.filename = imageset["mask"]
@@ -825,7 +825,7 @@ class DataBlockDictImporter(object):
                                     pickle.load(infile)
                                 )
                     if "gain" in imageset and imageset["gain"] is not None:
-                        imageset["gain"] = load_path(
+                        imageset["gain"] = resolve_path(
                             imageset["gain"], directory=directory
                         )
                         iset.external_lookup.gain.filename = imageset["gain"]
@@ -835,7 +835,7 @@ class DataBlockDictImporter(object):
                                     pickle.load(infile)
                                 )
                     if "pedestal" in imageset and imageset["pedestal"] is not None:
-                        imageset["pedestal"] = load_path(
+                        imageset["pedestal"] = resolve_path(
                             imageset["pedestal"], directory=directory
                         )
                         iset.external_lookup.pedestal.filename = imageset["pedestal"]
@@ -845,14 +845,18 @@ class DataBlockDictImporter(object):
                                     pickle.load(infile)
                                 )
                     if "dx" in imageset and imageset["dx"] is not None:
-                        imageset["dx"] = load_path(imageset["dx"], directory=directory)
+                        imageset["dx"] = resolve_path(
+                            imageset["dx"], directory=directory
+                        )
                         iset.external_lookup.dx.filename = imageset["dx"]
                         with open(imageset["dx"]) as infile:
                             iset.external_lookup.dx.data = ImageDouble(
                                 pickle.load(infile)
                             )
                     if "dy" in imageset and imageset["dy"] is not None:
-                        imageset["dy"] = load_path(imageset["dy"], directory=directory)
+                        imageset["dy"] = resolve_path(
+                            imageset["dy"], directory=directory
+                        )
                         iset.external_lookup.dy.filename = imageset["dy"]
                         with open(imageset["dy"]) as infile:
                             iset.external_lookup.dy.data = ImageDouble(
@@ -860,7 +864,7 @@ class DataBlockDictImporter(object):
                             )
                     iset.update_detector_px_mm_data()
                 elif "master" in imageset:
-                    template = load_path(imageset["master"], directory=directory)
+                    template = resolve_path(imageset["master"], directory=directory)
                     i0, i1 = scan.get_image_range()
                     if not check_format:
                         format_class = FormatMultiImage
@@ -878,7 +882,7 @@ class DataBlockDictImporter(object):
                         format_kwargs=format_kwargs,
                     )
                     if "mask" in imageset and imageset["mask"] is not None:
-                        imageset["mask"] = load_path(imageset["mask"], directory)
+                        imageset["mask"] = resolve_path(imageset["mask"], directory)
                         iset.external_lookup.mask.filename = imageset["mask"]
                         if check_format:
                             with open(imageset["mask"]) as infile:
@@ -886,7 +890,7 @@ class DataBlockDictImporter(object):
                                     pickle.load(infile)
                                 )
                     if "gain" in imageset and imageset["gain"] is not None:
-                        imageset["gain"] = load_path(imageset["gain"], directory)
+                        imageset["gain"] = resolve_path(imageset["gain"], directory)
                         iset.external_lookup.gain.filename = imageset["gain"]
                         if check_format:
                             with open(imageset["gain"]) as infile:
@@ -894,7 +898,7 @@ class DataBlockDictImporter(object):
                                     pickle.load(infile)
                                 )
                     if "pedestal" in imageset and imageset["pedestal"] is not None:
-                        imageset["pedestal"] = load_path(
+                        imageset["pedestal"] = resolve_path(
                             imageset["pedestal"], directory
                         )
                         iset.external_lookup.pedestal.filename = imageset["pedestal"]
@@ -904,14 +908,14 @@ class DataBlockDictImporter(object):
                                     pickle.load(infile)
                                 )
                     if "dx" in imageset and imageset["dx"] is not None:
-                        imageset["dx"] = load_path(imageset["dx"], directory)
+                        imageset["dx"] = resolve_path(imageset["dx"], directory)
                         iset.external_lookup.dx.filename = imageset["dx"]
                         with open(imageset["dx"]) as infile:
                             iset.external_lookup.dx.data = ImageDouble(
                                 pickle.load(infile)
                             )
                     if "dy" in imageset and imageset["dy"] is not None:
-                        imageset["dy"] = load_path(imageset["dy"], directory)
+                        imageset["dy"] = resolve_path(imageset["dy"], directory)
                         iset.external_lookup.dy.filename = imageset["dy"]
                         with open(imageset["dy"]) as infile:
                             iset.external_lookup.dy.data = ImageDouble(
@@ -938,7 +942,7 @@ class DataBlockDictImporter(object):
                     iset.set_goniometer(gonio, i)
                     iset.set_scan(scan, i)
                 if "mask" in imageset and imageset["mask"] is not None:
-                    imageset["mask"] = load_path(imageset["mask"], directory)
+                    imageset["mask"] = resolve_path(imageset["mask"], directory)
                     iset.external_lookup.mask.filename = imageset["mask"]
                     if check_format:
                         with open(imageset["mask"]) as infile:
@@ -946,7 +950,7 @@ class DataBlockDictImporter(object):
                                 pickle.load(infile)
                             )
                 if "gain" in imageset and imageset["gain"] is not None:
-                    imageset["gain"] = load_path(imageset["gain"], directory)
+                    imageset["gain"] = resolve_path(imageset["gain"], directory)
                     iset.external_lookup.gain.filename = imageset["gain"]
                     if check_format:
                         with open(imageset["gain"]) as infile:
@@ -954,7 +958,7 @@ class DataBlockDictImporter(object):
                                 pickle.load(infile)
                             )
                 if "pedestal" in imageset and imageset["pedestal"] is not None:
-                    imageset["pedestal"] = load_path(imageset["pedestal"], directory)
+                    imageset["pedestal"] = resolve_path(imageset["pedestal"], directory)
                     iset.external_lookup.pedestal.filename = imageset["pedestal"]
                     if check_format:
                         with open(imageset["pedestal"]) as infile:
@@ -962,12 +966,12 @@ class DataBlockDictImporter(object):
                                 pickle.load(infile)
                             )
                 if "dx" in imageset and imageset["dx"] is not None:
-                    imageset["dx"] = load_path(imageset["dx"], directory)
+                    imageset["dx"] = resolve_path(imageset["dx"], directory)
                     iset.external_lookup.dx.filename = imageset["dx"]
                     with open(imageset["dx"]) as infile:
                         iset.external_lookup.dx.data = ImageDouble(pickle.load(infile))
                 if "dy" in imageset and imageset["dy"] is not None:
-                    imageset["dy"] = load_path(imageset["dy"], directory)
+                    imageset["dy"] = resolve_path(imageset["dy"], directory)
                     iset.external_lookup.dy.filename = imageset["dy"]
                     with open(imageset["dy"]) as infile:
                         iset.external_lookup.dy.data = ImageDouble(pickle.load(infile))

--- a/model/experiment_list.py
+++ b/model/experiment_list.py
@@ -31,7 +31,7 @@ from dxtbx.model import (
     ScanFactory,
 )
 from dxtbx.serialize import xds
-from dxtbx.serialize.filename import load_path
+from dxtbx.serialize.filename import resolve_path
 from dxtbx.serialize.load import _decode_dict
 from dxtbx.sweep_filenames import template_image_range
 
@@ -195,7 +195,7 @@ class ExperimentListDict(object):
         if param not in imageset_data:
             return None, None
 
-        filename = load_path(imageset_data[param], directory=self._directory)
+        filename = resolve_path(imageset_data[param], directory=self._directory)
         if self._check_format and filename:
             with open(filename, "rb") as fh:
                 return filename, pickle.load(fh)
@@ -368,7 +368,7 @@ class ExperimentListDict(object):
     def _make_stills(self, imageset, format_kwargs=None):
         """ Make a still imageset. """
         filenames = [
-            load_path(p, directory=self._directory) for p in imageset["images"]
+            resolve_path(p, directory=self._directory) for p in imageset["images"]
         ]
         indices = None
         if "single_file_indices" in imageset:
@@ -400,7 +400,7 @@ class ExperimentListDict(object):
     ):
         """ Make an image sweep. """
         # Get the template format
-        template = load_path(imageset["template"], directory=self._directory)
+        template = resolve_path(imageset["template"], directory=self._directory)
 
         # Get the number of images (if no scan is given we'll try
         # to find all the images matching the template
@@ -475,7 +475,7 @@ class ExperimentListDict(object):
     @staticmethod
     def _from_file(filename, directory=None):
         """ Load a model dictionary from a file. """
-        filename = load_path(filename, directory=directory)
+        filename = resolve_path(filename, directory=directory)
         try:
             with open(filename, "r") as infile:
                 return json.load(infile, object_hook=_decode_dict)

--- a/serialize/filename.py
+++ b/serialize/filename.py
@@ -1,9 +1,11 @@
 from __future__ import absolute_import, division, print_function
 import os
 
+import warnings
+
 
 def load_path(path, directory=None):
-    """Load a filename from a JSON file.
+    """[DEPRECATED: Use resolve_path] Load a filename from a JSON file.
 
     First expand any environment and user variables. Then create the absolute path
     from the current directory (i.e. the directory in which the JSON file is
@@ -12,6 +14,27 @@ def load_path(path, directory=None):
     Params:
       path The path to the file.
 
+    """
+    warnings.warn(
+        "Use dxtbx.filename.resolve_path instead of load_path",
+        DeprecationWarning,
+        stacklevel=2,
+    )
+    return resolve_path(path, directory)
+
+
+def resolve_path(path, directory=None):
+    """Resolve a file path.
+
+    First expand any environment and user variables. Then create the absolute
+    path by applying the relative path to the provided directory, if necessary.
+
+    Args:
+      path (str): The path to resolve
+      directory (Optional[str]): The local path to resolve relative links
+
+    Returns:
+        str: The absolute path to the file to read
     """
     if not path:
         return ""

--- a/serialize/imageset.py
+++ b/serialize/imageset.py
@@ -6,7 +6,7 @@ import os
 from dxtbx.format.image import ImageBool, ImageDouble  # noqa: F401, import dependency
 from dxtbx.imageset import ImageSet, ImageSetFactory, ImageSweep
 from dxtbx.model import BeamFactory, DetectorFactory, GoniometerFactory, ScanFactory
-from dxtbx.serialize.filename import load_path
+from dxtbx.serialize.filename import resolve_path
 
 
 def filename_to_absolute(filename):
@@ -99,23 +99,23 @@ def basic_imageset_from_dict(d, directory=None):
     """ Construct an ImageSet class from the dictionary."""
     # Get the filename list and create the imageset
     filenames = map(
-        lambda p: load_path(p, directory=directory), map(str, d["filenames"])
+        lambda p: resolve_path(p, directory=directory), map(str, d["filenames"])
     )
     imageset = ImageSetFactory.new(filenames)[0]
 
     # Set some external lookups
     if "mask" in d and d["mask"] is not None and d["mask"] is not "":
-        path = load_path(d["mask"], directory=directory)
+        path = resolve_path(d["mask"], directory=directory)
         with open(path) as infile:
             imageset.external_lookup.mask.filename = path
             imageset.external_lookup.mask.data = ImageBool(pickle.load(infile))
     if "gain" in d and d["gain"] is not None and d["gain"] is not "":
-        path = load_path(d["gain"], directory=directory)
+        path = resolve_path(d["gain"], directory=directory)
         with open(path) as infile:
             imageset.external_lookup.gain.filename = path
             imageset.external_lookup.gain.data = ImageDouble(pickle.load(infile))
     if "pedestal" in d and d["pedestal"] is not None and d["pedestal"] is not "":
-        path = load_path(d["pedestal"], directory=directory)
+        path = resolve_path(d["pedestal"], directory=directory)
         with open(path) as infile:
             imageset.external_lookup.pedestal.filename = path
             imageset.external_lookup.pedestal.data = ImageDouble(pickle.load(infile))
@@ -135,7 +135,7 @@ def basic_imageset_from_dict(d, directory=None):
 def imagesweep_from_dict(d, check_format=True, directory=None):
     """Construct and image sweep from the dictionary."""
     # Get the template (required)
-    template = load_path(str(d["template"]), directory=directory)
+    template = resolve_path(str(d["template"]), directory=directory)
 
     # If the scan isn't set, find all available files
     scan_dict = d.get("scan")
@@ -175,17 +175,17 @@ def imagesweep_from_dict(d, check_format=True, directory=None):
 
     # Set some external lookups
     if "mask" in d and d["mask"] is not None and d["mask"] is not "":
-        path = load_path(d["mask"], directory=directory)
+        path = resolve_path(d["mask"], directory=directory)
         with open(path) as infile:
             sweep.external_lookup.mask.filename = path
             sweep.external_lookup.mask.data = ImageBool(pickle.load(infile))
     if "gain" in d and d["gain"] is not None and d["gain"] is not "":
-        path = load_path(d["gain"], directory=directory)
+        path = resolve_path(d["gain"], directory=directory)
         with open(path) as infile:
             sweep.external_lookup.gain.filename = path
             sweep.external_lookup.gain.data = ImageDouble(pickle.load(infile))
     if "pedestal" in d and d["pedestal"] is not None and d["pedestal"] is not "":
-        path = load_path(d["pedestal"], directory=directory)
+        path = resolve_path(d["pedestal"], directory=directory)
         with open(path) as infile:
             sweep.external_lookup.pedestal.filename = path
             sweep.external_lookup.pedestal.data = ImageDouble(pickle.load(infile))

--- a/tests/serialize/test_filename.py
+++ b/tests/serialize/test_filename.py
@@ -2,14 +2,14 @@ from __future__ import absolute_import, division, print_function
 
 import os
 
+from dxtbx.serialize.filename import resolve_path
 
-def test_load_path():
-    from dxtbx.serialize.filename import load_path
 
+def test_resolve_path():
     os.environ["HELLO_WORLD"] = "EXPANDED"
     new_path = os.path.join("~", "$HELLO_WORLD", "path")
-    path = load_path(new_path)
+    path = resolve_path(new_path)
     assert path == os.path.join(os.path.expanduser("~"), "EXPANDED", "path")
     new_path = os.path.join("$HELLO_WORLD", "path")
-    path = load_path(new_path)
+    path = resolve_path(new_path)
     assert path == os.path.abspath(os.path.join("EXPANDED", "path"))


### PR DESCRIPTION
`load_path` wasn't very descriptive; and implied that it was doing more work than just processing the pathname. `resolve_path` isn't perfect but is much better and doesn't suggest that it's doing any file reading.

In this patch I've kept `load_path` but it raises a DeprecationWarning when used; I don't know if this is treated as an external API so removing will break anything else? I'm happy to remove completely if nobody thinks this is the case....