### PR TITLE
Python 3: libpasteurize.fixes.fix_newstyle

### DIFF
--- a/example/to_xds.py
+++ b/example/to_xds.py
@@ -12,8 +12,10 @@ from __future__ import absolute_import, division, print_function
 # classes.
 
 from builtins import object
-import sys
+
 import math
+import sys
+
 from scitbx import matrix
 
 from dxtbx.model.detector_helpers_types import detector_helpers_types

--- a/example/to_xds.py
+++ b/example/to_xds.py
@@ -11,6 +11,7 @@ from __future__ import absolute_import, division, print_function
 # an example XDS.INP file. This should illustrate the usage of the dxtbx
 # classes.
 
+from builtins import object
 import sys
 import math
 from scitbx import matrix
@@ -36,7 +37,7 @@ def xds_detector_name(xia2_name):
     raise RuntimeError("detector %s unknown" % xia2_name)
 
 
-class to_xds:
+class to_xds(object):
     def __init__(self, sweep):
         self._template = sweep.get_template()
         self._start_end = min(sweep.indices()), max(sweep.indices())

--- a/filecache.py
+++ b/filecache.py
@@ -290,7 +290,7 @@ class lazy_file_cache(object):
 
         end_position = self._cache_object.tell()
 
-        if end_position < self._cache_size or line_candidate.endswith("\n"):
+        if end_position < self._cache_size or line_candidate.endswith(b"\n"):
             # Found a complete line within the cache
             return line_candidate, end_position
 
@@ -301,7 +301,7 @@ class lazy_file_cache(object):
         # Need more data
         while end_position == self._cache_size and not self._cache_limit_reached:
             # Do we have a complete line?
-            if line_candidate.endswith("\n"):
+            if line_candidate.endswith(b"\n"):
                 return line_candidate, end_position
 
             # Ran against cache limit. Extend cache
@@ -317,7 +317,7 @@ class lazy_file_cache(object):
             end_position = self._cache_object.tell()
 
         # Do we have a complete line?
-        if line_candidate.endswith("\n") or self._all_cached:
+        if line_candidate.endswith(b"\n") or self._all_cached:
             return line_candidate, end_position
 
         assert self._cache_limit_reached  # Only legitimate way of reaching here
@@ -371,7 +371,7 @@ class pseudo_file(object):
 
     def next(self):
         data = self.readline()
-        if data == "":
+        if data == b"":
             raise StopIteration()
         return data
 
@@ -384,7 +384,7 @@ class pseudo_file(object):
                 start=self._seek, maxbytes=size
             )
         elif size == 0:
-            data = ""
+            data = b""
         else:
             data, self._seek = self._cache_object.pass_read(start=self._seek)
         return data

--- a/filecache.py
+++ b/filecache.py
@@ -41,12 +41,13 @@
 # Any further access attempts will then result in an exception.
 
 from __future__ import absolute_import, division, print_function
+from builtins import object
 import io
 import os
 from threading import Lock
 
 
-class lazy_file_cache:
+class lazy_file_cache(object):
     """An object providing shared cached access to files"""
 
     def __init__(self, file_object):
@@ -340,7 +341,7 @@ class lazy_file_cache:
                 )
 
 
-class pseudo_file:
+class pseudo_file(object):
     """A file-like object that serves as frontend to a dxtbx lazy file cache."""
 
     def __init__(self, lazy_cache_object):

--- a/filecache.py
+++ b/filecache.py
@@ -1,10 +1,3 @@
-#!/usr/bin/env python
-#
-#   Copyright (C) 2015 Diamond Light Source, Markus Gerstel
-#
-#   This code is distributed under the BSD license, a copy of which is
-#   included in the root directory of this package.
-#
 # A shared caching layer for file-like objects.
 # pseudo_file objects can be used as drop-in replacements for actual file
 # handles to provide a transparent caching layer to avoid reading multiple

--- a/filecache_controller.py
+++ b/filecache_controller.py
@@ -8,12 +8,13 @@
 # A simple cache controller. Caching only one file at a time.
 
 from __future__ import absolute_import, division, print_function
+from builtins import object
 import dxtbx.filecache
 import os
 import threading
 
 
-class simple_controller:
+class simple_controller(object):
     """A simple cache controller. Caching one file at a time."""
 
     def __init__(self):
@@ -81,7 +82,7 @@ class simple_controller:
             return self._cache.open()
 
 
-class non_caching_controller:
+class non_caching_controller(object):
     """A controller that does not do any caching."""
 
     @staticmethod

