### PR TITLE
Rename Beam.get_direction

### DIFF
--- a/command_line/print_sweep.py
+++ b/command_line/print_sweep.py
@@ -25,7 +25,7 @@ def print_sweep(list_of_images):
         o = matrix.col(d.get_origin())
         f = matrix.col(d.get_fast_axis())
         s = matrix.col(d.get_slow_axis())
-        s0 = matrix.col(b.get_direction())
+        s0 = matrix.col(b.get_sample_to_source_direction())
 
         beam_offset = o - o.dot(s0) * s0
         print(

--- a/datablock.py
+++ b/datablock.py
@@ -1303,8 +1303,8 @@ class BeamDiff(object):
     def __call__(self, a, b):
         aw = a.get_wavelength()
         bw = b.get_wavelength()
-        ad = matrix.col(a.get_direction())
-        bd = matrix.col(b.get_direction())
+        ad = matrix.col(a.get_sample_to_source_direction())
+        bd = matrix.col(b.get_sample_to_source_direction())
         an = matrix.col(a.get_polarization_normal())
         bn = matrix.col(b.get_polarization_normal())
         af = a.get_polarization_fraction()

--- a/example/resolution_corners.py
+++ b/example/resolution_corners.py
@@ -28,7 +28,7 @@ def resolution_corners(frame):
     S = matrix.col(detector.get_slow_axis())
     origin = matrix.col(detector.get_origin())
 
-    s0 = -1 * matrix.col(beam.get_direction())
+    s0 = -1 * matrix.col(beam.get_sample_to_source_direction())
 
     for ds in 0, 1:
         for df in 0, 1:

--- a/example/to_xds.py
+++ b/example/to_xds.py
@@ -106,8 +106,10 @@ class to_xds(object):
         origin = R * self.get_detector().get_origin()
         beam = (
             R
-            * self.get_beam().get_direction()
-            / math.sqrt(matrix.col(self.get_beam().get_direction()).dot())
+            * self.get_beam().get_sample_to_source_direction()
+            / math.sqrt(
+                matrix.col(self.get_beam().get_sample_to_source_direction()).dot()
+            )
         )
         centre = -(origin - origin.dot(N) * N)
         x = centre.dot(F)

--- a/model/__init__.py
+++ b/model/__init__.py
@@ -803,7 +803,8 @@ class _(object):
             raise RuntimeError("expected extension {%s}, got %s" % (ext_str, ext))
 
 
-class BeamDeprecatedMethods(object):
+@boost.python.inject_into(Beam)
+class _(object):
     def get_direction(self):
         import warnings
 
@@ -815,12 +816,3 @@ class BeamDeprecatedMethods(object):
             stacklevel=2,
         )
         return self.get_sample_to_source_direction()
-
-
-boost.python.inject_into(Beam)(BeamDeprecatedMethods)
-boost.python.inject_into(Crystal)(CrystalAux)
-boost.python.inject_into(Detector)(DetectorAux)
-boost.python.inject_into(Experiment)(ExperimentAux)
-boost.python.inject_into(ExperimentList)(ExperimentListAux)
-boost.python.inject_into(MosaicCrystalKabsch2010)(MosaicCrystalKabsch2010Aux)
-boost.python.inject_into(MosaicCrystalSauter2014)(MosaicCrystalSauter2014Aux)

--- a/model/__init__.py
+++ b/model/__init__.py
@@ -801,3 +801,26 @@ class _(object):
         else:
             ext_str = "|".join(j_ext + p_ext)
             raise RuntimeError("expected extension {%s}, got %s" % (ext_str, ext))
