### PR TITLE
Refactor SMV format classes

### DIFF
--- a/format/FormatSMV.py
+++ b/format/FormatSMV.py
@@ -61,6 +61,25 @@ class FormatSMV(Format):
 
         return header_size, header_dictionary
 
+    def _get_endianic_raw_data(self, size):
+        from boost.python import streambuf
+        from dxtbx import read_uint16, read_uint16_bs, is_big_endian
+        from scitbx.array_family import flex
+
+        big_endian = self._header_dictionary["BYTE_ORDER"] == "big_endian"
+
+        with self.open_file(self._image_file, "rb") as fh:
+            fh.seek(self._header_size)
+
+            if big_endian == is_big_endian():
+                raw_data = read_uint16(streambuf(fh), int(size[0] * size[1]))
+            else:
+                raw_data = read_uint16_bs(streambuf(fh), int(size[0] * size[1]))
+
+        # note that x and y are reversed here
+        raw_data.reshape(flex.grid(size[1], size[0]))
+        return raw_data
+
     def __init__(self, image_file, **kwargs):
         """Initialise the image structure from the given file."""
 

--- a/format/FormatSMV.py
+++ b/format/FormatSMV.py
@@ -11,7 +11,10 @@
 
 from __future__ import absolute_import, division, print_function
 
+from boost.python import streambuf
 from dxtbx.format.Format import Format
+from dxtbx.ext import read_uint16, read_uint16_bs, is_big_endian
+from scitbx.array_family import flex
 
 
 class FormatSMV(Format):
@@ -62,10 +65,6 @@ class FormatSMV(Format):
         return header_size, header_dictionary
 
     def _get_endianic_raw_data(self, size):
-        from boost.python import streambuf
-        from dxtbx import read_uint16, read_uint16_bs, is_big_endian
-        from scitbx.array_family import flex
-
         big_endian = self._header_dictionary["BYTE_ORDER"] == "big_endian"
 
         with self.open_file(self._image_file, "rb") as fh:

--- a/format/FormatSMVADSC.py
+++ b/format/FormatSMVADSC.py
@@ -244,28 +244,10 @@ class FormatSMVADSC(FormatSMV):
         """Get the pixel intensities (i.e. read the image and return as a
         flex array of integers.)"""
 
-        from boost.python import streambuf
-        from dxtbx.ext import read_uint16, read_uint16_bs, is_big_endian
-        from scitbx.array_family import flex
-
         assert len(self.get_detector()) == 1
         panel = self.get_detector()[0]
-        size = panel.get_image_size()
-        f = FormatSMVADSC.open_file(self._image_file, "rb")
-        f.read(self._header_size)
-
-        if self._header_dictionary["BYTE_ORDER"] == "big_endian":
-            big_endian = True
-        else:
-            big_endian = False
-
-        if big_endian == is_big_endian():
-            raw_data = read_uint16(streambuf(f), int(size[0] * size[1]))
-        else:
-            raw_data = read_uint16_bs(streambuf(f), int(size[0] * size[1]))
-
         image_size = panel.get_image_size()
-        raw_data.reshape(flex.grid(image_size[1], image_size[0]))
+        raw_data = self._get_endianic_raw_data(size=image_size)
 
         # if we subtract PEDESTAL is this still raw?
         if "IMAGE_PEDESTAL" in self._header_dictionary:

--- a/format/FormatSMVADSCSN445.py
+++ b/format/FormatSMVADSCSN445.py
@@ -69,32 +69,13 @@ class FormatSMVADSCSN445(FormatSMVADSCSN):
         """Get the pixel intensities (i.e. read the image and return as a
         flex array of integers.)"""
 
-        from boost.python import streambuf
-        from dxtbx.ext import read_uint16, read_uint16_bs, is_big_endian
-        from scitbx.array_family import flex
-
         assert len(self.get_detector()) == 1
-        image_pedestal = 40
         panel = self.get_detector()[0]
-        size = panel.get_image_size()
-        if self._header_dictionary["BYTE_ORDER"] == "big_endian":
-            big_endian = True
-        else:
-            big_endian = False
-
-        with FormatSMVADSCSN.open_file(self._image_file, "rb") as fh:
-            fh.seek(self._header_size)
-
-            if big_endian == is_big_endian():
-                raw_data = read_uint16(streambuf(fh), int(size[0] * size[1]))
-            else:
-                raw_data = read_uint16_bs(streambuf(fh), int(size[0] * size[1]))
+        image_size = panel.get_image_size()
+        raw_data = self._get_endianic_raw_data(size=image_size)
 
         # apply image pedestal, will result in *negative pixel values*
-
+        image_pedestal = 40
         raw_data -= image_pedestal
-
-        image_size = panel.get_image_size()
-        raw_data.reshape(flex.grid(image_size[1], image_size[0]))
 
         return raw_data

