### PR TITLE
Python 3: urllib

### DIFF
--- a/format/Format.py
+++ b/format/Format.py
@@ -7,6 +7,8 @@
 
 from __future__ import absolute_import, division, print_function
 
+from future import standard_library
+standard_library.install_aliases()
 import sys
 
 if sys.hexversion < 0x3040000:
@@ -566,9 +568,9 @@ class Format(object):
         caching transparently if possible."""
 
         if url and Format.is_url(filename):
-            import urllib2
+            import urllib.request, urllib.error, urllib.parse
 
-            fh_func = lambda: urllib2.urlopen(filename)
+            fh_func = lambda: urllib.request.urlopen(filename)
 
         elif Format.is_bz2(filename):
             if bz2 is None:

--- a/format/Format.py
+++ b/format/Format.py
@@ -8,8 +8,12 @@
 from __future__ import absolute_import, division, print_function
 
 from future import standard_library
+
 standard_library.install_aliases()
+
 import sys
+import urllib.parse
+import urllib.request
 
 if sys.hexversion < 0x3040000:
     # try Python3.3 backport bz2 pypi module first.
@@ -43,8 +47,6 @@ from dxtbx.model.goniometer import GoniometerFactory
 from dxtbx.model.detector import DetectorFactory
 from dxtbx.model.beam import BeamFactory
 from dxtbx.model.scan import ScanFactory
-
-from six.moves.urllib.parse import urlparse
 
 _cache_controller = dxtbx.filecache_controller.simple_controller()
 
@@ -533,12 +535,8 @@ class Format(object):
         # Windows file paths can get caught up in this - check that the
         # first letter is one character (which I think should be safe: all
         # URL types are longer than this right?)
-
-        scheme = urlparse(path).scheme
-        if scheme and len(scheme) != 1:
-            return True
-
-        return False
+        scheme = urllib.parse.urlparse(path).scheme
+        return scheme and len(scheme) != 1
 
     @staticmethod
     def is_bz2(filename):
@@ -568,8 +566,6 @@ class Format(object):
         caching transparently if possible."""
 
         if url and Format.is_url(filename):
-            import urllib.request, urllib.error, urllib.parse
-
             fh_func = lambda: urllib.request.urlopen(filename)
 
         elif Format.is_bz2(filename):


### PR DESCRIPTION
This pull request is based on the `libfuturize.fixes.fix_future_standard_library_urllib` fixer. In Python 3 `urllib2` is replaced by `urllib` and methods move around a bit. 

Tiny change, there is only one place where this is an issue.