### PR TITLE
remove format_class.get_mask() as it doesn't appear to be used

### DIFF
--- a/format/Format.py
+++ b/format/Format.py
@@ -491,12 +491,6 @@ class Format(object):
         long as the result is an scan."""
         return None
 
-    def get_mask(self, index=None, goniometer=None):
-        """Overload this method to provide dynamic masks to be used during
-        spotfinding or integration."""
-
-        return None
-
     def get_goniometer_shadow_masker(self, goniometer=None):
         """Overload this method to allow generation of dynamic goniometer shadow
         masks to be used during spotfinding or integration."""

--- a/format/FormatCBFFullPilatus.py
+++ b/format/FormatCBFFullPilatus.py
@@ -149,33 +149,6 @@ class FormatCBFFullPilatus(FormatCBFFull):
 
         return self._raw_data
 
-    def get_mask(self, goniometer=None):
-        from scitbx.array_family import flex
-
-        detector = self.get_detector()
-        mask = [
-            flex.bool(flex.grid(reversed(p.get_image_size())), True) for p in detector
-        ]
-        for i, p in enumerate(detector):
-            untrusted_regions = p.get_mask()
-            for j, (f0, s0, f1, s1) in enumerate(untrusted_regions):
-                sub_array = flex.bool(flex.grid(s1 - s0, f1 - f0), False)
-                mask[i].matrix_paste_block_in_place(sub_array, s0, f0)
-
-        if len(detector) == 1:
-            raw_data = [self.get_raw_data()]
-        else:
-            raw_data = self.get_raw_data()
-            assert len(raw_data) == len(detector)
-        trusted_mask = [
-            p.get_trusted_range_mask(im) for im, p in zip(raw_data, detector)
-        ]
-
-        # returns merged untrusted pixels and active areas using bitwise AND
-        # (pixels are accepted if they are inside of the active areas AND inside
-        # of the trusted range)
-        return tuple(m & tm for m, tm in zip(mask, trusted_mask))
-
     def get_vendortype(self):
         from dxtbx.format.FormatPilatusHelpers import get_vendortype as gv
 

--- a/format/FormatCBFFullPilatusDLS300KSN104.py
+++ b/format/FormatCBFFullPilatusDLS300KSN104.py
@@ -55,19 +55,6 @@ class FormatCBFFullPilatusDLS300KSN104(FormatCBFFullPilatus):
         self._dynamic_shadowing = self.has_dynamic_shadowing(**kwargs)
         FormatCBFFullPilatus.__init__(self, image_file, **kwargs)
 
-    def get_mask(self, goniometer=None):
-        mask = super(FormatCBFFullPilatusDLS300KSN104, self).get_mask()
-        if self._dynamic_shadowing:
-            gonio_masker = self.get_goniometer_shadow_masker(goniometer=goniometer)
-            scan = self.get_scan()
-            detector = self.get_detector()
-            shadow_mask = gonio_masker.get_mask(detector, scan.get_oscillation()[0])
-            assert len(mask) == len(shadow_mask)
-            for m, sm in zip(mask, shadow_mask):
-                if sm is not None:
-                    m &= ~sm
-        return mask
-
     def get_goniometer_shadow_masker(self, goniometer=None):
         if goniometer is None:
             goniometer = self.get_goniometer()

--- a/format/FormatCBFFullPilatusDLS6MSN100.py
+++ b/format/FormatCBFFullPilatusDLS6MSN100.py
@@ -51,19 +51,6 @@ class FormatCBFFullPilatusDLS6MSN100(FormatCBFFullPilatus):
         self._dynamic_shadowing = self.has_dynamic_shadowing(**kwargs)
         FormatCBFFullPilatus.__init__(self, image_file, **kwargs)
 
-    def get_mask(self, goniometer=None):
-        mask = super(FormatCBFFullPilatusDLS6MSN100, self).get_mask()
-        if self._dynamic_shadowing:
-            gonio_masker = self.get_goniometer_shadow_masker(goniometer=goniometer)
-            scan = self.get_scan()
-            detector = self.get_detector()
-            shadow_mask = gonio_masker.get_mask(detector, scan.get_oscillation()[0])
-            assert len(mask) == len(shadow_mask)
-            for m, sm in zip(mask, shadow_mask):
-                if sm is not None:
-                    m &= sm
-        return mask
-
     def get_goniometer_shadow_masker(self, goniometer=None):
         if goniometer is None:
             goniometer = self.get_goniometer()

--- a/format/FormatCBFFullPilatusDLS6MSN126.py
+++ b/format/FormatCBFFullPilatusDLS6MSN126.py
@@ -56,23 +56,6 @@ class FormatCBFFullPilatusDLS6MSN126(FormatCBFFullPilatus):
         self._dynamic_shadowing = self.has_dynamic_shadowing(**kwargs)
         FormatCBFFullPilatus.__init__(self, image_file, **kwargs)
 
-    def get_mask(self, goniometer=None):
-        mask = super(FormatCBFFullPilatusDLS6MSN126, self).get_mask()
-
-        # when device was installed with SmarGon on I03 this was the signature
-        # now it lives on i02-1 => detect - at the moment device has single
-        # axis in new home
-        if len(self.get_goniometer().get_names()) == 3 and self._dynamic_shadowing:
-            gonio_masker = self.get_goniometer_shadow_masker(goniometer=goniometer)
-            scan = self.get_scan()
-            detector = self.get_detector()
-            shadow_mask = gonio_masker.get_mask(detector, scan.get_oscillation()[0])
-            assert len(mask) == len(shadow_mask)
-            for m, sm in zip(mask, shadow_mask):
-                if sm is not None:
-                    m &= sm
-        return mask
-
     def get_goniometer_shadow_masker(self, goniometer=None):
         if goniometer is None:
             goniometer = self.get_goniometer()

--- a/format/FormatCBFMiniEiger.py
+++ b/format/FormatCBFMiniEiger.py
@@ -201,33 +201,6 @@ class FormatCBFMiniEiger(FormatCBFMini):
 
         return self._raw_data
 
-    def get_mask(self, goniometer=None):
-        from scitbx.array_family import flex
-
-        detector = self.get_detector()
-        mask = [
-            flex.bool(flex.grid(reversed(p.get_image_size())), True) for p in detector
-        ]
-        for i, p in enumerate(detector):
-            untrusted_regions = p.get_mask()
-            for j, (f0, s0, f1, s1) in enumerate(untrusted_regions):
-                sub_array = flex.bool(flex.grid(s1 - s0, f1 - f0), False)
-                mask[i].matrix_paste_block_in_place(sub_array, s0, f0)
-
-        if len(detector) == 1:
-            raw_data = [self.get_raw_data()]
-        else:
-            raw_data = self.get_raw_data()
-            assert len(raw_data) == len(detector)
-        trusted_mask = [
-            p.get_trusted_range_mask(im) for im, p in zip(raw_data, detector)
-        ]
-
-        # returns merged untrusted pixels and active areas using bitwise AND
-        # (pixels are accepted if they are inside of the active areas AND
-        # inside of the trusted range)
-        return tuple([m & tm for m, tm in zip(mask, trusted_mask)])
-
     def detectorbase_start(self):
         from iotbx.detectors.eiger_minicbf import EigerCBFImage
 

--- a/format/FormatCBFMiniEigerDLS16MSN160.py
+++ b/format/FormatCBFMiniEigerDLS16MSN160.py
@@ -90,19 +90,6 @@ class FormatCBFMiniEigerDLS16MSN160(FormatCBFMiniEiger):
             axes, angles, names, scan_axis=2
         )
 
-    def get_mask(self, goniometer=None):
-        mask = super(FormatCBFMiniEigerDLS16MSN160, self).get_mask()
-        if self._dynamic_shadowing:
-            gonio_masker = self.get_goniometer_shadow_masker(goniometer=goniometer)
-            scan = self.get_scan()
-            detector = self.get_detector()
-            shadow_mask = gonio_masker.get_mask(detector, scan.get_oscillation()[0])
-            assert len(mask) == len(shadow_mask)
-            for m, sm in zip(mask, shadow_mask):
-                if sm is not None:
-                    m &= sm
-        return mask
-
     def get_goniometer_shadow_masker(self, goniometer=None):
         if goniometer is None:
             goniometer = self.get_goniometer()

--- a/format/FormatCBFMiniPilatus.py
+++ b/format/FormatCBFMiniPilatus.py
@@ -93,32 +93,6 @@ class FormatCBFMiniPilatus(FormatCBFMini):
             self._image_file, format, exposure_time, osc_start, osc_range, timestamp
         )
 
-    def get_mask(self, goniometer=None):
-        from scitbx.array_family import flex
-
-        detector = self.get_detector()
-        mask = [
-            flex.bool(flex.grid(reversed(p.get_image_size())), True) for p in detector
-        ]
-        for i, p in enumerate(detector):
-            untrusted_regions = p.get_mask()
-            for j, (f0, s0, f1, s1) in enumerate(untrusted_regions):
-                sub_array = flex.bool(flex.grid(s1 - s0, f1 - f0), False)
-                mask[i].matrix_paste_block_in_place(sub_array, s0, f0)
-
-        if len(detector) == 1:
-            raw_data = [self.get_raw_data()]
-        else:
-            raw_data = self.get_raw_data()
-            assert len(raw_data) == len(detector)
-        trusted_mask = [
-            p.get_trusted_range_mask(im) for im, p in zip(raw_data, detector)
-        ]
-
-        # returns merged untrusted pixels and active areas using bitwise AND (pixels are accepted
-        # if they are inside of the active areas AND inside of the trusted range)
-        return tuple([m & tm for m, tm in zip(mask, trusted_mask)])
-
     def get_vendortype(self):
         from dxtbx.format.FormatPilatusHelpers import get_vendortype as gv
 

--- a/format/FormatCBFMiniPilatusDLS12M.py
+++ b/format/FormatCBFMiniPilatusDLS12M.py
@@ -211,24 +211,6 @@ class FormatCBFMiniPilatusDLS12M(FormatCBFMiniPilatus):
             goniometer = self.get_goniometer()
         return GoniometerMaskerFactory.dls_i23_kappa(goniometer)
 
-    def get_mask(self, goniometer=None):
-        from dxtbx.model import MultiAxisGoniometer
-
-        mask = super(FormatCBFMiniPilatusDLS12M, self).get_mask()
-        if (
-            isinstance(self.get_goniometer(), MultiAxisGoniometer)
-            and self._dynamic_shadowing
-        ):
-            gonio_masker = self.get_goniometer_shadow_masker(goniometer=goniometer)
-            scan = self.get_scan()
-            detector = self.get_detector()
-            shadow_mask = gonio_masker.get_mask(detector, scan.get_oscillation()[0])
-            assert len(mask) == len(shadow_mask)
-            for m, sm in zip(mask, shadow_mask):
-                if sm is not None:
-                    m &= sm
-        return mask
-
     def _goniometer(self):
         """Return a model for a simple single-axis goniometer. This should
         probably be checked against the image header."""

--- a/format/FormatCBFMiniPilatusDLS6MSN100.py
+++ b/format/FormatCBFMiniPilatusDLS6MSN100.py
@@ -357,19 +357,6 @@ class FormatCBFMiniPilatusDLS6MSN100(FormatCBFMiniPilatus):
     def get_goniometer_shadow_masker(self, goniometer=None):
         return GoniometerMaskerFactory.mini_kappa(goniometer)
 
-    def get_mask(self, goniometer=None):
-        mask = super(FormatCBFMiniPilatusDLS6MSN100, self).get_mask()
-        if self._dynamic_shadowing:
-            gonio_masker = self.get_goniometer_shadow_masker(goniometer=goniometer)
-            scan = self.get_scan()
-            detector = self.get_detector()
-            shadow_mask = gonio_masker.get_mask(detector, scan.get_oscillation()[0])
-            assert len(mask) == len(shadow_mask)
-            for m, sm in zip(mask, shadow_mask):
-                if sm is not None:
-                    m &= sm
-        return mask
-
     def _read_cbf_image(self):
         from cbflib_adaptbx import uncompress
         import binascii

--- a/format/FormatHDF5EigerNearlyNexus.py
+++ b/format/FormatHDF5EigerNearlyNexus.py
@@ -20,7 +20,6 @@ from dxtbx.format.nexus import DetectorFactory
 from dxtbx.format.nexus import GoniometerFactory
 from dxtbx.format.nexus import ScanFactory
 from dxtbx.format.nexus import DataFactory
-from dxtbx.format.nexus import MaskFactory
 
 import h5py
 import numpy
@@ -398,9 +397,6 @@ class FormatHDF5EigerNearlyNexus(FormatHDF5):
 
     def get_raw_data(self, index):
         return self._raw_data[index]
-
-    def get_mask(self, index=None, goniometer=None):
-        return MaskFactory(self.instrument.detectors, index).mask
 
     def get_num_images(self):
         scan = self._scan()

--- a/format/FormatHDF5SaclaMPCCD.py
+++ b/format/FormatHDF5SaclaMPCCD.py
@@ -397,12 +397,6 @@ class FormatHDF5SaclaMPCCD(FormatHDF5, FormatStill):
 
         return self._detector_instance
 
-    def get_mask(self, index=None, goniometer=None):
-        # This means when the pixel mask is present, trusted region is ignored.
-        # The used provided masks (if any) will be automatically merged.
-        # see https://github.com/dials/dials/issues/236
-        return self.mask
-
     def get_beam(self, index=None):
         if index is not None and self.index != index:
             self.set_index(index)

--- a/format/FormatHDF5SaclaRayonix.py
+++ b/format/FormatHDF5SaclaRayonix.py
@@ -124,12 +124,6 @@ class FormatHDF5SaclaRayonix(FormatHDF5, FormatStill):
 
         return self._detector_instance
 
-    def get_mask(self, index=None, goniometer=None):
-        # This means when the pixel mask is present, trusted region is ignored.
-        # The used provided masks (if any) will be automatically merged.
-        # see https://github.com/dials/dials/issues/236
-        return self.mask
-
     def get_beam(self, index=None):
         if index is not None and self.index != index:
             self.set_index(index)

--- a/format/FormatMultiImage.py
+++ b/format/FormatMultiImage.py
@@ -80,9 +80,6 @@ class FormatMultiImage(Format):
     def get_raw_data(self, index=None):
         raise NotImplementedError
 
-    def get_mask(self, index=None, goniometer=None):
-        return None
-
     def get_detectorbase(self, index=None):
         raise NotImplementedError
 

--- a/format/FormatNexus.py
+++ b/format/FormatNexus.py
@@ -10,7 +10,6 @@ from dxtbx.format.nexus import DetectorFactory, DetectorFactoryFromGroup
 from dxtbx.format.nexus import GoniometerFactory
 from dxtbx.format.nexus import ScanFactory
 from dxtbx.format.nexus import DataFactory, DetectorGroupDataFactory
-from dxtbx.format.nexus import MaskFactory
 
 
 class FormatNexus(FormatHDF5):
@@ -126,9 +125,6 @@ class FormatNexus(FormatHDF5):
 
     def get_raw_data(self, index):
         return self._raw_data[index]
-
-    def get_mask(self, index=None, goniometer=None):
-        return MaskFactory(self.instrument.detectors, index).mask
 
     def get_num_images(self):
         if self._scan() is not None:

--- a/format/FormatNexusEigerDLS16M.py
+++ b/format/FormatNexusEigerDLS16M.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import, division, print_function
 
 import h5py
 import libtbx
-from scitbx.array_family import flex
 from dxtbx.format.FormatNexus import FormatNexus
 from dxtbx.model import MultiAxisGoniometer
 from dxtbx.masking import GoniometerMaskerFactory
@@ -55,28 +54,6 @@ class FormatNexusEigerDLS16M(FormatNexus):
 
         super(FormatNexusEigerDLS16M, self).__init__(image_file, **kwargs)
         self._dynamic_shadowing = self.has_dynamic_shadowing(**kwargs)
-
-    def get_mask(self, index, goniometer=None):
-        mask = super(FormatNexusEigerDLS16M, self).get_mask()
-        if mask is None:
-            # XXX mask really shouldn't be None
-            # https://jira.diamond.ac.uk/browse/SCI-8308
-            mask = tuple(
-                flex.bool(flex.grid(reversed(panel.get_image_size())), True)
-                for panel in self.get_detector()
-            )
-        if self._dynamic_shadowing and self.get_scan():
-            gonio_masker = self.get_goniometer_shadow_masker(goniometer=goniometer)
-            scan = self.get_scan()
-            detector = self.get_detector()
-            shadow_mask = gonio_masker.get_mask(
-                detector, scan.get_angle_from_image_index(index)
-            )
-            assert len(mask) == len(shadow_mask)
-            for m, sm in zip(mask, shadow_mask):
-                if sm is not None:
-                    m &= sm
-        return mask
 
     def get_goniometer_shadow_masker(self, goniometer=None):
         if not self._dynamic_shadowing:

--- a/format/FormatPYunspecified.py
+++ b/format/FormatPYunspecified.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import, division, print_function
 
-from builtins import range
 import copy
 import os
 
@@ -12,7 +11,6 @@ from iotbx.detectors.cspad_detector_formats import reverse_timestamp
 from iotbx.detectors.cspad_detector_formats import detector_format_version
 from dxtbx import IncorrectFormatError
 from spotfinder.applications.xfel import cxi_phil
-from scitbx.array_family import flex
 from iotbx.detectors.npy import NpyImage
 import sys
 
@@ -175,37 +173,6 @@ class FormatPYunspecified(FormatPY):
                 oscillation=(0.0, 0.0),
                 epochs={1: self._timesec},
             )
-
-    def get_mask(self, goniometer=None):
-        """Creates a mask merging untrusted pixels with active areas."""
-        detector_base = self.detectorbase
-        # get effective active area coordinates
-        tile_manager = detector_base.get_tile_manager(detector_base.horizons_phil_cache)
-        tiling = tile_manager.effective_tiling_as_flex_int(
-            reapply_peripheral_margin=True
-        )
-        # get the raw data to get the size of the mask
-        data = self.get_raw_data()
-        if tiling is None or len(tiling) == 0:
-            return None
-
-        # set the mask to the same dimensions as the data
-        mask = flex.bool(flex.grid(data.focus()))
-
-        # set active areas to True so they are not masked
-        for i in range(len(tiling) // 4):
-            x1, y1, x2, y2 = tiling[4 * i : (4 * i) + 4]
-            sub_array = flex.bool(flex.grid(x2 - x1, y2 - y1), True)
-            mask.matrix_paste_block_in_place(sub_array, x1, y1)
-
-        # create untrusted pixel mask
-        detector = self.get_detector()
-        assert len(detector) == 1
-        trusted_mask = detector[0].get_trusted_range_mask(data)
-
-        # returns merged untrusted pixels and active areas using bitwise AND (pixels are accepted
-        # if they are inside of the active areas AND inside of the trusted range)
-        return (mask & trusted_mask,)
 
 
 class FormatPYunspecifiedInMemory(FormatPYunspecified):


### PR DESCRIPTION
As far as I can tell the format_class.get_mask() method no longer appears to be called after the recent masking refactor. At least all the dials/dxtbx tests appear to pass after removing the methods. I don't know whether this is an oversight, a bug, or reflects a lack of test coverage.