### PR TITLE
fix python 3 bytes/strings issues in Nexus

### DIFF
--- a/format/FormatHDF5EigerNearlyNexus.py
+++ b/format/FormatHDF5EigerNearlyNexus.py
@@ -22,16 +22,18 @@ from dxtbx.format.nexus import ScanFactory
 from dxtbx.format.nexus import DataFactory
 from dxtbx.format.nexus import MaskFactory
 
+import h5py
+import numpy
+
 
 def find_entries(nx_file):
     """
     Find NXmx entries
-
     """
     if "entry" in nx_file:
         entry = nx_file["entry"]
         if "NX_class" in entry.attrs:
-            if entry.attrs["NX_class"] == "NXentry":
+            if entry.attrs["NX_class"] == numpy.string_("NXentry"):
                 if "definition" not in entry:
                     return entry
     return None
@@ -40,10 +42,7 @@ def find_entries(nx_file):
 def is_eiger_nearly_nexus_file(filename):
     """
     A hacky function to check if this is an EIGER-flavoured nexus file
-
     """
-    import h5py
-
     # Get the file handle
     handle = h5py.File(filename, "r")
 
@@ -51,7 +50,10 @@ def is_eiger_nearly_nexus_file(filename):
     entry = find_entries(handle)
     if entry is not None:
         try:
-            return "Dectris Eiger" in entry["instrument"]["detector"]["description"][()]
+            return (
+                numpy.string_("Dectris Eiger")
+                in entry["instrument"]["detector"]["description"][()]
+            )
         except KeyError:
             pass
     return False
@@ -60,11 +62,9 @@ def is_eiger_nearly_nexus_file(filename):
 class EigerNXmxFixer(object):
     """
     A hacky class to read an NXmx file
-
     """
 
     def __init__(self, input_filename, memory_mapped_name):
-        import h5py
         from scitbx import matrix
 
         # Copy the master file to the in memory handle
@@ -80,7 +80,7 @@ class EigerNXmxFixer(object):
             dataset[()] = value
 
         # Add NXmx definition
-        create_scalar(handle["entry"], "definition", "S4", "NXmx")
+        create_scalar(handle["entry"], "definition", "S4", numpy.string_("NXmx"))
 
         # Add saturation value
         try:
@@ -103,7 +103,9 @@ class EigerNXmxFixer(object):
             )
 
         # Add detector type
-        create_scalar(handle["entry/instrument/detector"], "type", "S4", "PIXEL")
+        create_scalar(
+            handle["entry/instrument/detector"], "type", "S4", numpy.string_("PIXEL")
+        )
 
         # Move the beam
         # print "Copying /entry/instrument/beam to /entry/sample/beam"
@@ -113,7 +115,7 @@ class EigerNXmxFixer(object):
         module_path = "/entry/instrument/detector/module"
         # print "Creating detector module %s" % (module_path)
         group = handle.create_group(module_path)
-        group.attrs["NX_class"] = "NXdetector_module"
+        group.attrs["NX_class"] = numpy.string_("NXdetector_module")
 
         # Add a module index
         create_scalar(group, "module_index", "int64", 0)
@@ -139,6 +141,7 @@ class EigerNXmxFixer(object):
 
         for d in delete:
             del handle[d]
+        depends_on = "/entry/instrument/detector/transformations/translation"
 
         # Add fast_pixel_size dataset
         # print "Using /entry/instrument/detector/geometry/orientation/value as fast/slow pixel directions"
@@ -160,13 +163,13 @@ class EigerNXmxFixer(object):
             "float32",
             handle["/entry/instrument/detector/x_pixel_size"][()],
         )
-        group["fast_pixel_direction"].attrs["transformation_type"] = "translation"
+        group["fast_pixel_direction"].attrs["transformation_type"] = numpy.string_(
+            "translation"
+        )
         group["fast_pixel_direction"].attrs["vector"] = fast_axis
         group["fast_pixel_direction"].attrs["offset"] = (0, 0, 0)
-        group["fast_pixel_direction"].attrs["units"] = "m"
-        group["fast_pixel_direction"].attrs[
-            "depends_on"
-        ] = "/entry/instrument/detector/transformations/translation"
+        group["fast_pixel_direction"].attrs["units"] = numpy.string_("m")
+        group["fast_pixel_direction"].attrs["depends_on"] = numpy.string_(depends_on)
 
         # Add slow_pixel_size dataset
         create_scalar(
@@ -175,32 +178,31 @@ class EigerNXmxFixer(object):
             "float32",
             handle["/entry/instrument/detector/y_pixel_size"][()],
         )