--- a/format/FormatSMVADSCSN905.py
+++ b/format/FormatSMVADSCSN905.py
@@ -80,32 +80,13 @@ class FormatSMVADSCSN905(FormatSMVADSCSN):
         """Get the pixel intensities (i.e. read the image and return as a
         flex array of integers.)"""
 
-        from boost.python import streambuf
-        from dxtbx import read_uint16, read_uint16_bs, is_big_endian
-        from scitbx.array_family import flex
-
         assert len(self.get_detector()) == 1
-        image_pedestal = 40
         panel = self.get_detector()[0]
-        size = panel.get_image_size()
-        f = FormatSMVADSCSN.open_file(self._image_file, "rb")
-        f.read(self._header_size)
-
-        if self._header_dictionary["BYTE_ORDER"] == "big_endian":
-            big_endian = True
-        else:
-            big_endian = False
-
-        if big_endian == is_big_endian():
-            raw_data = read_uint16(streambuf(f), int(size[0] * size[1]))
-        else:
-            raw_data = read_uint16_bs(streambuf(f), int(size[0] * size[1]))
+        image_size = panel.get_image_size()
+        raw_data = self._get_endianic_raw_data(size=image_size)
 
         # apply image pedestal, will result in *negative pixel values*
-
+        image_pedestal = 40
         raw_data -= image_pedestal
-
-        image_size = panel.get_image_size()
-        raw_data.reshape(flex.grid(image_size[1], image_size[0]))
 
         return raw_data

--- a/format/FormatSMVADSCSN915.py
+++ b/format/FormatSMVADSCSN915.py
@@ -42,33 +42,14 @@ class FormatSMVADSCSN915(FormatSMVADSCSN):
         """Get the pixel intensities (i.e. read the image and return as a
         flex array of integers.)"""
 
-        from boost.python import streambuf
-        from dxtbx import read_uint16, read_uint16_bs, is_big_endian
-        from scitbx.array_family import flex
-
         assert len(self.get_detector()) == 1
-        image_pedestal = int(self._header_dictionary["IMAGE_PEDESTAL"])
         panel = self.get_detector()[0]
-        size = panel.get_image_size()
-        f = FormatSMVADSCSN.open_file(self._image_file, "rb")
-        f.read(self._header_size)
-
-        if self._header_dictionary["BYTE_ORDER"] == "big_endian":
-            big_endian = True
-        else:
-            big_endian = False
-
-        if big_endian == is_big_endian():
-            raw_data = read_uint16(streambuf(f), int(size[0] * size[1]))
-        else:
-            raw_data = read_uint16_bs(streambuf(f), int(size[0] * size[1]))
+        image_size = panel.get_image_size()
+        raw_data = self._get_endianic_raw_data(size=image_size)
 
         # apply image pedestal, will result in *negative pixel values*
-
+        image_pedestal = int(self._header_dictionary["IMAGE_PEDESTAL"])
         raw_data -= image_pedestal
-
-        image_size = panel.get_image_size()
-        raw_data.reshape(flex.grid(image_size[1], image_size[0]))
 
         return raw_data
 

--- a/format/FormatSMVADSCSN920.py
+++ b/format/FormatSMVADSCSN920.py
@@ -41,31 +41,13 @@ class FormatSMVADSCSN920(FormatSMVADSCSN):
         """Get the pixel intensities (i.e. read the image and return as a
         flex array of integers.)"""
 
-        from boost.python import streambuf
-        from dxtbx import read_uint16, read_uint16_bs, is_big_endian
-        from scitbx.array_family import flex
-
         assert len(self.get_detector()) == 1
-        image_pedestal = int(self._header_dictionary["IMAGE_PEDESTAL"])
         panel = self.get_detector()[0]
-        size = panel.get_image_size()
-        if self._header_dictionary["BYTE_ORDER"] == "big_endian":
-            big_endian = True
-        else:
-            big_endian = False
-
-        with FormatSMVADSCSN.open_file(self._image_file, "rb") as fh:
-            fh.seek(self._header_size)
-            if big_endian == is_big_endian():
-                raw_data = read_uint16(streambuf(fh), int(size[0] * size[1]))
-            else:
-                raw_data = read_uint16_bs(streambuf(fh), int(size[0] * size[1]))
+        image_size = panel.get_image_size()
+        raw_data = self._get_endianic_raw_data(size=image_size)
 
         # apply image pedestal, will result in *negative pixel values*
-
+        image_pedestal = int(self._header_dictionary["IMAGE_PEDESTAL"])
         raw_data -= image_pedestal
-
-        image_size = panel.get_image_size()
-        raw_data.reshape(flex.grid(image_size[1], image_size[0]))
 
         return raw_data

