### PR TITLE
Faster deserialisation of still experiments via information reuse

### DIFF
--- a/format/FormatMultiImage.py
+++ b/format/FormatMultiImage.py
@@ -207,7 +207,7 @@ class FormatMultiImage(Format):
 
         # Get the format instance
         assert len(filenames) == 1
-        if check_format is True:
+         if check_format:
             # HACK: Attempt to see if this was the same as the last file we generated
             # a format instance for. If it was, then give the same instance back. This
             # works around a structural problem with deserializing imagesets
@@ -317,7 +317,7 @@ class FormatMultiImage(Format):
                 single_file_index = single_file_indices[0]
                 # If we don't have a beam and detector provided we need
                 # to read it - but only for this image
-                if all(x is None for x in (beam, detector)):
+                if not beam and not detector:
                     beam = format_instance.get_beam(single_file_index)
                     detector = format_instance.get_detector(single_file_index)
                     goniometer = format_instance.get_goniometer(single_file_index)

--- a/format/FormatMultiImage.py
+++ b/format/FormatMultiImage.py
@@ -207,7 +207,7 @@ class FormatMultiImage(Format):
 
         # Get the format instance
         assert len(filenames) == 1
-         if check_format:
+        if check_format:
             # HACK: Attempt to see if this was the same as the last file we generated
             # a format instance for. If it was, then give the same instance back. This
             # works around a structural problem with deserializing imagesets

--- a/format/FormatMultiImage.py
+++ b/format/FormatMultiImage.py
@@ -95,6 +95,18 @@ class Masker(object):
 
 
 class FormatMultiImage(Format):
+    # HACK: Store information about the last imageset generated. This allows
+    # us to avoid reopening the file over and over in e.g. still cases where
+    # this can number over the tens of thousands of images.
+    # Fields: (key, format-instance, data-object)
+    # where key is (filename, kwargs) to ensure that we have exactly the
+    #       same file requirements.
+    _last_imageset_info = (
+        (None, None),
+        None,
+        None,
+    )  # type: Tuple[Tuple[str, Dict], Format, ImageSetData]
+
     def __init__(self, **kwargs):
         pass
 
@@ -193,9 +205,18 @@ class FormatMultiImage(Format):
         # Get the format instance
         assert len(filenames) == 1
         if check_format is True:
-            format_instance = cls(filenames[0], **format_kwargs)
+            # HACK: Attempt to see if this was the same as the last file we generated
+            # a format instance for. If it was, then give the same instance back. This
+            # works around a structural problem with deserializing imagesets
+            key, instance, isetdata = cls._last_imageset_info
+            if key == (filenames, format_kwargs):
+                format_instance = instance
+            else:
+                format_instance = cls(filenames[0], **format_kwargs)
+                isetdata = None
         else:
             format_instance = None
+            isetdata = None
             if not as_sweep:
                 lazy = True
 
@@ -263,40 +284,56 @@ class FormatMultiImage(Format):
             # Create the imageset
             from dxtbx.imageset import ImageSet
 
-            iset = ImageSet(
-                ImageSetData(
+            # HACK: If we've another imageset for this file, then reuse the ImageSetData
+            # This is because otherwise we waste immense amounts of memory on pointers
+            # - 8*8*N² bytes through redundant ImageSetData objects
+            if isetdata is None:
+                isetdata = ImageSetData(
                     reader=reader,
                     masker=masker,
                     vendor=vendor,
                     params=params,
                     format=cls,
-                ),
-                indices=single_file_indices,
-            )
+                )
 
-            # If any are None then read from format
-            if [beam, detector, goniometer, scan].count(None) != 0:
+            iset = ImageSet(isetdata, indices=single_file_indices)
 
-                # Get list of models
-                beam = []
-                detector = []
-                goniometer = []
-                scan = []
-                for i in range(format_instance.get_num_images()):
-                    beam.append(format_instance.get_beam(i))
-                    detector.append(format_instance.get_detector(i))
-                    goniometer.append(format_instance.get_goniometer(i))
-                    scan.append(format_instance.get_scan(i))
-
+            # We'd like to assume that single_file_indices is only a
+            # single value at the moment, but there are old datablock
+            # tests that violate this. Check.
             if single_file_indices is None:
+                assert (
+                    not beam and not detector
+                ), "Don't know how to handle provided beam"
                 single_file_indices = list(range(format_instance.get_num_images()))
+            else:
+                # Asking for multiple indices AND providing a model makes no sense
+                assert len(single_file_indices) == 1 or (not beam and not detector)
 
-            # Set the list of models
-            for i in range(len(single_file_indices)):
-                iset.set_beam(beam[single_file_indices[i]], i)
-                iset.set_detector(detector[single_file_indices[i]], i)
-                iset.set_goniometer(goniometer[single_file_indices[i]], i)
-                iset.set_scan(scan[single_file_indices[i]], i)
+            if len(single_file_indices) == 1:
+                single_file_index = single_file_indices[0]
+                # If we don't have a beam and detector provided we need
+                # to read it - but only for this image
+                if all(x is None for x in (beam, detector)):
+                    beam = format_instance.get_beam(single_file_index)
+                    detector = format_instance.get_detector(single_file_index)
+                    goniometer = format_instance.get_goniometer(single_file_index)
+                    scan = format_instance.get_scan(single_file_index)
+
+                # Set the list of models
+                iset.set_beam(beam)
+                iset.set_detector(detector)
+                iset.set_goniometer(goniometer)
+                iset.set_scan(scan)
+            else:
+                # breakpoint()
+                # Legacy case, multiple images. Read the model from the
+                # file and write to the per-imageset index
+                for i, index in enumerate(single_file_indices):
+                    iset.set_beam(format_instance.get_beam(index), i)
+                    iset.set_detector(format_instance.get_detector(index), i)
+                    iset.set_goniometer(format_instance.get_goniometer(index), i)
+                    iset.set_scan(format_instance.get_scan(index), i)
 
         else:
 
@@ -349,6 +386,12 @@ class FormatMultiImage(Format):
                 scan=scan,
                 indices=single_file_indices,
             )
+
+        cls._last_imageset_info = (
+            (filenames, format_kwargs),
+            format_instance,
+            isetdata,
+        )
 
         # Return the imageset
         return iset

--- a/format/FormatMultiImage.py
+++ b/format/FormatMultiImage.py
@@ -6,6 +6,12 @@ import os
 from scitbx.array_family import flex
 
 from dxtbx.format.Format import Format
+from dxtbx.imageset import ImageSetData, ImageSweep
+
+try:
+    from typing import Dict, Tuple
+except ImportError:
+    pass
 
 
 class Reader(object):
