### PR TITLE
switch fast_axis to +x and configure rayonix based on binning size

### DIFF
--- a/format/FormatHDF5SaclaRayonix.py
+++ b/format/FormatHDF5SaclaRayonix.py
@@ -19,7 +19,7 @@ class FormatHDF5SaclaRayonix(FormatHDF5, FormatStill):
         h5_handle = h5py.File(image_file, "r")
         if "metadata/detector" not in h5_handle:
             return False
-        if h5_handle["metadata/detector"].value != "Rayonix MX300HS":
+        if h5_handle["metadata/detector"][()] != "Rayonix MX300HS":
             return False
         if any(elem.startswith("tag-") for elem in h5_handle):
             return True
@@ -100,7 +100,7 @@ class FormatHDF5SaclaRayonix(FormatHDF5, FormatStill):
         import h5py
 
         h5_handle = h5py.File(self.image_filename, "r")
-        eV = h5_handle[self.tag]["photon_energy_ev"].value
+        eV = h5_handle[self.tag]["photon_energy_ev"][()]
         h5_handle.close()
 
         return self._beam_factory.simple(12398.4 / eV)

--- a/format/FormatHDF5SaclaRayonix.py
+++ b/format/FormatHDF5SaclaRayonix.py
@@ -36,8 +36,12 @@ class FormatHDF5SaclaRayonix(FormatHDF5, FormatStill):
         self.image_filename = image_file
         FormatHDF5.__init__(self, image_file, **kwargs)
 
-        self.PIXEL_SIZE = 78.2 / 1000  # um
-        self.RECONST_SIZE = 3840
+        self.bin_size = 2
+        # Override bin size by environment variable
+        if os.getenv("RAYONIX_BINNING"):
+            self.bin_size = int(os.environ["RAYONIX_BINNING"])
+        self.PIXEL_SIZE = self.bin_size*39.1 / 1000  # um
+        self.RECONST_SIZE = 7680//self.bin_size
         # This hard-coded value can be overwritten
         # by RAYONIX_DISTANCE
 
@@ -81,7 +85,7 @@ class FormatHDF5SaclaRayonix(FormatHDF5, FormatStill):
                 self.RECONST_SIZE / 2 * self.PIXEL_SIZE,
                 self.RECONST_SIZE / 2 * self.PIXEL_SIZE,
             ),
-            fast_direction="-x",
+            fast_direction="+x",
             slow_direction="-y",
             pixel_size=(self.PIXEL_SIZE, self.PIXEL_SIZE),
             image_size=(self.RECONST_SIZE, self.RECONST_SIZE),

--- a/format/FormatHDF5SaclaRayonix.py
+++ b/format/FormatHDF5SaclaRayonix.py
@@ -66,7 +66,7 @@ class FormatHDF5SaclaRayonix(FormatHDF5, FormatStill):
         import h5py
 
         h5_handle = h5py.File(self.image_filename, "r")
-        self.pixelsize_in_um = h5_handle["metadata"]["pixelsize_in_um"].value
+        self.pixelsize_in_um = h5_handle["metadata"]["pixelsize_in_um"][()]
         h5_handle.close()
 
     def get_image_file(self, index=None):


### PR DESCRIPTION
During the recent round of beamtimes at SACLA, we identified that the fast axis convention for FormatHDF5SaclaRayonix is flipped (when compared with how the data is written out by the rayonix). This became obvious when looking at the kapton shadow along the beam from the source to sample direction (as can be seen in dials.image_viewer in the figure attached). The kapton 'line' should be tilted about the vertical axis by 10 degrees in the clockwise direction but is instead tilted in the anti-clockwise direction. This PR fixes it. The fast axis convention in this PR is also consistent with the FormatTIFFRayonix class when it is used on the raw image files. 
The second part of the changes relate to how the rayonix is configured. For our beamtimes, the rayonix was configured in 4x4 binning mode and based on the rayonix website, there are a variety of other binning modes supported. By supplying an environment variable RAYONIX_BINNING, one can configure it. The default is kept at 2 which is what it was prior to this PR. 
Note that the rayonix image shown has been rotated by 90 degrees because that is how the detector was set up. 

-- Asmit and Aaron 


![kapton_rayonix](https://user-images.githubusercontent.com/10836284/61491027-20e13f80-a963-11e9-92c1-26fb4bd84a32.png)