--- a/format/FormatSMVCMOS1.py
+++ b/format/FormatSMVCMOS1.py
@@ -195,11 +195,10 @@ class FormatSMVCMOS1(FormatSMV):
         from scitbx.array_family import flex
 
         assert len(self.get_detector()) == 1
-        size = self.get_detector()[0].get_image_size()
-        f = FormatSMV.open_file(self._image_file)
-        f.read(self._header_size)
-        raw_data = read_uint16(streambuf(f), int(size[0] * size[1]))
         image_size = self.get_detector()[0].get_image_size()
+        with self.open_file(self._image_file) as fh:
+            fh.seek(self._header_size)
+            raw_data = read_uint16(streambuf(fh), int(image_size[0] * image_size[1]))
         raw_data.reshape(flex.grid(image_size[1], image_size[0]))
 
         return raw_data

--- a/format/FormatSMVJHSim.py
+++ b/format/FormatSMVJHSim.py
@@ -160,39 +160,16 @@ class FormatSMVJHSim(FormatSMV):
         """Get the pixel intensities (i.e. read the image and return as a
         flex array of integers.)"""
 
-        from boost.python import streambuf
-        from dxtbx import read_uint16, read_uint16_bs, is_big_endian
-        from scitbx.array_family import flex
-
         assert len(self.get_detector()) == 1
-        image_pedestal = 1
-        try:
-            image_pedestal = float(self._header_dictionary["ADC_OFFSET"])
-        except KeyError:
-            pass
         panel = self.get_detector()[0]
-        size = panel.get_image_size()
-        f = FormatSMVJHSim.open_file(self._image_file, "rb")
-        f.read(self._header_size)
-
-        if self._header_dictionary["BYTE_ORDER"] == "big_endian":
-            big_endian = True
-        else:
-            big_endian = False
-
-        if big_endian == is_big_endian():
-            raw_data = read_uint16(streambuf(f), int(size[0] * size[1]))
-        else:
-            raw_data = read_uint16_bs(streambuf(f), int(size[0] * size[1]))
+        image_size = panel.get_image_size()
+        raw_data = self._get_endianic_raw_data(size=image_size)
 
         # apply image pedestal, will result in *negative pixel values*
         # this is a horrible idea since raw_data is unsigned
         # see all instances of image_pedestal in dxtbx
-
+        image_pedestal = self._header_dictionary.get("ADC_OFFSET", 1)
         raw_data -= int(image_pedestal)
-
-        image_size = panel.get_image_size()
-        raw_data.reshape(flex.grid(image_size[1], image_size[0]))
 
         return raw_data
 

--- a/format/FormatSMVNOIR.py
+++ b/format/FormatSMVNOIR.py
@@ -202,28 +202,10 @@ class FormatSMVNOIR(FormatSMVRigaku):
         """Get the pixel intensities (i.e. read the image and return as a
         flex array of integers.)"""
 
-        from boost.python import streambuf
-        from dxtbx.ext import read_uint16, read_uint16_bs, is_big_endian
-        from scitbx.array_family import flex
-
         assert len(self.get_detector()) == 1
         panel = self.get_detector()[0]
-        size = panel.get_image_size()
-        f = FormatSMVNOIR.open_file(self._image_file, "rb")
-        f.read(self._header_size)
-
-        if self._header_dictionary["BYTE_ORDER"] == "big_endian":
-            big_endian = True
-        else:
-            big_endian = False
-
-        if big_endian == is_big_endian():
-            raw_data = read_uint16(streambuf(f), int(size[0] * size[1]))
-        else:
-            raw_data = read_uint16_bs(streambuf(f), int(size[0] * size[1]))
-
         image_size = panel.get_image_size()
-        raw_data.reshape(flex.grid(image_size[1], image_size[0]))
+        raw_data = self._get_endianic_raw_data(size=image_size)
 
         return raw_data
 

--- a/format/FormatSMVRigaku.py
+++ b/format/FormatSMVRigaku.py
@@ -119,28 +119,10 @@ class FormatSMVRigaku(FormatSMV):
         """Get the pixel intensities (i.e. read the image and return as a
         flex array of integers.)"""
 
-        from boost.python import streambuf
-        from dxtbx.ext import read_uint16, read_uint16_bs, is_big_endian
-        from scitbx.array_family import flex
-
         assert len(self.get_detector()) == 1
         panel = self.get_detector()[0]
-        size = panel.get_image_size()
-        f = FormatSMVRigaku.open_file(self._image_file, "rb")
-        f.read(self._header_size)
-
-        if self._header_dictionary["BYTE_ORDER"] == "big_endian":
-            big_endian = True
-        else:
-            big_endian = False
-
-        if big_endian == is_big_endian():
-            raw_data = read_uint16(streambuf(f), int(size[0] * size[1]))
-        else:
-            raw_data = read_uint16_bs(streambuf(f), int(size[0] * size[1]))
-
         image_size = panel.get_image_size()