--- a/filecache_controller.py
+++ b/filecache_controller.py
@@ -1,17 +1,13 @@
-#!/usr/bin/env python
-#
-#   Copyright (C) 2015 Diamond Light Source, Markus Gerstel
-#
-#   This code is distributed under the BSD license, a copy of which is
-#   included in the root directory of this package.
-#
 # A simple cache controller. Caching only one file at a time.
 
 from __future__ import absolute_import, division, print_function
+
 from builtins import object
-import dxtbx.filecache
+
 import os
 import threading
+
+import dxtbx.filecache
 
 
 class simple_controller(object):

--- a/format/Registry.py
+++ b/format/Registry.py
@@ -4,6 +4,7 @@
 
 from __future__ import absolute_import, division, print_function
 
+from builtins import object
 import pkg_resources
 import warnings
 
@@ -119,7 +120,7 @@ def get_format_class_for_file(image_file, format_hint=None):
     return None
 
 
-class _Registry:
+class _Registry(object):
     # deprecated class
 
     @staticmethod

--- a/model/__init__.py
+++ b/model/__init__.py
@@ -8,12 +8,12 @@ import boost.python
 import cctbx.crystal
 from dxtbx_model_ext import *
 from dxtbx.imageset import ImageSet, ImageSweep, ImageGrid
-from dxtbx.model.beam import *
-from dxtbx.model.goniometer import *
-from dxtbx.model.detector import *
-from dxtbx.model.scan import *
-from dxtbx.model.crystal import *
-from dxtbx.model.profile import *
+from dxtbx.model.beam import BeamFactory
+from dxtbx.model.crystal import CrystalFactory
+from dxtbx.model.detector import DetectorFactory
+from dxtbx.model.goniometer import GoniometerFactory
+from dxtbx.model.profile import ProfileModelFactory
+from dxtbx.model.scan import ScanFactory
 from libtbx.containers import OrderedSet
 
 from six.moves import StringIO

--- a/model/__init__.py
+++ b/model/__init__.py
@@ -29,24 +29,20 @@ class DetectorAux(boost.python.injector, Detector):
     def iter_preorder(self):
         """ Iterate through the groups and panels depth-first. """
         stack = [self.hierarchy()]
-        while len(stack) > 0:
+        while stack:
             node = stack.pop()
             yield node
             if node.is_group():
-                for child in reversed(node):
-                    stack.append(child)
+                stack.extend(reversed(node))
 
     def iter_levelorder(self):
-        """ Iterate through the groups and panels depth-first. """
-        from collections import deque
-
-        queue = deque([self.hierarchy()])
-        while len(queue) > 0:
-            node = queue.popleft()
+        """ Iterate through the groups and panels breadth-first. """
+        queue = [self.hierarchy()]
+        while queue:
+            node = queue.pop(0)
             yield node
             if node.is_group():
-                for child in node:
-                    queue.append(child)
+                queue.extend(node)
 
 
 class CrystalAux(boost.python.injector, Crystal):

--- a/model/beam.py
+++ b/model/beam.py
@@ -11,6 +11,7 @@ from __future__ import absolute_import, division
 # in internal ticket #1555. This is not designed to be used outside of the
 # XSweep classes.
 
+from builtins import object
 import math
 import pycbf
 from dxtbx_model_ext import Beam
@@ -47,7 +48,7 @@ beam_phil_scope = libtbx.phil.parse(
 )
 
 
-class BeamFactory:
+class BeamFactory(object):
     """A factory class for beam objects, which encapsulate standard beam
     models. In cases where a full cbf description is available this
     will be used, otherwise simplified descriptions can be applied."""

--- a/model/beam.py
+++ b/model/beam.py
@@ -1,18 +1,11 @@
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function
 
-#!/usr/bin/env python
-# beam.py
-#   Copyright (C) 2011 Diamond Light Source, Graeme Winter
-#
-#   This code is distributed under the BSD license, a copy of which is
-#   included in the root directory of this package.
-#
-# A model for the beam for the "updated experimental model" project documented
-# in internal ticket #1555. This is not designed to be used outside of the
-# XSweep classes.
+# A model for the beam for the "updated experimental model" project
 
 from builtins import object
+
 import math
+
 import pycbf
 from dxtbx_model_ext import Beam
 import libtbx.phil
@@ -52,9 +45,6 @@ class BeamFactory(object):
     """A factory class for beam objects, which encapsulate standard beam
     models. In cases where a full cbf description is available this
     will be used, otherwise simplified descriptions can be applied."""