-        group["slow_pixel_direction"].attrs["transformation_type"] = "translation"
+        group["slow_pixel_direction"].attrs["transformation_type"] = numpy.string_(
+            "translation"
+        )
         group["slow_pixel_direction"].attrs["vector"] = slow_axis
         group["slow_pixel_direction"].attrs["offset"] = (0, 0, 0)
-        group["slow_pixel_direction"].attrs["units"] = "m"
-        group["slow_pixel_direction"].attrs[
-            "depends_on"
-        ] = "/entry/instrument/detector/transformations/translation"
+        group["slow_pixel_direction"].attrs["units"] = numpy.string_("m")
+        group["slow_pixel_direction"].attrs["depends_on"] = numpy.string_(depends_on)
 
         # Add module offset dataset
         # print "Set module offset to be zero relative to detector"
         create_scalar(group, "module_offset", "float32", 0)
-        group["module_offset"].attrs["transformation_type"] = "translation"
+        group["module_offset"].attrs["transformation_type"] = numpy.string_(
+            "translation"
+        )
         group["module_offset"].attrs["vector"] = (0, 0, 0)
         group["module_offset"].attrs["offset"] = (0, 0, 0)
-        group["module_offset"].attrs["units"] = "m"
-        group["module_offset"].attrs[
-            "depends_on"
-        ] = "/entry/instrument/detector/transformations/translation"
+        group["module_offset"].attrs["units"] = numpy.string_("m")
+        group["module_offset"].attrs["depends_on"] = numpy.string_(depends_on)
 
         # Create detector depends_on
-        depends_on = "/entry/instrument/detector/transformations/translation"
         create_scalar(
             handle["/entry/instrument/detector"],
             "depends_on",
             "S%d" % len(depends_on),
-            depends_on,
+            numpy.string_(depends_on),
         )
 
         # Add detector position
@@ -217,22 +219,22 @@ class EigerNXmxFixer(object):
             )
         )
         group = handle.create_group("/entry/instrument/detector/transformations")
-        group.attrs["NX_class"] = "NXtransformations"
+        group.attrs["NX_class"] = numpy.string_("NXtransformations")
         create_scalar(group, "translation", "float32", detector_offset_vector.length())
-        group["translation"].attrs["transformation_type"] = "translation"
+        group["translation"].attrs["transformation_type"] = numpy.string_("translation")
         if detector_offset_vector.length() > 0:
             group["translation"].attrs["vector"] = detector_offset_vector.normalize()
         else:
             group["translation"].attrs["vector"] = detector_offset_vector
         group["translation"].attrs["offset"] = 0
-        group["translation"].attrs["units"] = "m"
-        group["translation"].attrs["depends_on"] = "."
+        group["translation"].attrs["units"] = numpy.string_("m")
+        group["translation"].attrs["depends_on"] = numpy.string_(".")
 
         # Create goniometer transformations if not found
         if "/entry/sample/transformations" not in handle:
             # print "Creating group /entry/sample/transformation"
             group = handle.create_group("/entry/sample/transformations")
-            group.attrs["NX_class"] = "NXtransformations"
+            group.attrs["NX_class"] = numpy.string_("NXtransformations")
         else:
             group = handle["/entry/sample/transformations"]
 
@@ -266,11 +268,11 @@ class EigerNXmxFixer(object):
             for name in sorted(handle["/entry/data"]):
                 num_images += len(handle_orig["/entry/data/%s" % name])
             dataset = group.create_dataset("omega", (num_images,), dtype="float32")
-            dataset.attrs["units"] = "degree"
-            dataset.attrs["transformation_type"] = "rotation"
+            dataset.attrs["units"] = numpy.string_("degree")
+            dataset.attrs["transformation_type"] = numpy.string_("rotation")
             dataset.attrs["vector"] = default_axis
             dataset.attrs["offset"] = 0
-            dataset.attrs["depends_on"] = "."
+            dataset.attrs["depends_on"] = numpy.string_(".")
             omega_range_average = handle[
                 "/entry/sample/goniometer/omega_range_average"
             ][()]
@@ -287,7 +289,7 @@ class EigerNXmxFixer(object):
                 handle["/entry/sample"],
                 "depends_on",
                 "S%d" % len(dataset.name),