-        raw_data.reshape(flex.grid(image_size[1], image_size[0]))
+        raw_data = self._get_endianic_raw_data(size=image_size)
 
         return raw_data
 

--- a/format/FormatSMVRigakuSaturnNoTS.py
+++ b/format/FormatSMVRigakuSaturnNoTS.py
@@ -207,33 +207,14 @@ class FormatSMVRigakuSaturnNoTS(FormatSMVRigaku):
         """Get the pixel intensities (i.e. read the image and return as a
         flex array of integers.)"""
 
-        from boost.python import streambuf
-        from dxtbx import read_uint16, read_uint16_bs, is_big_endian
-        from scitbx.array_family import flex
-
         assert len(self.get_detector()) == 1
-        image_pedestal = int(self._header_dictionary["DARK_PEDESTAL"])
         panel = self.get_detector()[0]
-        size = panel.get_image_size()
-        f = FormatSMVRigaku.open_file(self._image_file, "rb")
-        f.read(self._header_size)
-
-        if self._header_dictionary["BYTE_ORDER"] == "big_endian":
-            big_endian = True
-        else:
-            big_endian = False
-
-        if big_endian == is_big_endian():
-            raw_data = read_uint16(streambuf(f), int(size[0] * size[1]))
-        else:
-            raw_data = read_uint16_bs(streambuf(f), int(size[0] * size[1]))
+        image_size = panel.get_image_size()
+        raw_data = self._get_endianic_raw_data(size=image_size)
 
         # apply image pedestal, will result in *negative pixel values*
-
+        image_pedestal = int(self._header_dictionary["DARK_PEDESTAL"])
         raw_data -= image_pedestal
-
-        image_size = panel.get_image_size()
-        raw_data.reshape(flex.grid(image_size[1], image_size[0]))
 
         return raw_data
 

--- a/format/FormatSMVTimePix_SU.py
+++ b/format/FormatSMVTimePix_SU.py
@@ -313,25 +313,7 @@ class FormatSMVTimePix_SU_512x512(FormatSMVTimePix_SU):
         """Get the pixel intensities (i.e. read the image and return as a
         flex array of integers.)"""
 
-        from boost.python import streambuf
-        from dxtbx import read_uint16, read_uint16_bs, is_big_endian
-        from scitbx.array_family import flex
-
-        f = self.open_file(self._image_file, "rb")
-        f.read(self._header_size)
-
-        if self._header_dictionary["BYTE_ORDER"] == "big_endian":
-            big_endian = True
-        else:
-            big_endian = False
-
-        if big_endian == is_big_endian():
-            raw_data = read_uint16(streambuf(f), int(512 * 512))
-        else:
-            raw_data = read_uint16_bs(streambuf(f), int(512 * 512))
-
-        image_size = (512, 512)
-        raw_data.reshape(flex.grid(image_size[1], image_size[0]))
+        raw_data = self._get_endianic_raw_data(size=(512, 512))
 
         # split into separate panels
         self._raw_data = []
@@ -417,28 +399,9 @@ class FormatSMVTimePix_SU_516x516(FormatSMVTimePix_SU):
         """Get the pixel intensities (i.e. read the image and return as a
         flex array of integers.)"""
 
-        from boost.python import streambuf
-        from dxtbx import read_uint16, read_uint16_bs, is_big_endian
-        from scitbx.array_family import flex
-
-        f = self.open_file(self._image_file, "rb")
-        f.read(self._header_size)
-
         nx = int(self._header_dictionary["SIZE1"])  # number of pixels
         ny = int(self._header_dictionary["SIZE2"])  # number of pixels
-
-        if self._header_dictionary["BYTE_ORDER"] == "big_endian":
-            big_endian = True
-        else:
-            big_endian = False
-
-        if big_endian == is_big_endian():
-            raw_data = read_uint16(streambuf(f), int(nx * ny))
-        else:
-            raw_data = read_uint16_bs(streambuf(f), int(nx * ny))
-
-        # note that x and y are reversed here
-        raw_data.reshape(flex.grid(ny, nx))
+        raw_data = self._get_endianic_raw_data(size=(nx, ny))
 
         self._raw_data = raw_data
 


### PR DESCRIPTION
extract common get_raw_data spells into a common function

as part of this work I noticed that the following format classes are not covered by tests:
* FormatSMVADSCSN905
* FormatSMVADSCSN915
* FormatSMVADSCSN920
* FormatSMVCMOS1
* FormatSMVJHSim
* FormatSMVRigakuSaturnNoTS
* FormatSMVTimePix_SU_512x512
* FormatSMVTimePix_SU_516x516