### PR TITLE
Python 3: basestring

### DIFF
--- a/data/beamline_defs/__init__.py
+++ b/data/beamline_defs/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division
 
+import importlib
 
 from builtins import bytes
 
@@ -19,8 +20,6 @@ def get_beamline_definition(detector_id, **kwargs):
         # http://stackoverflow.com/questions/1546226/a-simple-way-to-remove-multiple-spaces-in-a-string-in-python/15913564#15913564
 
     try:
-        import importlib
-
         beamline = importlib.import_module("dxtbx.data.beamline_defs.%s" % filename)
         generator_object = beamline.get_definition(**kwargs)
     except ImportError:

--- a/data/beamline_defs/__init__.py
+++ b/data/beamline_defs/__init__.py
@@ -62,7 +62,7 @@ class template(object):
 
         def __lookup(key):
             entry = keys[key]
-            if isinstance(entry, basestring):
+            if isinstance(entry, str):
                 return entry.replace("?", "." if mmCIFsemantics else "_")
             else:
                 return entry[column]

--- a/data/beamline_defs/__init__.py
+++ b/data/beamline_defs/__init__.py
@@ -1,13 +1,15 @@
 from __future__ import absolute_import, division
 
 
+from builtins import bytes
+
+
 def get_beamline_definition(detector_id, **kwargs):
     import unicodedata
     import string
-    import types
 
-    if not isinstance(detector_id, types.UnicodeType):
-        detector_id = unicode(detector_id, "utf-8", "ignore")
+    if isinstance(detector_id, bytes):
+        detector_id = detector_id.decode("utf-8", "ignore")
 
     valid_chars = frozenset("_.%s%s" % (string.ascii_letters, string.digits))
     filename = unicodedata.normalize("NFKD", detector_id).encode("ASCII", "ignore")

--- a/format/FormatPYunspecified.py
+++ b/format/FormatPYunspecified.py
@@ -6,6 +6,7 @@ import os
 from dxtbx.format.FormatPY import FormatPY
 from six.moves import range
 import six.moves.cPickle as pickle
+from past.builtins import basestring
 
 
 class FormatPYunspecified(FormatPY):

--- a/format/FormatPYunspecified.py
+++ b/format/FormatPYunspecified.py
@@ -97,17 +97,17 @@ class FormatPYunspecified(FormatPY):
         horizons_phil = params.persist.commands
 
         if is_file:
-            I = NpyImage(file_name)
+            image = NpyImage(file_name)
         else:
             print(
                 "This is not a file; assume the data are in the defined dictionary format"
             )
-            I = NpyImage(file_name, source_data=self._image_file)
-        I.readHeader(horizons_phil)
-        I.translate_tiles(horizons_phil)
+            image = NpyImage(file_name, source_data=self._image_file)
+        image.readHeader(horizons_phil)
+        image.translate_tiles(horizons_phil)
         # necessary to keep the phil parameters for subsequent calls to get_tile_manager()
-        I.horizons_phil_cache = copy.deepcopy(horizons_phil)
-        self.detectorbase = I
+        image.horizons_phil_cache = copy.deepcopy(horizons_phil)
+        self.detectorbase = image
 
     def _goniometer(self):
 


### PR DESCRIPTION
This fixes `basestring` and `types.UnicodeType` usage.

There's only a couple of places in the code that use `basestring` explicitly.
- One of these doesn't need to
- One of these _does_ because it needs to identify str/unicode on 2 and str on 3

and one place that uses `UnicodeType`.

(Intention: Squash)