-                str(dataset.name),
+                numpy.string_(dataset.name),
             )
 
         # Change relative paths to absolute paths

--- a/format/FormatHDF5EigerNearlyNexus.py
+++ b/format/FormatHDF5EigerNearlyNexus.py
@@ -51,8 +51,8 @@ def is_eiger_nearly_nexus_file(filename):
     if entry is not None:
         try:
             return (
-                numpy.string_("Dectris Eiger")
-                in entry["instrument"]["detector"]["description"][()]
+                numpy.string_("dectris eiger")
+                in entry["instrument"]["detector"]["description"][()].lower()
             )
         except KeyError:
             pass

--- a/format/nexus.py
+++ b/format/nexus.py
@@ -1038,7 +1038,7 @@ def get_change_of_basis(transformation):
             )
         )
     else:
-        raise Sorry("Unrecognized tranformation type: %d" % axis_type)
+        raise ValueError("Unrecognized tranformation type: %d" % axis_type)
 
     return cob
 
@@ -1291,7 +1291,8 @@ class DetectorFactoryFromGroup(object):
                         raise RuntimeError("Unknown material: %s" % material)
                     table = attenuation_coefficient.get_table(material)
                     wavelength = beam.get_wavelength()
-                    p.set_mu(table.mu_at_angstrom(wavelength) / 10.0)
+                    mu = table.mu_at_angstrom(wavelength) / 10.0
+                    p.set_mu(mu)
 
                 if (
                     "sensor_thickness" in nx_detector.handle

--- a/format/nexus.py
+++ b/format/nexus.py
@@ -9,7 +9,7 @@ import numpy
 import six
 
 try:
-    from dxtbx_format_nexus_ext import *
+    from dxtbx_format_nexus_ext import dataset_as_flex_int
 except ImportError:
     # Workaround for psana build, which doesn't link HDF5 properly
     if "SIT_ROOT" not in os.environ:

--- a/format/nexus.py
+++ b/format/nexus.py
@@ -5,6 +5,9 @@ import functools
 import math
 import os
 
+import numpy
+import six
+
 try:
     from dxtbx_format_nexus_ext import *
 except ImportError:
@@ -155,9 +158,12 @@ def find_entries(nx_file, entry):
 
     def visitor(name, obj):
         if "NX_class" in obj.attrs:
-            if obj.attrs["NX_class"] in ["NXentry", "NXsubentry"]:
+            if obj.attrs["NX_class"] in [
+                numpy.string_("NXentry"),
+                numpy.string_("NXsubentry"),
+            ]:
                 if "definition" in obj:
-                    if obj["definition"][()] == "NXmx":
+                    if obj["definition"][()] == numpy.string_("NXmx"):
                         hits.append(obj)
 
     visitor(entry, nx_file[entry])
@@ -170,10 +176,11 @@ def find_class(nx_file, nx_class):
     Find a given NXclass
     """
     hits = []
+    nx_class = numpy.string_(nx_class)
 
     def visitor(name, obj):
         if "NX_class" in obj.attrs:
-            if obj.attrs["NX_class"] in [nx_class]:
+            if obj.attrs["NX_class"] == nx_class:
                 hits.append(obj)
 
     nx_file.visititems(visitor)
@@ -184,6 +191,8 @@ def convert_units(value, input_units, output_units):
     """
     Hacky utility function to convert units
     """
+    if six.PY3 and isinstance(input_units, bytes):
+        input_units = input_units.decode("latin-1")
     converters = {
         "m": {
             "mm": lambda x: x * 1e3,
@@ -223,12 +232,12 @@ def visit_dependencies(nx_file, item, visitor=None):
     """
     Walk the dependency chain and call a visitor function
     """
-    dependency_chain = []
+    dependency_chain = set()
     if os.path.basename(item) == "depends_on":
         depends_on = nx_file[item][()]
     else:
         depends_on = nx_file[item].attrs["depends_on"]
-    while not depends_on == ".":
+    while not depends_on == numpy.string_("."):
         if visitor is not None:
             visitor(nx_file, depends_on)
         if depends_on in dependency_chain:
@@ -237,7 +246,7 @@ def visit_dependencies(nx_file, item, visitor=None):
             _ = nx_file[depends_on]
         except Exception:
             raise RuntimeError("'%s' is missing from nx_file" % depends_on)
-        dependency_chain.append(depends_on)
+        dependency_chain.add(depends_on)
         try:
             depends_on = nx_file[depends_on].attrs["depends_on"]
         except Exception:
@@ -260,12 +269,12 @@ def construct_vector(nx_file, item, vector=None):
             units = item.attrs["units"]
             ttype = item.attrs["transformation_type"]
             vector = matrix.col(item.attrs["vector"])
-            if ttype == "translation":
+            if ttype == numpy.string_("translation"):
                 value = convert_units(value, units, "mm")
                 if hasattr(value, "__iter__") and len(value) == 1:
                     value = value[0]
                 self.vector = vector * value + self.vector
-            elif ttype == "rotation":
+            elif ttype == numpy.string_("rotation"):
                 if hasattr(value, "__iter__") and len(value):
                     value = value[0]
                 if units == "rad":
@@ -291,7 +300,7 @@ def construct_vector(nx_file, item, vector=None):
             offset = convert_units(offset, units, "mm")
         else:
             offset = vector * 0.0
-        if ttype == "translation":
+        if ttype == numpy.string_("translation"):
             value = convert_units(value, units, "mm")
             try:
                 vector = vector * value
@@ -327,14 +336,18 @@ def construct_axes(nx_file, item, vector=None):
             units = item.attrs["units"]
             ttype = item.attrs["transformation_type"]
             vector = [float(v) for v in item.attrs["vector"]]
-            if ttype == "translation":
+            if ttype == numpy.string_("translation"):
                 return
-            elif ttype == "rotation":
+            elif ttype == numpy.string_("rotation"):
                 if hasattr(value, "__iter__") and len(value):
                     value = value[0]
-                if units == "rad":
+                if units == numpy.string_("rad"):
                     value *= math.pi / 180
-                elif units not in ["deg", "degree", "degrees"]:
+                elif units not in [
+                    numpy.string_("deg"),
+                    numpy.string_("degree"),
+                    numpy.string_("degrees"),
+                ]:
                     raise RuntimeError("Invalid units: %s" % units)
 
                 # is the axis moving? Check the values for this axis
@@ -378,7 +391,7 @@ def construct_axes(nx_file, item, vector=None):
             offset = nx_file[item].attrs["offset"]
         else:
             offset = vector * 0.0
-        if ttype == "translation":
+        if ttype == numpy.string_("translation"):
             value = convert_units(value, units, "mm")
             try:
                 vector = vector * value
@@ -450,7 +463,7 @@ class NXdetector_module(object):
                     check_attr("transformation_type"),
                     check_attr("vector"),
                     check_attr("offset"),
-                    check_attr("units", dtype=str),
+                    check_attr("units", dtype=(numpy.string_, str)),
                     check_attr("depends_on"),
                 ],
             },
@@ -461,7 +474,7 @@ class NXdetector_module(object):
                     check_attr("transformation_type"),
                     check_attr("vector"),
                     check_attr("offset"),
-                    check_attr("units", dtype=str),
+                    check_attr("units", dtype=(numpy.string_, str)),
                     check_attr("depends_on"),
                 ],
             },
@@ -472,7 +485,7 @@ class NXdetector_module(object):
                     check_attr("transformation_type"),
                     check_attr("vector"),
                     check_attr("offset"),
-                    check_attr("units", dtype=str),
+                    check_attr("units", dtype=(numpy.string_, str)),
                     check_attr("depends_on"),
                 ],
             },
@@ -625,7 +638,7 @@ class NXdetector(object):
                 "minOccurs": 0,
                 "checks": [
                     check_dset(dtype=["float32", "float64"], is_scalar=True),
-                    check_attr("units", dtype=str),
+                    check_attr("units", dtype=numpy.string_),
                 ],
             },
             "threshold_energy": {
@@ -907,14 +920,9 @@ def is_nexus_file(filename):
     """
     import h5py
 
-    # Get the file handle
-    handle = h5py.File(filename, "r")
-
-    # Find the NXmx entries
-    count = 0
-    for entry in find_entries(handle, "/"):
-        count += 1
-    return count > 0
+    with h5py.File(filename, "r") as handle:
+        # Find the NXmx entries
+        return bool(find_entries(handle, "/"))
 
 
 class BeamFactory(object):
@@ -974,10 +982,14 @@ def get_change_of_basis(transformation):
     # 4x4 change of basis matrix (homogeneous coordinates)
     cob = None
 
-    if axis_type == "rotation":
-        if units == "rad":
+    if axis_type == numpy.string_("rotation"):
+        if units == numpy.string_("rad"):
             deg = False
-        elif units in ["deg", "degree", "degrees"]:
+        elif units in [
+            numpy.string_("deg"),
+            numpy.string_("degree"),
+            numpy.string_("degrees"),
+        ]:
             deg = True
         else:
             raise RuntimeError("Invalid units: %s" % units)
@@ -1002,7 +1014,7 @@ def get_change_of_basis(transformation):
                 1,
             )
         )