@@ -174,9 +180,6 @@ class FormatMultiImage(Format):
         Factory method to create an imageset
 
         """
-        from dxtbx.imageset import ImageSetData
-        from dxtbx.imageset import ImageSweep
-
         if isinstance(filenames, str):
             filenames = [filenames]
         elif len(filenames) > 1:

--- a/imageset.py
+++ b/imageset.py
@@ -534,6 +534,8 @@ class ImageSetFactory(object):
         check_format=True,
         single_file_indices=None,
         format_kwargs=None,
+        beam=None,
+        detector=None,
     ):
         """Create an image set"""
         from dxtbx.format.Registry import Registry
@@ -556,6 +558,8 @@ class ImageSetFactory(object):
             as_imageset=True,
             format_kwargs=format_kwargs,
             check_format=check_format,
+            beam=beam,
+            detector=detector,
         )
 
         # Return the imageset

--- a/imageset.py
+++ b/imageset.py
@@ -1,10 +1,29 @@
 from __future__ import absolute_import, division, print_function
 
 import boost.python
-import dxtbx.format.image  # noqa: F401, import dependency for unpickling
 
-ext = boost.python.import_ext("dxtbx_ext")
-from dxtbx_imageset_ext import *
+import dxtbx.format.image  # noqa: F401, import dependency for unpickling
+from dxtbx_imageset_ext import (
+    ExternalLookup,
+    ExternalLookupItemBool,
+    ExternalLookupItemDouble,
+    ImageGrid,
+    ImageSet,
+    ImageSetData,
+    ImageSweep,
+)
+
+__all__ = [
+    "ExternalLookup",
+    "ExternalLookupItemBool",
+    "ExternalLookupItemDouble",
+    "ImageGrid",
+    "ImageSet",
+    "ImageSetData",
+    "ImageSetFactory",
+    "ImageSetLazy",
+    "ImageSweep",
+]
 
 
 class MemReader(object):

--- a/imageset.py
+++ b/imageset.py
@@ -17,12 +17,15 @@ __all__ = [
     "ExternalLookup",
     "ExternalLookupItemBool",
     "ExternalLookupItemDouble",
+    "FilenameAnalyser",
     "ImageGrid",
     "ImageSet",
     "ImageSetData",
     "ImageSetFactory",
     "ImageSetLazy",
     "ImageSweep",
+    "MemMasker",
+    "MemReader",
 ]
 
 

--- a/imageset.py
+++ b/imageset.py
@@ -262,7 +262,7 @@ class ImageSweepAux(boost.python.injector, ImageSweep):
                 stop = len(self)
             else:
                 stop = item.stop
-            if item.step != None:
+            if item.step is not None:
                 raise IndexError("Sweeps must be sequential")
             return self.partial_set(start, stop)
         else:
@@ -373,7 +373,7 @@ class ImageSetFactory(object):
         imagesetlist = []
         for filelist in filelist_per_imageset:
             try:
-                if filelist[2] == True:
+                if filelist[2]:
                     iset = ImageSetFactory._create_sweep(filelist, check_headers)
                 else:
                     iset = ImageSetFactory._create_imageset(filelist, check_headers)

--- a/model/experiment_list.py
+++ b/model/experiment_list.py
@@ -36,7 +36,7 @@ from dxtbx.serialize.load import _decode_dict
 from dxtbx.sweep_filenames import template_image_range
 
 try:
-    from typing import List, Dict, Any, Tuple, Optional
+    from typing import Any, Dict, List, Optional, Tuple
 except ImportError:
     pass
 

--- a/model/experiment_list.py
+++ b/model/experiment_list.py
@@ -70,6 +70,8 @@ class ExperimentListDict(object):
         self._obj = deepcopy(obj)
         self._check_format = check_format
         self._directory = directory
+        # To keep track of file->format mapping to speed up stills importing
+        self._imageset_format_cache = {}
 
     def decode(self):
         """ Decode the dictionary into a list of experiments. """
@@ -259,7 +261,10 @@ class ExperimentListDict(object):
 
                     if imageset_data["__id__"] == "ImageSet":
                         imageset = self._make_stills(
-                            imageset_data, format_kwargs=format_kwargs
+                            imageset_data,
+                            beam=beam,
+                            detector=detector,
+                            format_kwargs=format_kwargs,
                         )
                     elif imageset_data["__id__"] == "ImageGrid":
                         imageset = self._make_grid(
@@ -371,8 +376,8 @@ class ExperimentListDict(object):
         """ Can't make a mem imageset from dict. """
         return None
 
-    def _make_stills(self, imageset, format_kwargs=None):
-        """ Make a still imageset. """
+    def _make_stills(self, imageset, beam=None, detector=None, format_kwargs=None):
+        """ Make a still imageset."""
         filenames = [
             resolve_path(p, directory=self._directory) for p in imageset["images"]
         ]
@@ -380,13 +385,24 @@ class ExperimentListDict(object):
         if "single_file_indices" in imageset:
             indices = imageset["single_file_indices"]
             assert len(indices) == len(filenames)
