### PR TITLE
Avoid * imports, explicitly declare exported symbols

### DIFF
--- a/format/image.py
+++ b/format/image.py
@@ -1,2 +1,41 @@
 from __future__ import absolute_import, division, print_function
-from dxtbx_format_image_ext import *
+
+from dxtbx_format_image_ext import (
+    CBFFastImageListReader,
+    CBFFastReader,
+    CBFImageListReader,
+    CBFReader,
+    HDF5Reader,
+    ImageBool,
+    ImageBuffer,
+    ImageDouble,
+    ImageInt,
+    ImageReader,
+    ImageTileBool,
+    ImageTileDouble,
+    ImageTileInt,
+    SMVImageListReader,
+    SMVReader,
+    TIFFImageListReader,
+    TIFFReader,
+)
+
+__all__ = (
+    "CBFFastImageListReader",
+    "CBFFastReader",
+    "CBFImageListReader",
+    "CBFReader",
+    "HDF5Reader",
+    "ImageBool",
+    "ImageBuffer",
+    "ImageDouble",
+    "ImageInt",
+    "ImageReader",
+    "ImageTileBool",
+    "ImageTileDouble",
+    "ImageTileInt",
+    "SMVImageListReader",
+    "SMVReader",
+    "TIFFImageListReader",
+    "TIFFReader",
+)

--- a/format/image.py
+++ b/format/image.py
@@ -1,24 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
-from dxtbx_format_image_ext import (
-    CBFFastImageListReader,
-    CBFFastReader,
-    CBFImageListReader,
-    CBFReader,
-    HDF5Reader,
-    ImageBool,
-    ImageBuffer,
-    ImageDouble,
-    ImageInt,
-    ImageReader,
-    ImageTileBool,
-    ImageTileDouble,
-    ImageTileInt,
-    SMVImageListReader,
-    SMVReader,
-    TIFFImageListReader,
-    TIFFReader,
-)
+from dxtbx_format_image_ext import *
 
 __all__ = (
     "CBFFastImageListReader",

--- a/imageset.py
+++ b/imageset.py
@@ -26,7 +26,6 @@ __all__ = (
     "ImageSetFactory",
     "ImageSetLazy",
     "ImageSweep",
-    "MemMasker",
     "MemReader",
 )
 

--- a/imageset.py
+++ b/imageset.py
@@ -6,7 +6,29 @@ import dxtbx.format.image  # noqa: F401, import dependency for unpickling
 import dxtbx.format.Registry
 
 ext = boost.python.import_ext("dxtbx_ext")
-from dxtbx_imageset_ext import *
+from dxtbx_imageset_ext import (
+    ExternalLookup,
+    ExternalLookupItemBool,
+    ExternalLookupItemDouble,
+    ImageGrid,
+    ImageSet,
+    ImageSetData,
+    ImageSweep,
+)
+
+__all__ = (
+    "ExternalLookup",
+    "ExternalLookupItemBool",
+    "ExternalLookupItemDouble",
+    "ImageGrid",
+    "ImageSet",
+    "ImageSetData",
+    "ImageSetFactory",
+    "ImageSetLazy",
+    "ImageSweep",
+    "MemMasker",
+    "MemReader",
+)
 
 
 class MemReader(object):

--- a/model/__init__.py
+++ b/model/__init__.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import, division, print_function
 
-
 from builtins import range
 import collections
 import json
@@ -9,7 +8,39 @@ import sys
 
 import boost.python
 import cctbx.crystal
-from dxtbx_model_ext import *
+from dxtbx_model_ext import (
+    Beam,
+    BeamBase,
+    Crystal,
+    CrystalBase,
+    Detector,
+    DetectorNode,
+    Experiment,
+    ExperimentList,
+    Goniometer,
+    GoniometerBase,
+    KappaDirection,
+    KappaGoniometer,
+    KappaScanAxis,
+    MosaicCrystalKabsch2010,
+    MosaicCrystalSauter2014,
+    MultiAxisGoniometer,
+    OffsetParallaxCorrectedPxMmStrategy,
+    OffsetPxMmStrategy,
+    Panel,
+    ParallaxCorrectedPxMmStrategy,
+    PxMmStrategy,
+    Scan,
+    ScanBase,
+    SimplePxMmStrategy,
+    VirtualPanel,
+    VirtualPanelFrame,
+    get_mod2pi_angles_in_range,
+    get_range_of_mod2pi_angles,
+    is_angle_in_range,
+    parallax_correction,
+    parallax_correction_inv,
+)
 from dxtbx.imageset import ImageSet, ImageSweep, ImageGrid
 from dxtbx.model.beam import BeamFactory
 from dxtbx.model.crystal import CrystalFactory
@@ -21,6 +52,50 @@ from libtbx.containers import OrderedSet
 
 from six.moves import StringIO
 import six.moves.cPickle as pickle
+
+
+__all__ = (
+    "Beam",
+    "BeamBase",
+    "BeamFactory",
+    "Crystal",
+    "CrystalBase",
+    "CrystalFactory",
+    "Detector",
+    "DetectorFactory",
+    "DetectorNode",
+    "Experiment",
+    "ExperimentList",
+    "Goniometer",
+    "GoniometerBase",
+    "GoniometerFactory",
+    "ImageGrid",
+    "ImageSet",
+    "ImageSweep",
+    "KappaDirection",
+    "KappaGoniometer",
+    "KappaScanAxis",
+    "MosaicCrystalKabsch2010",
+    "MosaicCrystalSauter2014",
+    "MultiAxisGoniometer",
+    "OffsetParallaxCorrectedPxMmStrategy",
+    "OffsetPxMmStrategy",
+    "Panel",
+    "ParallaxCorrectedPxMmStrategy",
+    "ProfileModelFactory",
+    "PxMmStrategy",
+    "Scan",
+    "ScanBase",
+    "ScanFactory",
+    "SimplePxMmStrategy",
+    "VirtualPanel",
+    "VirtualPanelFrame",
+    "get_mod2pi_angles_in_range",
+    "get_range_of_mod2pi_angles",
+    "is_angle_in_range",
+    "parallax_correction",
+    "parallax_correction_inv",
+)
 
 
 class DetectorAux(object):


### PR DESCRIPTION
less `from x import *`
more `__all__=(...)`