-    elif axis_type == "translation":
+    elif axis_type == numpy.string_("translation"):
         setting = convert_units(setting, units, "mm")
         translation = offset + (vector * setting)
         cob = sqr(
@@ -1044,7 +1056,7 @@ def get_depends_on_chain_using_equipment_components(transformation):
     while True:
         parent_id = current.attrs["depends_on"]
 
-        if parent_id == ".":
+        if parent_id == numpy.string_("."):
             return chain
         parent = current.parent[parent_id]
 
@@ -1071,7 +1083,7 @@ def get_cummulative_change_of_basis(transformation):
 
     parent_id = transformation.attrs["depends_on"]
 
-    if parent_id == ".":
+    if parent_id == numpy.string_("."):
         return None, cob
     parent = transformation.parent[parent_id]
 
@@ -1336,7 +1348,17 @@ class DetectorFactory(object):
         thickness_value = float(convert_units(thickness_value, thickness_units, "mm"))
 
         # Get the detector material
-        material = str(nx_detector["sensor_material"][()])
+        material = {
+            numpy.string_("Si"): "Si",
+            numpy.string_("Silicon"): "Si",
+            numpy.string_("Sillicon"): "Si",
+            numpy.string_("CdTe"): "CdTe",
+            numpy.string_("GaAs"): "GaAs",
+        }.get(nx_detector["sensor_material"][()])
+        if not material:
+            raise RuntimeError(
+                "Unknown material: %s" % nx_detector["sensor_material"][()]
+            )
 
         # Get the fast pixel size and vector
         fast_pixel_direction = nx_module["fast_pixel_direction"]
@@ -1375,18 +1397,6 @@ class DetectorFactory(object):
         # Compute the attenuation coefficient.
         # This will fail for undefined composite materials
         # mu_at_angstrom returns cm^-1, but need mu in mm^-1
-        if material == "Si":
-            pass
-        elif material == "Silicon":
-            material = "Si"
-        elif material == "Sillicon":
-            material = "Si"
-        elif material == "CdTe":
-            pass
-        elif material == "GaAs":
-            pass
-        else:
-            raise RuntimeError("Unknown material: %s" % material)
         table = attenuation_coefficient.get_table(material)
         wavelength = beam.get_wavelength()
         mu = table.mu_at_angstrom(wavelength) / 10.0
@@ -1394,7 +1404,7 @@ class DetectorFactory(object):
         # Construct the detector model
         pixel_size = (fast_pixel_direction_value, slow_pixel_direction_value)
         # image size stored slow to fast but dxtbx needs fast to slow
-        image_size = tuple(reversed(map(int, nx_module["data_size"][-2:])))
+        image_size = tuple(int(x) for x in reversed(nx_module["data_size"][-2:]))
 
         if known_backwards(image_size):
             image_size = tuple(reversed(image_size))
@@ -1450,7 +1460,7 @@ def find_goniometer_rotation(obj):
     tree = get_depends_on_chain_using_equipment_components(thing)
     for t in tree:
         o = obj.handle.file[t.name]
-        if o.attrs["transformation_type"] == "rotation":
+        if o.attrs["transformation_type"] == numpy.string_("rotation"):
             # if this is changing, assume is scan axis
             v = o[()]
             if min(v) < max(v):


### PR DESCRIPTION
### _The Most Important Thing_

_If you remember nothing else, remember this:_

_**All strings in HDF5 hold encoded text.**_

_You can’t store arbitrary binary data in HDF5 strings. Not only will this break, it will break in odd, hard-to-discover ways that will leave you confused and cursing._

(http://docs.h5py.org/en/stable/strings.html#the-most-important-thing)

Basically change all string comparisons against `numpy.string_()`. (Alas we also have to tolerate NearlyNexus files, which contain `string` instead of `numpy.string_()`)

Not saying this is ideal. Or that everything works. In fact this does not make a single test pass, but it does make them fail in a different place.

No dials/dxtbx regressions.