### PR TITLE
Python 3: standard library

### DIFF
--- a/format/FormatPYunspecifiedStill.py
+++ b/format/FormatPYunspecifiedStill.py
@@ -1,7 +1,12 @@
 from __future__ import absolute_import, division, print_function
 
 from future import standard_library
+
 standard_library.install_aliases()
+
+import copy
+import pickle
+
 from dxtbx.format.FormatStill import FormatStill
 from dxtbx.format.FormatPYunspecified import FormatPYunspecified
 from dxtbx.format.FormatPYunspecified import FormatPYunspecifiedInMemory
@@ -17,10 +22,8 @@ class FormatPYunspecifiedStill(FormatStill, FormatPYunspecified):
         """
 
         try:
-            stream = FormatPYunspecified.open_file(image_file, "rb")
-            import pickle as pickle
-
-            data = pickle.load(stream)
+            with FormatPYunspecified.open_file(image_file, "rb") as fh:
+                data = pickle.load(fh)
         except IOError:
             return False
 
@@ -62,8 +65,6 @@ class FormatPYunspecifiedStillInMemory(FormatStill, FormatPYunspecifiedInMemory)
     def __init__(self, data, **kwargs):
         """ @param data In memory image dictionary, alredy initialized """
         FormatPYunspecifiedInMemory.__init__(self, data, **kwargs)
-
-        import copy
 
         self._image_file = copy.deepcopy(data)
 

--- a/format/FormatPYunspecifiedStill.py
+++ b/format/FormatPYunspecifiedStill.py
@@ -1,5 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
+from future import standard_library
+standard_library.install_aliases()
 from dxtbx.format.FormatStill import FormatStill
 from dxtbx.format.FormatPYunspecified import FormatPYunspecified
 from dxtbx.format.FormatPYunspecified import FormatPYunspecifiedInMemory
@@ -16,7 +18,7 @@ class FormatPYunspecifiedStill(FormatStill, FormatPYunspecified):
 
         try:
             stream = FormatPYunspecified.open_file(image_file, "rb")
-            import cPickle as pickle
+            import pickle as pickle
 
             data = pickle.load(stream)
         except IOError:


### PR DESCRIPTION
This pull request is based on the `libfuturize.fixes.fix_future_standard_library` fixer. This is the usual "`cpickle` becomes `pickle`" stuff, and this is just the futurize variant of the `six.moves` import.

Again, tiny change, there is only one place where this is an issue.

If you're wondering why there are two ways of achieving the same thing: The futurize constructs are made so that once the Python 3 move is complete one can just remove the two `from future import` / `install_aliases` lines from the top of every file and the result is pythonic Python 3 code. Whereas with `six` you may then have further rewriting to do before you can get rid of `six` and have clean Python 3 code.