+
+
+class BeamDeprecatedMethods(object):
+    def get_direction(self):
+        import warnings
+
+        warnings.warn(
+            "Calling get_direction is deprecated. Please use "
+            "get_sample_to_source_direction instead. "
+            "See https://github.com/cctbx/dxtbx/issues/6",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.get_sample_to_source_direction()
+
+
+boost.python.inject_into(Beam)(BeamDeprecatedMethods)
+boost.python.inject_into(Crystal)(CrystalAux)
+boost.python.inject_into(Detector)(DetectorAux)
+boost.python.inject_into(Experiment)(ExperimentAux)
+boost.python.inject_into(ExperimentList)(ExperimentListAux)
+boost.python.inject_into(MosaicCrystalKabsch2010)(MosaicCrystalKabsch2010Aux)
+boost.python.inject_into(MosaicCrystalSauter2014)(MosaicCrystalSauter2014Aux)

--- a/model/__init__.py
+++ b/model/__init__.py
@@ -810,7 +810,7 @@ class _(object):
 
         warnings.warn(
             "Calling get_direction is deprecated. Please use "
-            "get_sample_to_source_direction instead. "
+            ".get_sample_to_source_direction() instead. "
             "See https://github.com/cctbx/dxtbx/issues/6",
             DeprecationWarning,
             stacklevel=2,

--- a/model/beam.h
+++ b/model/beam.h
@@ -30,7 +30,7 @@ namespace dxtbx { namespace model {
     virtual ~BeamBase() {}
 
     // Get the direction
-    virtual vec3<double> get_direction() const = 0;
+    virtual vec3<double> get_sample_to_source_direction() const = 0;
     // Get the wavelength
     virtual double get_wavelength() const = 0;
     // Get the beam divergence
@@ -202,7 +202,7 @@ namespace dxtbx { namespace model {
     virtual ~Beam() {}
 
     /** Get the direction */
-    vec3<double> get_direction() const {
+    vec3<double> get_sample_to_source_direction() const {
       return direction_;
     }
 
@@ -373,7 +373,7 @@ namespace dxtbx { namespace model {
       }
 
       // static model checks
-      return std::abs(angle_safe(direction_, rhs.get_direction())) <= eps
+      return std::abs(angle_safe(direction_, rhs.get_sample_to_source_direction())) <= eps
              && std::abs(wavelength_ - rhs.get_wavelength()) <= eps
              && std::abs(divergence_ - rhs.get_divergence()) <= eps
              && std::abs(sigma_divergence_ - rhs.get_sigma_divergence()) <= eps
@@ -414,7 +414,7 @@ namespace dxtbx { namespace model {
       }
 
       // static model checks
-      return std::abs(angle_safe(direction_, rhs.get_direction()))
+      return std::abs(angle_safe(direction_, rhs.get_sample_to_source_direction()))
                <= direction_tolerance
              && std::abs(wavelength_ - rhs.get_wavelength()) <= wavelength_tolerance
              && std::abs(
@@ -455,7 +455,7 @@ namespace dxtbx { namespace model {
   inline std::ostream &operator<<(std::ostream &os, const Beam &b) {
     os << "Beam:\n";
     os << "    wavelength: " << b.get_wavelength() << "\n";
-    os << "    sample to source direction : " << b.get_direction().const_ref() << "\n";
+    os << "    sample to source direction : " << b.get_sample_to_source_direction().const_ref() << "\n";
     os << "    divergence: " << b.get_divergence() << "\n";
     os << "    sigma divergence: " << b.get_sigma_divergence() << "\n";
     os << "    polarization normal: " << b.get_polarization_normal().const_ref()

--- a/model/boost_python/beam.cc
+++ b/model/boost_python/beam.cc
@@ -31,7 +31,7 @@ namespace dxtbx { namespace model { namespace boost_python {
 
   struct BeamPickleSuite : boost::python::pickle_suite {
     static boost::python::tuple getinitargs(const Beam &obj) {
-      return boost::python::make_tuple(obj.get_direction(),
+      return boost::python::make_tuple(obj.get_sample_to_source_direction(),
                                        obj.get_wavelength(),
                                        obj.get_divergence(),
                                        obj.get_sigma_divergence(),
@@ -177,7 +177,7 @@ namespace dxtbx { namespace model { namespace boost_python {
   template <>
   boost::python::dict to_dict<Beam>(const Beam &obj) {
     boost::python::dict result;
-    result["direction"] = obj.get_direction();
+    result["direction"] = obj.get_sample_to_source_direction();
     result["wavelength"] = obj.get_wavelength();
     result["divergence"] = rad_as_deg(obj.get_divergence());
     result["sigma_divergence"] = rad_as_deg(obj.get_sigma_divergence());
@@ -221,7 +221,7 @@ namespace dxtbx { namespace model { namespace boost_python {
   void export_beam() {
     // Export BeamBase
     class_<BeamBase, boost::noncopyable>("BeamBase", no_init)
-      .def("get_direction", &BeamBase::get_direction)
+      .def("get_sample_to_source_direction", &BeamBase::get_sample_to_source_direction)
       .def("set_direction", &BeamBase::set_direction)
       .def("get_wavelength", &BeamBase::get_wavelength)
       .def("set_wavelength", &BeamBase::set_wavelength)

--- a/serialize/xds.py
+++ b/serialize/xds.py
@@ -254,7 +254,9 @@ class to_xds(object):
 
         # Beam stuff
         self.wavelength = self.get_beam().get_wavelength()
-        self.beam_vector = Rd * matrix.col(self.get_beam().get_direction())
+        self.beam_vector = Rd * matrix.col(
+            self.get_beam().get_sample_to_source_direction()
+        )
         # just to make sure it is the correct length
         self.beam_vector = self.beam_vector.normalize()  # / self.wavelength
         self.beam_vector = (-self.beam_vector).elems

--- a/tests/model/test_beam.py
+++ b/tests/model/test_beam.py
@@ -21,8 +21,8 @@ def test_setting_direction_and_wavelength():
     eps = 1e-7
 
     # Check direction is a unit vector
-    assert matrix.col(b.get_direction()).length() == pytest.approx(1)
-    assert abs(matrix.col(b.get_direction()) - unit_direction) <= eps
+    assert matrix.col(b.get_sample_to_source_direction()).length() == pytest.approx(1)
+    assert abs(matrix.col(b.get_sample_to_source_direction()) - unit_direction) <= eps
 
     # Check wavelength is correct
     assert b.get_wavelength() == pytest.approx(wavelength)
@@ -44,8 +44,8 @@ def test_setting_s0():
     eps = 1e-7
 
     # Check direction is a unit vector
-    assert matrix.col(b.get_direction()).length() == pytest.approx(1)
-    assert abs(matrix.col(b.get_direction()) - unit_direction) <= eps
+    assert matrix.col(b.get_sample_to_source_direction()).length() == pytest.approx(1)
+    assert abs(matrix.col(b.get_sample_to_source_direction()) - unit_direction) <= eps
 
     # Check wavelength is correct
     assert b.get_wavelength() == pytest.approx(wavelength)

--- a/tests/serialize/test_serialize.py
+++ b/tests/serialize/test_serialize.py
@@ -19,7 +19,7 @@ def test_beam():
     # Test with a template and partial dictionary
     d2 = {"direction": (0, 1, 0), "divergence": 0.2}
     b3 = BeamFactory.from_dict(d2, d)
-    assert b3.get_direction() == (0, 1, 0)
+    assert b3.get_sample_to_source_direction() == (0, 1, 0)
     assert b3.get_wavelength() == 2
     assert b3.get_divergence() == pytest.approx(0.2)
     assert b3.get_sigma_divergence() == pytest.approx(0.1)

--- a/tests/serialize/test_xds.py
+++ b/tests/serialize/test_xds.py
@@ -73,7 +73,9 @@ JOB=XYCORR INIT COLSPOT IDXREF DEFPIX INTEGRATE CORRECT\
     assert approx_equal(real_space_b, converter.get_real_space_b())
     assert approx_equal(real_space_c, converter.get_real_space_c())
     assert approx_equal(goniometer.get_rotation_axis(), converter.get_rotation_axis())
-    assert approx_equal(beam.get_direction(), converter.get_sample_to_source().elems)
+    assert approx_equal(
+        beam.get_sample_to_source_direction(), converter.get_sample_to_source().elems
+    )
     assert approx_equal(detector[0].get_fast_axis(), converter.get_detector_fast())
     assert approx_equal(detector[0].get_slow_axis(), converter.get_detector_slow())
     assert approx_equal(detector[0].get_origin(), converter.get_detector_origin())


### PR DESCRIPTION
Beam.get_direction --> Beam.get_sample_to_source_direction.
Fixes #6

Made a PR to make the API change visible, but it turns out to be trivial, with only a handful of changes across DIALS, xia2 and cctbx