-
-    def __init__(self):
-        pass
 
     @staticmethod
     def from_phil(params, reference=None):
@@ -161,8 +151,7 @@ class BeamFactory(object):
         transmission=None,
     ):
         assert polarization
-        assert polarization_fraction >= 0.0
-        assert polarization_fraction <= 1.0
+        assert 0.0 <= polarization_fraction <= 1.0
 
         if divergence is None or sigma_divergence is None:
             divergence = 0.0

--- a/model/beam.py
+++ b/model/beam.py
@@ -85,23 +85,14 @@ class BeamFactory(object):
 
         Returns:
             The beam model
-
         """
-        from dxtbx.model import Beam
+        if d is None and t is None:
+            return None
+        joint = t.copy() if t else {}
+        joint.update(d)
 
-        # If None, return None
-        if d is None:
-            if t is None:
-                return None
-            else:
-                return from_dict(t, None)
-        elif t:
-            joined = t.copy()
-            joined.update(d)
-            d = joined
-
-        # Create the model from the dictionary
-        return Beam.from_dict(d)
+        # Create the model from the joint dictionary
+        return Beam.from_dict(joint)
 
     @staticmethod
     def make_beam(

--- a/model/detector.py
+++ b/model/detector.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, division, print_function
 # flat detectors, or composite detectors constructed from a number of flat
 # elements.
 
+from builtins import object
 import pycbf
 from scitbx import matrix
 from dxtbx_model_ext import Panel, Detector
@@ -184,7 +185,7 @@ detector_phil_scope = libtbx.phil.parse(
 )
 
 
-class DetectorFactory:
+class DetectorFactory(object):
     """A factory class for detector objects, which will encapsulate standard
     detector designs to make it a little easier to get started with these. In
     cases where a CBF image is provided a full description can be used, in

--- a/model/detector.py
+++ b/model/detector.py
@@ -1,26 +1,23 @@
 from __future__ import absolute_import, division, print_function
 
 # A model for the detector for the "updated experimental model" project
-# documented in internal ticket #1555. This is not designed to be used outside
-# of the XSweep classes. N.B. this should probably be generalized for non
+# N.B. this should probably be generalized for non
 # flat detectors, or composite detectors constructed from a number of flat
 # elements.
 
 from builtins import object
+
+import os
+
+import libtbx.phil
 import pycbf
 from scitbx import matrix
 from dxtbx_model_ext import Panel, Detector
 from dxtbx_model_ext import SimplePxMmStrategy, ParallaxCorrectedPxMmStrategy
 from dxtbx.model.detector_helpers import detector_helper_sensors
 from dxtbx.model.detector_helpers import find_undefined_value
-import libtbx.phil
 