-        return ImageSetFactory.make_imageset(
+
+        # Do we know the format class? Pass it through if we do to save time
+        format_class = None
+        if filenames[0] in self._imageset_format_cache:
+            format_class = self._imageset_format_cache[filenames[0]]
+
+        imageset = ImageSetFactory.make_imageset(
             filenames,
-            None,
+            format_class=format_class,
+            beam=beam,
+            detector=detector,
             check_format=self._check_format,
             single_file_indices=indices,
             format_kwargs=format_kwargs,
         )
+        # Save this format-filename association for the next imageset
+        self._imageset_format_cache[filenames[0]] = imageset.get_format_class()
+        return imageset
 
     def _make_grid(self, imageset, format_kwargs=None):
         """ Make a still imageset. """

--- a/model/experiment_list.py
+++ b/model/experiment_list.py
@@ -35,6 +35,11 @@ from dxtbx.serialize.filename import resolve_path
 from dxtbx.serialize.load import _decode_dict
 from dxtbx.sweep_filenames import template_image_range
 
+try:
+    from typing import List, Dict, Any, Tuple, Optional
+except ImportError:
+    pass
+
 __all__ = [
     "BeamComparison",
     "DetectorComparison",

--- a/model/experiment_list.py
+++ b/model/experiment_list.py
@@ -392,9 +392,7 @@ class ExperimentListDict(object):
             assert len(indices) == len(filenames)
 
         # Do we know the format class? Pass it through if we do to save time
-        format_class = None
-        if filenames[0] in self._imageset_format_cache:
-            format_class = self._imageset_format_cache[filenames[0]]
+        format_class = self._imageset_format_cache.get(filenames[0])
 
         imageset = ImageSetFactory.make_imageset(
             filenames,

--- a/model/experiment_list.py
+++ b/model/experiment_list.py
@@ -382,7 +382,7 @@ class ExperimentListDict(object):
         return None
 
     def _make_stills(self, imageset, beam=None, detector=None, format_kwargs=None):
-        """ Make a still imageset."""
+        """Make a still imageset."""
         filenames = [
             resolve_path(p, directory=self._directory) for p in imageset["images"]
         ]


### PR DESCRIPTION
This dramatically increases performance when deserialising experiment lists constructed as one-imageset-per-image, as they currently commonly appear to be[1] for still image sets. This reduces the load time to around ~5s for an example 11k image dataset. This is down from *too long to measure*, which is unsurprising given the "read every image for every image" loops it removes.

Some of the changes here aren't elegant solutions - there are some severe restrictions imposed by the data model and the cyclic nature of needing to resolve the format to construct an imageset in order to deserialize an imageset. These should be confronted, but at a later date.

I believe this overlaps with some of the 'Lazy' and 'load_models' solutions put in in the recent past:
- https://github.com/cctbx/cctbx_project/pull/313 (Add option to delay load models when reading raw data)
- https://github.com/cctbx/cctbx_project/pull/312 (Lazy experiment list)
- https://github.com/dials/dials/pull/802 (Updates to dxtbx and dials to allow image viewer regarding load_models)
though I'm not certain which stage of the problem all of those are dealing with so it might not overlap all of them.

Changes made:
- `FormatMultiImage.get_imageset` no longer attempts to read every model for every image if a beam and detector has been provided and a single file index has been requested. This prevents the worst of the N² file reading loops that was preventing still experiment lists from loading
- `FormatMultiImage.get_imageset` caches the format instance from the last time it was called. If it is immediately asked for the same filename and format arguments again, it reuses these instances rather than trying to recreate the format class, which did a lot of file IO
- `FormatMultiImage` also reuses `ImageSetData` objects from the last time it was called - otherwise you end up with N unique `ImageSetData` objects allocating 8²×N² bytes of pointers (7.3 GB for 11k images!)
- `ExperimentListDict._make_stills` also caches previous filename-format lookups so that this doesn't need to be redone for every image in a multi-image file.

[1]: This isn't completely true, as there are tests like [this](https://github.com/cctbx/dxtbx/commit/381b90fbcc07e8889623a5ca39beaae00fae0aea#diff-46bae859cf3345bbbc948e5b7e463da2R776) which explicitly load multiple-image still ImageSet objects. I don't think it's used in live analysis at the moment, though we have been discussing changing this.