-import os
-
-if "DXTBX_OVERLOAD_SCALE" in os.environ:
-    dxtbx_overload_scale = float(os.environ["DXTBX_OVERLOAD_SCALE"])
-else:
-    dxtbx_overload_scale = 1
+dxtbx_overload_scale = float(os.getenv("DXTBX_OVERLOAD_SCALE", "1"))
 
 detector_phil_scope = libtbx.phil.parse(
     """
@@ -191,9 +188,6 @@ class DetectorFactory(object):
     cases where a CBF image is provided a full description can be used, in
     other cases assumptions will be made about the experiment configuration.
     In all cases information is provided in the CBF coordinate frame."""
-
-    def __init__(self):
-        pass
 
     @staticmethod
     def generate_from_phil(params, beam=None):
@@ -451,7 +445,7 @@ class DetectorFactory(object):
             if panel_id >= len(detector):
                 from libtbx.utils import Sorry
 
-                raise Sorry("Detector does not have panel index {0}".format(panel_id))
+                raise Sorry("Detector does not have panel index {}".format(panel_id))
             px_size_f, px_size_s = detector[0].get_pixel_size()
             slow_fast_beam_centre_mm = (
                 params.detector.slow_fast_beam_centre[0] * px_size_s,

--- a/model/detector.py
+++ b/model/detector.py
@@ -469,26 +469,16 @@ class DetectorFactory(object):
 
         Returns:
             The detector model
-
         """
-        from dxtbx.model import Detector
+        if d is None and t is None:
+            return None
+        joint = t.copy() if t else {}
+        if isinstance(d, list):
+            d = {"panels": d}
+        joint.update(d)
 
-        # If None, return None
-        if d is None:
-            if t is None:
-                return None
-            else:
-                return from_dict(t, None)
-        elif t is not None:
-            if isinstance(d, list):
-                d = {"panels": d}
-            d2 = dict(list(t.items()) + list(d.items()))
-        else:
-            if isinstance(d, list):
-                d = {"panels": d}
-
-        # Create the model from the dictionary
-        return Detector.from_dict(d)
+        # Create the model from the joint dictionary
+        return Detector.from_dict(joint)
 
     @staticmethod
     def make_detector(

--- a/model/detector_helpers.py
+++ b/model/detector_helpers.py
@@ -9,6 +9,7 @@ from __future__ import absolute_import, division
 #
 # Helpers for the detector class...
 
+from builtins import object
 import math
 from scitbx import matrix
 
@@ -122,7 +123,7 @@ def find_undefined_value(cbf_handle):
     return cbf_handle.get_doublevalue()
 
 
-class detector_helper_sensors:
+class detector_helper_sensors(object):
     """A helper class which allows enumeration of detector sensor technologies
     which should help in identifying specific detectors when needed. These are
     currently limited to IMAGE_PLATE CCD PAD."""

--- a/model/detector_helpers.py
+++ b/model/detector_helpers.py
@@ -1,16 +1,10 @@
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, print_function
 
-#!/usr/bin/env python
-# detector_helpers.py
-#   Copyright (C) 2011 Diamond Light Source, Graeme Winter
-#
-#   This code is distributed under the BSD license, a copy of which is
-#   included in the root directory of this package.
-#
 # Helpers for the detector class...
 
 from builtins import object
 import math
+
 from scitbx import matrix
 
 
@@ -135,12 +129,12 @@ class detector_helper_sensors(object):
 
     @staticmethod
     def check_sensor(sensor_type):
-        if sensor_type in [
+        if sensor_type in (
             detector_helper_sensors.SENSOR_CCD,
             detector_helper_sensors.SENSOR_PAD,
             detector_helper_sensors.SENSOR_IMAGE_PLATE,
             detector_helper_sensors.SENSOR_UNKNOWN,
-        ]:
+        ):
             return True
         return False
 
@@ -167,8 +161,8 @@ def set_slow_fast_beam_centre_mm(detector, beam, beam_centre, panel_id=None):
         panel_id = detector.get_panel_intersection(us0)
         if panel_id < 0:
             panel_id = detector.get_panel_intersection(-us0)
-        if panel_id < 0:
-            panel_id = 0
+            if panel_id < 0:
+                panel_id = 0
 
     # Get data from the chosen panel
     panel = detector[panel_id]
@@ -272,10 +266,7 @@ def set_mosflm_beam_centre(detector, beam, mosflm_beam_centre):
 def set_detector_distance(detector, distance):
     """
     Set detector origin from distance along normal
-
     """
-    from scitbx import matrix
-
     assert len(detector) == 1
     normal = matrix.col(detector[0].get_normal())
     origin = matrix.col(detector[0].get_origin())

--- a/model/detector_helpers_types.py
+++ b/model/detector_helpers_types.py
@@ -6,6 +6,7 @@ dimensions.
 
 from __future__ import absolute_import, division, print_function
 
+from builtins import object
 import os
 import sys
 
@@ -14,7 +15,7 @@ from dxtbx.model.detector_helpers import detector_helper_sensors
 from dxtbx.model.detector import DetectorFactory
 
 
-class detector_helpers_types:
+class detector_helpers_types(object):
     """A singleton class to help with identifying specific detectors used for
     macromolecular crystallography."""
 

--- a/model/detector_helpers_types.py
+++ b/model/detector_helpers_types.py
@@ -7,6 +7,7 @@ dimensions.
 from __future__ import absolute_import, division, print_function
 
 from builtins import object
+import io
 import os
 import sys
 
@@ -29,7 +30,7 @@ class detector_helpers_types(object):
 
         self._detectors = {}
 
-        with open(detector_lib, "r", encoding="ascii") as fh:
+        with io.open(detector_lib, "r", encoding="ascii") as fh:
             for record in fh:
                 if record.startswith(("Sensor", "-----")):
                     continue

--- a/model/detector_helpers_types.py
+++ b/model/detector_helpers_types.py
@@ -29,25 +29,24 @@ class detector_helpers_types(object):
 
         self._detectors = {}
 
-        for record in open(detector_lib):
-            if "Sensor" in record[:6]:
-                continue
-            if "------" in record[:6]:
-                continue
+        with open(detector_lib, "r", encoding="ascii") as fh:
+            for record in fh:
+                if record.startswith(("Sensor", "-----")):
+                    continue
 
-            text = record.split("#")[0].strip()
+                text = record.split("#")[0].strip()
 
-            if not text:
-                continue
+                if not text:
+                    continue
 
-            tokens = text.split()
+                tokens = text.split()
 
-            assert len(tokens) == 6
+                assert len(tokens) == 6
 
-            sensor = DetectorFactory.sensor(tokens[0])
-            fast, slow, df, ds = map(int, tokens[1:5])
+                sensor = DetectorFactory.sensor(tokens[0])
+                fast, slow, df, ds = map(int, tokens[1:5])
 
-            self._detectors[(sensor, fast, slow, df, ds)] = tokens[5]
+                self._detectors[(sensor, fast, slow, df, ds)] = tokens[5]
 
     def get(self, sensor, fast, slow, df, ds):
         """Look up a name for a detector with this sensor type (listed in
@@ -62,10 +61,10 @@ class detector_helpers_types(object):
             for s in detector_helper_sensors.all():
                 try:
                     return self.get(s, fast, slow, df, ds)
-                except Exception:
+                except ValueError:
                     pass
 
-            raise RuntimeError(
+            raise ValueError(
                 "detector %s %d %d %d %d unknown" % (sensor, fast, slow, df, ds)
             )
 
@@ -79,7 +78,7 @@ class detector_helpers_types(object):
                 if (sensor, fast, slow, df + ddf, ds + dds) in self._detectors:
                     return self._detectors[(sensor, fast, slow, df + ddf, ds + dds)]
 
-        raise RuntimeError(
+        raise ValueError(
             "detector %s %d %d %d %d unknown" % (sensor, fast, slow, df, ds)
         )
 

--- a/model/goniometer.py
+++ b/model/goniometer.py
@@ -250,23 +250,16 @@ class GoniometerFactory(object):
 
         Returns:
             The goniometer model
-
         """
-        from dxtbx.model import Goniometer, MultiAxisGoniometer
+        if d is None and t is None:
+            return None
+        joint = t.copy() if t else {}
+        joint.update(d)
 
-        # If None, return None
-        if d is None:
-            if t is None:
-                return None
-            else:
-                return from_dict(t, None)
-        elif t is not None:
-            d = dict(list(t.items()) + list(d.items()))
-
-        # Create the model from the dictionary
-        if "axes" in d and "angles" in d and "scan_axis" in d:
-            return MultiAxisGoniometer.from_dict(d)
-        return Goniometer.from_dict(d)
+        # Create the model from the joint dictionary
+        if {"axes", "angles", "scan_axis"}.issubset(joint):
+            return MultiAxisGoniometer.from_dict(joint)
+        return Goniometer.from_dict(joint)
 
     @staticmethod
     def make_goniometer(rotation_axis, fixed_rotation):

--- a/model/goniometer.py
+++ b/model/goniometer.py
@@ -9,6 +9,7 @@ from __future__ import absolute_import, division, print_function
 # documented in internal ticket #1555. This is not designed to be used outside
 # of the XSweep classes.
 
+from builtins import object
 import pycbf
 from dxtbx_model_ext import KappaGoniometer  # noqa: F401, import dependency
 from dxtbx_model_ext import Goniometer, MultiAxisGoniometer
@@ -67,7 +68,7 @@ goniometer_phil_scope = libtbx.phil.parse(
 )
 
 
-class GoniometerFactory:
+class GoniometerFactory(object):
     """A factory class for goniometer objects, which will encapsulate
     some standard goniometer designs to make it a little easier to get
     started with all of this - for cases when we are not using a CBF.

--- a/model/goniometer.py
+++ b/model/goniometer.py
@@ -1,21 +1,17 @@
 from __future__ import absolute_import, division, print_function
 
-#   Copyright (C) 2011 Diamond Light Source, Graeme Winter
-#
-#   This code is distributed under the BSD license, a copy of which is
-#   included in the root directory of this package.
-#
 # A model for the goniometer for the "updated experimental model" project
-# documented in internal ticket #1555. This is not designed to be used outside
-# of the XSweep classes.
 
 from builtins import object
+
+import math
+
+import libtbx.phil
 import pycbf
+import scitbx.math  # noqa: F401, import dependency
 from dxtbx_model_ext import KappaGoniometer  # noqa: F401, import dependency
 from dxtbx_model_ext import Goniometer, MultiAxisGoniometer
-import libtbx.phil
-import scitbx.math  # noqa: F401, import dependency
-
+from scitbx.array_family import flex
 
 goniometer_phil_scope = libtbx.phil.parse(
     """
@@ -75,9 +71,6 @@ class GoniometerFactory(object):
     When we have a CBF just use that factory method and everything will be
     peachy."""
 
-    def __init__(self):
-        pass
-
     @staticmethod
     def single_axis_goniometer_from_phil(params, reference=None):
         """
@@ -119,8 +112,6 @@ class GoniometerFactory(object):
 
     @staticmethod
     def multi_axis_goniometer_from_phil(params, reference=None):
-        from scitbx.array_family import flex
-
         # Check the axes parameter
         if params.goniometer.axes is not None:
             if len(params.goniometer.axes) % 3:
@@ -285,8 +276,6 @@ class GoniometerFactory(object):
 
     @staticmethod
     def make_kappa_goniometer(alpha, omega, kappa, phi, direction, scan_axis):
-        import math
-
         omega_axis = (1, 0, 0)
         phi_axis = (1, 0, 0)
 
@@ -307,8 +296,6 @@ class GoniometerFactory(object):
             scan_axis = 0
         else:
             scan_axis = 2
-
-        from scitbx.array_family import flex
 
         axes = flex.vec3_double((phi_axis, kappa_axis, omega_axis))
         angles = flex.double((phi, kappa, omega))
@@ -393,8 +380,6 @@ class GoniometerFactory(object):
         it is assumed that the file has already been read."""
 
         # find the goniometer axes and dependencies
-        from scitbx.array_family import flex
-
         axis_names = flex.std_string()
         depends_on = flex.std_string()
         axes = flex.vec3_double()

--- a/model/scan.py
+++ b/model/scan.py
@@ -1,21 +1,17 @@
 from __future__ import absolute_import, division, print_function
 
-#   Copyright (C) 2011 Diamond Light Source, Graeme Winter
-#
-#   This code is distributed under the BSD license, a copy of which is
-#   included in the root directory of this package.
-#
-# A model for the scan for the "updated experimental model" project documented
-# in internal ticket #1555. This is not designed to be used outside of the
-# XSweep classes.
+# A model for the scan for the "updated experimental model" project
 
 from builtins import object
+
+import os
+
+import libtbx.phil
 import pycbf
 from dxtbx_model_ext import Scan
-
 from dxtbx.model.scan_helpers import scan_helper_image_files
 from dxtbx.model.scan_helpers import scan_helper_image_formats
-import libtbx.phil
+from scitbx.array_family import flex
 
 scan_phil_scope = libtbx.phil.parse(
     """
@@ -139,8 +135,6 @@ class ScanFactory(object):
     def make_scan(
         image_range, exposure_times, oscillation, epochs, batch_offset=0, deg=True
     ):
-        from scitbx.array_family import flex
-
         if not isinstance(exposure_times, list):
             num_images = image_range[1] - image_range[0] + 1
             exposure_times = [exposure_times for i in range(num_images)]
@@ -169,8 +163,6 @@ class ScanFactory(object):
     @staticmethod
     def single(filename, format, exposure_times, osc_start, osc_width, epoch):
         """Construct an scan instance for a single image."""
-
-        import os
 
         index = scan_helper_image_files.image_to_index(os.path.split(filename)[-1])
         if epoch is None:

--- a/model/scan.py
+++ b/model/scan.py
@@ -110,26 +110,19 @@ class ScanFactory(object):
 
         Returns:
             The scan model
-
         """
-        from dxtbx.model import Scan
+        if d is None and t is None:
+            return None
+        joint = t.copy() if t else {}
+        joint.update(d)
 
-        # If None, return None
-        if d is None:
-            if t is None:
-                return None
-            else:
-                return from_dict(t, None)
-        elif t is not None:
-            d = dict(list(t.items()) + list(d.items()))
-        if not isinstance(d["exposure_time"], list):
-            d["exposure_time"] = [d["exposure_time"]]
+        if not isinstance(joint["exposure_time"], list):
+            joint["exposure_time"] = [joint["exposure_time"]]
+        joint.setdefault("batch_offset", 0)  # backwards compatibility 20180205
+        joint.setdefault("valid_image_ranges", {})  # backwards compatibility 20181113
 
-        d.setdefault("batch_offset", 0)  # backwards compatibility 20180205
-        if "valid_image_ranges" not in d:
-            d["valid_image_ranges"] = {}  # backwards compatibility 20181113
-        # Create the model from the dictionary
-        return Scan.from_dict(d)
+        # Create the model from the joint dictionary
+        return Scan.from_dict(joint)
 
     @staticmethod
     def make_scan(

--- a/model/scan.py
+++ b/model/scan.py
@@ -9,6 +9,7 @@ from __future__ import absolute_import, division, print_function
 # in internal ticket #1555. This is not designed to be used outside of the
 # XSweep classes.
 
+from builtins import object
 import pycbf
 from dxtbx_model_ext import Scan
 
@@ -47,7 +48,7 @@ scan_phil_scope = libtbx.phil.parse(
 )
 
 
-class ScanFactory:
+class ScanFactory(object):
     """A factory for scan instances, to help with constructing the classes
     in a set of common circumstances."""
 

--- a/model/scan_helpers.py
+++ b/model/scan_helpers.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function
 # Helpers for the scan class, which are things for handling e.g. filenames,
 # templates and so on.
 
+from builtins import object
 import os
 import re
 import math
@@ -147,7 +148,7 @@ def template_number2image(template, number):
     return image
 
 
-class scan_helper_image_files:
+class scan_helper_image_files(object):
     """A helper class which handles things like image names, making templates,
     finding matching images and so on. Currently this just provides aliases
     to existing functions elsewhere, but ultimately it would be good if they
@@ -188,7 +189,7 @@ class scan_helper_image_files:
         return template_number2image(template, index)
 
 
-class scan_helper_image_formats:
+class scan_helper_image_formats(object):
     """A helper class which enxapsulates the allowed and supported image
     formats namely CBF, TIFF, SMV, RAXIS, MAR. N.B. there will be some
     crosstalk between this class and the _image_format classes."""

--- a/tests/model/test_detector2.py
+++ b/tests/model/test_detector2.py
@@ -143,7 +143,7 @@ def test_get_valid_D_matrix(detector):
         assert abs(fast - matrix.col((1, 0, 0))) < 1e-7
         assert abs(slow - matrix.col((0, 1, 0))) < 1e-7
         assert abs(orig - matrix.col((0, 0, 100))) < 1e-7
-        D = obj.get_D_matrix()
+        assert obj.get_D_matrix()
 
     # Get the quadrants and set their frames
     q1, q2 = detector.hierarchy().children()

--- a/tests/model/test_detector2.py
+++ b/tests/model/test_detector2.py
@@ -50,9 +50,7 @@ def test_flat(detector):
     assert all(t == et for t, et in zip(types, expected_types))
 
 
-def test_iterate_and_index(detector):
-    """ Test iteration and indexing through the detector in various ways. """
-
+def test_child_iteration(detector):
     # Iterate through the detector's children and check output
     expected_types = ["Q", "Q"]
     expected_names = ["Q1", "Q2"]
@@ -64,6 +62,8 @@ def test_iterate_and_index(detector):
     assert all(n == en for n, en in zip(names, expected_names))
     assert all(t == et for t, et in zip(types, expected_types))
 
+
+def test_child_iteration_in_reverse(detector):
     # Iterate through the detector's children in reverse and check output
     expected_types = ["Q", "Q"]
     expected_names = ["Q2", "Q1"]
@@ -75,6 +75,8 @@ def test_iterate_and_index(detector):
     assert all(n == en for n, en in zip(names, expected_names))
     assert all(t == et for t, et in zip(types, expected_types))
 
+
+def test_child_indexing(detector):
     # Use an index to access the detector children
     assert len(detector.hierarchy()) == 2
     group = detector.hierarchy()[1]
@@ -83,6 +85,8 @@ def test_iterate_and_index(detector):
     panel = group[0]
     assert panel.get_name() == "P3" and panel.get_type() == "P"
 
+
+def test_depth_first_iteration(detector):
     # Iterate through the tree pre-order and check output
     expected_types = ["D", "Q", "P", "P", "Q", "P", "P"]
     expected_names = ["D1", "Q1", "P1", "P2", "Q2", "P3", "P4"]
@@ -94,6 +98,8 @@ def test_iterate_and_index(detector):
     assert all(n == en for n, en in zip(names, expected_names))
     assert all(t == et for t, et in zip(types, expected_types))
 
+
+def test_breadth_first_iteration(detector):
     # Iterate through the tree level-order and check output
     expected_types = ["D", "Q", "Q", "P", "P", "P", "P"]
     expected_names = ["D1", "Q1", "Q2", "P1", "P2", "P3", "P4"]
@@ -105,6 +111,8 @@ def test_iterate_and_index(detector):
     assert all(n == en for n, en in zip(names, expected_names))
     assert all(t == et for t, et in zip(types, expected_types))
 
+
+def test_panels_depth_first_iteration(detector):
     # Iterate through the panels in pre-order and check output
     expected_types = ["P", "P", "P", "P"]
     expected_names = ["P1", "P2", "P3", "P4"]

--- a/tests/test_filecache.py
+++ b/tests/test_filecache.py
@@ -1,12 +1,14 @@
 from __future__ import absolute_import, division, print_function
 
+import io
 import os
+import random
+
+import dxtbx.filecache
 
 
 def test_filecache():
-    import dxtbx.filecache
     import libtbx.load_env
-    from io import BytesIO
 
     dxtbx_dir = libtbx.env.dist_path("dxtbx")
     image = os.path.join(dxtbx_dir, "tests", "phi_scan_001.cbf")
@@ -18,7 +20,7 @@ def test_filecache():
     cache = dxtbx.filecache.lazy_file_cache(open(image, "rb"))
 
     # read 100 bytes
-    sh = BytesIO(correct_data)
+    sh = io.BytesIO(correct_data)
     with cache.open() as fh:
         actual = fh.read(100)
         expected = sh.read(100)
@@ -31,14 +33,14 @@ def test_filecache():
         assert actual == expected
 
     # readlines
-    sh = BytesIO(correct_data)
+    sh = io.BytesIO(correct_data)
     with cache.open() as fh:
         actual = fh.readlines()
         expected = sh.readlines()
         assert actual == expected
 
     # 5x readline
-    sh = BytesIO(correct_data)
+    sh = io.BytesIO(correct_data)
     with cache.open() as fh:
         actual = [fh.readline() for n in range(5)]
         expected = [sh.readline() for n in range(5)]
@@ -51,7 +53,7 @@ def test_filecache():
     fh = dxtbx.filecache.pseudo_file(cache)
 
     # readline stress test
-    sh = BytesIO(correct_data)
+    sh = io.BytesIO(correct_data)
     with cache.open() as fh:
         actual = fh.readline()
         expected = sh.readline()
@@ -73,9 +75,8 @@ def test_filecache():
     cache.close()
     cache = dxtbx.filecache.lazy_file_cache(open(image, "rb"))
 
-    sh = BytesIO(correct_data)
+    sh = io.BytesIO(correct_data)
     fh = dxtbx.filecache.pseudo_file(cache)
-    import random
 
     random_a, random_b = random.randint(0, 10000), random.randint(0, 150000)
     print("Running test for parameters %d %d" % (random_a, random_b))
@@ -86,8 +87,6 @@ def test_filecache():
 
 
 def test_filecache_more(dials_regression):
-    import dxtbx.filecache
-
     filename = os.path.join(
         dials_regression, "image_examples", "MacScience", "reallysurprise_001.ipf"
     )
@@ -109,3 +108,12 @@ def test_filecache_more(dials_regression):
         fh.read(1024)
         data = fh.read()
         assert len(data) == 3000 * 3000 * 2
+
+
+def test_read_termination_at_end_of_file(tmpdir):
+    testfile = tmpdir.join("test")
+    testfile.write("\n".join(str(n) for n in range(5)))
+    cache = dxtbx.filecache.lazy_file_cache(testfile.open("rb"))
+    with cache.open() as fh:
+        for record in fh:
+            assert record, "Loop should have terminated already"


### PR DESCRIPTION
This pull request is based on the `libpasteurize.fixes.fix_newstyle` fixer.
Python 2 has two different class types, "old style" classes, which can be defined with
```python
class thing:
  pass
```
and "new style" classes, introduced with Python 2.2 in 2001, can be defined with
```python
class thing(object):
  pass
```
[The classes are subtly different](https://stackoverflow.com/questions/54867/what-is-the-difference-between-old-style-and-new-style-classes-in-python), for example `@property` decorators do not work properly on old style classes, and [with multiple inheritance the method resolution works differently](https://portingguide.readthedocs.io/en/latest/classes.html#method-resolution). This pull request first converts all remaining old style classes to new style classes - and then goes further and derives the new style classes as subclass of `builtins.object`, which is a backport of the python 3 `object`. By using this backported class one only needs to define the Python 3 methods `__next__`, `__str__`, and `__bool__` and python 2 compatibility methods for `next`, `__unicode__`, `__nonzero__`, and `__long__` are implemented automatically.