### PR TITLE
Format.get_mask() -> get_static_mask()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,7 +73,7 @@ jobs:
       script:
          # Finally. Do what we are here for. Run tests. Yay.
          - cd $HOME/build_dials/modules/dxtbx
-         - pytest -ra -n 2 --regression
+         - pytest -ra -n 2
 
     - name: "Flake8 - Python 2.7"
       addons: false
@@ -141,7 +141,7 @@ jobs:
       script:
          # Finally. Do what we are here for. Run tests. Yay.
          - cd $HOME/build_dials/modules/dxtbx
-         - pytest -ra -n 2 --regression
+         - pytest -ra -n 2
 
 before_cache:
   - cd $HOME

--- a/format/Format.py
+++ b/format/Format.py
@@ -299,6 +299,7 @@ class Format(object):
         Factory method to create an imageset
 
         """
+        from dxtbx.format.image import ImageBool
         from dxtbx.imageset import ImageSetData
         from dxtbx.imageset import ImageSet
         from dxtbx.imageset import ImageSweep
@@ -446,6 +447,16 @@ class Format(object):
                 scan=scan,
             )
 
+        if format_instance is not None:
+            static_mask = format_instance.get_static_mask()
+            if static_mask is not None:
+                if not iset.external_lookup.mask.data.empty():
+                    for m1, m2 in zip(static_mask, iset.external_lookup.mask.data):
+                        m1 &= m2.data()
+                    iset.external_lookup.mask.data = ImageBool(static_mask)
+                else:
+                    iset.external_lookup.mask.data = ImageBool(static_mask)
+
         # Return the imageset
         return iset
 
@@ -491,10 +502,8 @@ class Format(object):
         long as the result is an scan."""
         return None
 
-    def get_mask(self, index=None, goniometer=None):
-        """Overload this method to provide dynamic masks to be used during
-        spotfinding or integration."""
-
+    def get_static_mask(self):
+        """Overload this method to override the static mask."""
         return None
 
     def get_goniometer_shadow_masker(self, goniometer=None):

--- a/format/FormatCBFFullPilatus.py
+++ b/format/FormatCBFFullPilatus.py
@@ -149,33 +149,6 @@ class FormatCBFFullPilatus(FormatCBFFull):
 
         return self._raw_data
 
-    def get_mask(self, goniometer=None):
-        from scitbx.array_family import flex
-
-        detector = self.get_detector()
-        mask = [
-            flex.bool(flex.grid(reversed(p.get_image_size())), True) for p in detector
-        ]
-        for i, p in enumerate(detector):
-            untrusted_regions = p.get_mask()
-            for j, (f0, s0, f1, s1) in enumerate(untrusted_regions):
-                sub_array = flex.bool(flex.grid(s1 - s0, f1 - f0), False)
-                mask[i].matrix_paste_block_in_place(sub_array, s0, f0)
-
-        if len(detector) == 1:
-            raw_data = [self.get_raw_data()]
-        else:
-            raw_data = self.get_raw_data()
-            assert len(raw_data) == len(detector)
-        trusted_mask = [
-            p.get_trusted_range_mask(im) for im, p in zip(raw_data, detector)
-        ]
-
-        # returns merged untrusted pixels and active areas using bitwise AND
-        # (pixels are accepted if they are inside of the active areas AND inside
-        # of the trusted range)
-        return tuple(m & tm for m, tm in zip(mask, trusted_mask))
-
     def get_vendortype(self):
         from dxtbx.format.FormatPilatusHelpers import get_vendortype as gv
 

--- a/format/FormatCBFFullPilatusDLS300KSN104.py
+++ b/format/FormatCBFFullPilatusDLS300KSN104.py
@@ -55,19 +55,6 @@ class FormatCBFFullPilatusDLS300KSN104(FormatCBFFullPilatus):
         self._dynamic_shadowing = self.has_dynamic_shadowing(**kwargs)
         FormatCBFFullPilatus.__init__(self, image_file, **kwargs)
 
-    def get_mask(self, goniometer=None):
-        mask = super(FormatCBFFullPilatusDLS300KSN104, self).get_mask()
-        if self._dynamic_shadowing:
-            gonio_masker = self.get_goniometer_shadow_masker(goniometer=goniometer)
-            scan = self.get_scan()
-            detector = self.get_detector()
-            shadow_mask = gonio_masker.get_mask(detector, scan.get_oscillation()[0])
-            assert len(mask) == len(shadow_mask)
-            for m, sm in zip(mask, shadow_mask):
-                if sm is not None:
-                    m &= ~sm
-        return mask
-
     def get_goniometer_shadow_masker(self, goniometer=None):
         if goniometer is None:
             goniometer = self.get_goniometer()

--- a/format/FormatCBFFullPilatusDLS6MSN100.py
+++ b/format/FormatCBFFullPilatusDLS6MSN100.py
@@ -51,19 +51,6 @@ class FormatCBFFullPilatusDLS6MSN100(FormatCBFFullPilatus):
         self._dynamic_shadowing = self.has_dynamic_shadowing(**kwargs)
         FormatCBFFullPilatus.__init__(self, image_file, **kwargs)
 
-    def get_mask(self, goniometer=None):
-        mask = super(FormatCBFFullPilatusDLS6MSN100, self).get_mask()
-        if self._dynamic_shadowing:
-            gonio_masker = self.get_goniometer_shadow_masker(goniometer=goniometer)
-            scan = self.get_scan()
-            detector = self.get_detector()
-            shadow_mask = gonio_masker.get_mask(detector, scan.get_oscillation()[0])
-            assert len(mask) == len(shadow_mask)
-            for m, sm in zip(mask, shadow_mask):
-                if sm is not None:
-                    m &= sm
-        return mask
-
     def get_goniometer_shadow_masker(self, goniometer=None):
         if goniometer is None:
             goniometer = self.get_goniometer()

--- a/format/FormatCBFFullPilatusDLS6MSN126.py
+++ b/format/FormatCBFFullPilatusDLS6MSN126.py
@@ -56,23 +56,6 @@ class FormatCBFFullPilatusDLS6MSN126(FormatCBFFullPilatus):
         self._dynamic_shadowing = self.has_dynamic_shadowing(**kwargs)
         FormatCBFFullPilatus.__init__(self, image_file, **kwargs)
 
-    def get_mask(self, goniometer=None):
-        mask = super(FormatCBFFullPilatusDLS6MSN126, self).get_mask()
-
-        # when device was installed with SmarGon on I03 this was the signature
-        # now it lives on i02-1 => detect - at the moment device has single
-        # axis in new home
-        if len(self.get_goniometer().get_names()) == 3 and self._dynamic_shadowing:
-            gonio_masker = self.get_goniometer_shadow_masker(goniometer=goniometer)
-            scan = self.get_scan()
-            detector = self.get_detector()
-            shadow_mask = gonio_masker.get_mask(detector, scan.get_oscillation()[0])
-            assert len(mask) == len(shadow_mask)
-            for m, sm in zip(mask, shadow_mask):
-                if sm is not None:
-                    m &= sm
-        return mask
-
     def get_goniometer_shadow_masker(self, goniometer=None):
         if goniometer is None:
             goniometer = self.get_goniometer()

--- a/format/FormatCBFMiniEiger.py
+++ b/format/FormatCBFMiniEiger.py
@@ -201,33 +201,6 @@ class FormatCBFMiniEiger(FormatCBFMini):
 
         return self._raw_data
 
-    def get_mask(self, goniometer=None):
-        from scitbx.array_family import flex
-
-        detector = self.get_detector()
-        mask = [
-            flex.bool(flex.grid(reversed(p.get_image_size())), True) for p in detector
-        ]
-        for i, p in enumerate(detector):
-            untrusted_regions = p.get_mask()
-            for j, (f0, s0, f1, s1) in enumerate(untrusted_regions):
-                sub_array = flex.bool(flex.grid(s1 - s0, f1 - f0), False)
-                mask[i].matrix_paste_block_in_place(sub_array, s0, f0)
-
-        if len(detector) == 1:
-            raw_data = [self.get_raw_data()]
-        else:
-            raw_data = self.get_raw_data()
-            assert len(raw_data) == len(detector)
-        trusted_mask = [
-            p.get_trusted_range_mask(im) for im, p in zip(raw_data, detector)
-        ]
-
-        # returns merged untrusted pixels and active areas using bitwise AND
-        # (pixels are accepted if they are inside of the active areas AND
-        # inside of the trusted range)
-        return tuple([m & tm for m, tm in zip(mask, trusted_mask)])
-
     def detectorbase_start(self):
         from iotbx.detectors.eiger_minicbf import EigerCBFImage
 

--- a/format/FormatCBFMiniEigerDLS16MSN160.py
+++ b/format/FormatCBFMiniEigerDLS16MSN160.py
@@ -90,19 +90,6 @@ class FormatCBFMiniEigerDLS16MSN160(FormatCBFMiniEiger):
             axes, angles, names, scan_axis=2
         )
 
-    def get_mask(self, goniometer=None):
-        mask = super(FormatCBFMiniEigerDLS16MSN160, self).get_mask()
-        if self._dynamic_shadowing:
-            gonio_masker = self.get_goniometer_shadow_masker(goniometer=goniometer)
-            scan = self.get_scan()
-            detector = self.get_detector()
-            shadow_mask = gonio_masker.get_mask(detector, scan.get_oscillation()[0])
-            assert len(mask) == len(shadow_mask)
-            for m, sm in zip(mask, shadow_mask):
-                if sm is not None:
-                    m &= sm
-        return mask
-
     def get_goniometer_shadow_masker(self, goniometer=None):
         if goniometer is None:
             goniometer = self.get_goniometer()

--- a/format/FormatCBFMiniPilatus.py
+++ b/format/FormatCBFMiniPilatus.py
@@ -93,32 +93,6 @@ class FormatCBFMiniPilatus(FormatCBFMini):
             self._image_file, format, exposure_time, osc_start, osc_range, timestamp
         )
 
-    def get_mask(self, goniometer=None):
-        from scitbx.array_family import flex
-
-        detector = self.get_detector()
-        mask = [
-            flex.bool(flex.grid(reversed(p.get_image_size())), True) for p in detector
-        ]
-        for i, p in enumerate(detector):
-            untrusted_regions = p.get_mask()
-            for j, (f0, s0, f1, s1) in enumerate(untrusted_regions):
-                sub_array = flex.bool(flex.grid(s1 - s0, f1 - f0), False)
-                mask[i].matrix_paste_block_in_place(sub_array, s0, f0)
-
-        if len(detector) == 1:
-            raw_data = [self.get_raw_data()]
-        else:
-            raw_data = self.get_raw_data()
-            assert len(raw_data) == len(detector)
-        trusted_mask = [
-            p.get_trusted_range_mask(im) for im, p in zip(raw_data, detector)
-        ]
-
-        # returns merged untrusted pixels and active areas using bitwise AND (pixels are accepted
-        # if they are inside of the active areas AND inside of the trusted range)
-        return tuple([m & tm for m, tm in zip(mask, trusted_mask)])
-
     def get_vendortype(self):
         from dxtbx.format.FormatPilatusHelpers import get_vendortype as gv
 

--- a/format/FormatCBFMiniPilatusDLS12M.py
+++ b/format/FormatCBFMiniPilatusDLS12M.py
@@ -211,24 +211,6 @@ class FormatCBFMiniPilatusDLS12M(FormatCBFMiniPilatus):
             goniometer = self.get_goniometer()
         return GoniometerMaskerFactory.dls_i23_kappa(goniometer)
 
-    def get_mask(self, goniometer=None):
-        from dxtbx.model import MultiAxisGoniometer
-
-        mask = super(FormatCBFMiniPilatusDLS12M, self).get_mask()
-        if (
-            isinstance(self.get_goniometer(), MultiAxisGoniometer)
-            and self._dynamic_shadowing
-        ):
-            gonio_masker = self.get_goniometer_shadow_masker(goniometer=goniometer)
-            scan = self.get_scan()
-            detector = self.get_detector()
-            shadow_mask = gonio_masker.get_mask(detector, scan.get_oscillation()[0])
-            assert len(mask) == len(shadow_mask)
-            for m, sm in zip(mask, shadow_mask):
-                if sm is not None:
-                    m &= sm
-        return mask
-
     def _goniometer(self):
         """Return a model for a simple single-axis goniometer. This should
         probably be checked against the image header."""

--- a/format/FormatCBFMiniPilatusDLS6MSN100.py
+++ b/format/FormatCBFMiniPilatusDLS6MSN100.py
@@ -357,19 +357,6 @@ class FormatCBFMiniPilatusDLS6MSN100(FormatCBFMiniPilatus):
     def get_goniometer_shadow_masker(self, goniometer=None):
         return GoniometerMaskerFactory.mini_kappa(goniometer)
 
-    def get_mask(self, goniometer=None):
-        mask = super(FormatCBFMiniPilatusDLS6MSN100, self).get_mask()
-        if self._dynamic_shadowing:
-            gonio_masker = self.get_goniometer_shadow_masker(goniometer=goniometer)
-            scan = self.get_scan()
-            detector = self.get_detector()
-            shadow_mask = gonio_masker.get_mask(detector, scan.get_oscillation()[0])
-            assert len(mask) == len(shadow_mask)
-            for m, sm in zip(mask, shadow_mask):
-                if sm is not None:
-                    m &= sm
-        return mask
-
     def _read_cbf_image(self):
         from cbflib_adaptbx import uncompress
         import binascii

--- a/format/FormatHDF5SaclaMPCCD.py
+++ b/format/FormatHDF5SaclaMPCCD.py
@@ -143,7 +143,7 @@ class FormatHDF5SaclaMPCCD(FormatHDF5, FormatStill):
             panel_origins = list(zip(posx, posy, posz))
             sensor = h5_handle["metadata/sensor_id"][0]
             thickness = 0.050
-            if sensor.startswith("MPCCD-8B"):
+            if sensor.startswith(b"MPCCD-8B"):
                 thickness = 0.300  # Phase 3 sensor
             orig_mask = numpy.logical_not(h5_handle["metadata/pixelmask"][()])
             mask = self.split_panels(orig_mask, bool=True)

--- a/format/FormatHDF5SaclaMPCCD.py
+++ b/format/FormatHDF5SaclaMPCCD.py
@@ -323,11 +323,11 @@ class FormatHDF5SaclaMPCCD(FormatHDF5, FormatStill):
                         )
                         if abs(round(self.panel_rotations[i]) + 90) < 1:
                             det[
-                                round(subpanel_origin[1]) : round(
-                                    subpanel_origin[1] + size_slow
+                                int(round(subpanel_origin[1])) : int(
+                                    round(subpanel_origin[1] + size_slow)
                                 ),
-                                round(subpanel_origin[0]) : round(
-                                    subpanel_origin[0] + size_fast
+                                int(round(subpanel_origin[0])) : int(
+                                    round(subpanel_origin[0] + size_fast)
                                 ),
                             ] = source
                             # TODO: Is the border inclusive?
@@ -341,11 +341,11 @@ class FormatHDF5SaclaMPCCD(FormatHDF5, FormatStill):
                             )
                         elif abs(round(self.panel_rotations[i]) - 90) < 1:
                             det[
-                                round(subpanel_origin[1]) : round(
-                                    subpanel_origin[1] - size_slow
+                                int(round(subpanel_origin[1])) : int(
+                                    round(subpanel_origin[1] - size_slow)
                                 ) : -1,
-                                round(subpanel_origin[0]) : round(
-                                    subpanel_origin[0] - size_fast
+                                int(round(subpanel_origin[0])) : int(
+                                    round(subpanel_origin[0] - size_fast)
                                 ) : -1,
                             ] = source
                             self.active_areas.extend(

--- a/format/FormatHDF5SaclaMPCCD.py
+++ b/format/FormatHDF5SaclaMPCCD.py
@@ -397,7 +397,7 @@ class FormatHDF5SaclaMPCCD(FormatHDF5, FormatStill):
 
         return self._detector_instance
 
-    def get_mask(self, index=None, goniometer=None):
+    def get_static_mask(self):
         # This means when the pixel mask is present, trusted region is ignored.
         # The used provided masks (if any) will be automatically merged.
         # see https://github.com/dials/dials/issues/236

--- a/format/FormatHDF5SaclaRayonix.py
+++ b/format/FormatHDF5SaclaRayonix.py
@@ -124,7 +124,7 @@ class FormatHDF5SaclaRayonix(FormatHDF5, FormatStill):
 
         return self._detector_instance
 
-    def get_mask(self, index=None, goniometer=None):
+    def get_static_mask(self):
         # This means when the pixel mask is present, trusted region is ignored.
         # The used provided masks (if any) will be automatically merged.
         # see https://github.com/dials/dials/issues/236

--- a/format/FormatMultiImage.py
+++ b/format/FormatMultiImage.py
@@ -80,9 +80,6 @@ class FormatMultiImage(Format):
     def get_raw_data(self, index=None):
         raise NotImplementedError
 
-    def get_mask(self, index=None, goniometer=None):
-        return None
-
     def get_detectorbase(self, index=None):
         raise NotImplementedError
 

--- a/format/FormatMultiImage.py
+++ b/format/FormatMultiImage.py
@@ -131,6 +131,7 @@ class FormatMultiImage(Format):
         Factory method to create an imageset
 
         """
+        from dxtbx.format.image import ImageBool
         from dxtbx.imageset import ImageSetData
         from dxtbx.imageset import ImageSweep
 
@@ -319,6 +320,16 @@ class FormatMultiImage(Format):
                 scan=scan,
                 indices=single_file_indices,
             )
+
+        if format_instance is not None:
+            static_mask = format_instance.get_static_mask()
+            if static_mask is not None:
+                if not iset.external_lookup.mask.data.empty():
+                    for m1, m2 in zip(static_mask, iset.external_lookup.mask.data):
+                        m1 &= m2.data()
+                    iset.external_lookup.mask.data = ImageBool(static_mask)
+                else:
+                    iset.external_lookup.mask.data = ImageBool(static_mask)
 
         # Return the imageset
         return iset

--- a/format/FormatNexusEigerDLS16M.py
+++ b/format/FormatNexusEigerDLS16M.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import, division, print_function
 
 import h5py
 import libtbx
-from scitbx.array_family import flex
 from dxtbx.format.FormatNexus import FormatNexus
 from dxtbx.model import MultiAxisGoniometer
 from dxtbx.masking import GoniometerMaskerFactory
@@ -55,28 +54,6 @@ class FormatNexusEigerDLS16M(FormatNexus):
 
         super(FormatNexusEigerDLS16M, self).__init__(image_file, **kwargs)
         self._dynamic_shadowing = self.has_dynamic_shadowing(**kwargs)
-
-    def get_mask(self, index, goniometer=None):
-        mask = super(FormatNexusEigerDLS16M, self).get_mask()
-        if mask is None:
-            # XXX mask really shouldn't be None
-            # https://jira.diamond.ac.uk/browse/SCI-8308
-            mask = tuple(
-                flex.bool(flex.grid(reversed(panel.get_image_size())), True)
-                for panel in self.get_detector()
-            )
-        if self._dynamic_shadowing and self.get_scan():
-            gonio_masker = self.get_goniometer_shadow_masker(goniometer=goniometer)
-            scan = self.get_scan()
-            detector = self.get_detector()
-            shadow_mask = gonio_masker.get_mask(
-                detector, scan.get_angle_from_image_index(index)
-            )
-            assert len(mask) == len(shadow_mask)
-            for m, sm in zip(mask, shadow_mask):
-                if sm is not None:
-                    m &= sm
-        return mask
 
     def get_goniometer_shadow_masker(self, goniometer=None):
         if not self._dynamic_shadowing:

--- a/format/FormatPYunspecifiedStill.py
+++ b/format/FormatPYunspecifiedStill.py
@@ -59,13 +59,10 @@ class FormatPYunspecifiedStillInMemory(FormatStill, FormatPYunspecifiedInMemory)
     def understand(image_file):
         """ If it's an image dictionary, we understand this """
         data = image_file
-
-        try:
-            if "OSC_START" not in data or "OSC_RANGE" not in data:
-                return True
-        except AttributeError:
+        if not isinstance(data, dict):
             return False
-
+        if "OSC_START" not in data or "OSC_RANGE" not in data:
+            return True
         return data["OSC_RANGE"] <= 0
 
     def __init__(self, data, **kwargs):

--- a/model/experiment_list.py
+++ b/model/experiment_list.py
@@ -268,7 +268,16 @@ class ExperimentListDict(object):
                             dy = ImageDouble()
                         else:
                             dy = ImageDouble(dy)
-                        imageset.external_lookup.mask.data = mask
+
+                        if not imageset.external_lookup.mask.data.empty():
+                            if not mask.empty():
+                                for m1, m2 in zip(
+                                    mask, imageset.external_lookup.mask.data
+                                ):
+                                    m1 &= m2.data()
+                                imageset.external_lookup.mask.data = ImageBool(mask)
+                        else:
+                            imageset.external_lookup.mask.data = mask
                         imageset.external_lookup.mask.filename = mask_filename
                         imageset.external_lookup.gain.data = gain
                         imageset.external_lookup.gain.filename = gain_filename

--- a/model/experiment_list.py
+++ b/model/experiment_list.py
@@ -271,6 +271,7 @@ class ExperimentListDict(object):
 
                         if not imageset.external_lookup.mask.data.empty():
                             if not mask.empty():
+                                mask = tuple(m.data() for m in mask)
                                 for m1, m2 in zip(
                                     mask, imageset.external_lookup.mask.data
                                 ):

--- a/newsfragments/70.feature
+++ b/newsfragments/70.feature
@@ -1,0 +1,1 @@
+Add an optional Format.get_static_mask() method to allow format classes to define a static mask to be used on all images

--- a/newsfragments/70.feature
+++ b/newsfragments/70.feature
@@ -1,1 +1,0 @@
-Add an optional Format.get_static_mask() method to allow format classes to define a static mask to be used on all images

--- a/newsfragments/73.feature
+++ b/newsfragments/73.feature
@@ -1,0 +1,4 @@
+Add an optional Format.get_static_mask() method
+
+This allows format classes to define a static mask to be used across all images
+in an imageset.

--- a/tests/format/test_FormatHDF5SaclaMPCCD.py
+++ b/tests/format/test_FormatHDF5SaclaMPCCD.py
@@ -27,3 +27,70 @@ def test_static_mask(dials_data):
         mask = imageset.get_mask(0)
         assert len(mask) == 8
         assert [m.count(False) for m in mask] == [24296] * 8
+
+
+def test_MPCCD_Phase3_21528(dials_data):
+    master_h5 = (
+        dials_data("sacla_mpccd_phase3").join("MPCCD-Phase3-21528-5images.h5").strpath
+    )
+    assert FormatHDF5SaclaMPCCD.understand(master_h5)
+    expts = ExperimentListFactory.from_filenames([master_h5])
+    imageset = expts[0].imageset
+    assert imageset.get_format_class() == FormatHDF5SaclaMPCCD
+
+    detector = imageset.get_detector()
+    beam = imageset.get_beam()
+
+    assert len(detector) == 8
+    panel = detector[0]
+    assert panel.get_pixel_size() == pytest.approx((0.05, 0.05))
+    assert panel.get_image_size() == (512, 1024)
+    assert panel.get_trusted_range() == (-1.0, 65535.0)
+    assert panel.get_fast_axis() == pytest.approx(
+        (-0.0026929852392799875, -0.9999963739086762, 0.0)
+    )
+    assert panel.get_slow_axis() == pytest.approx(
+        (-0.9999963739086762, 0.0026929852392799875, 0.0)
+    )
+    assert panel.get_thickness() == pytest.approx(0.3)
+    assert panel.get_mu() == 0
+    assert panel.get_material() == ""
+    assert panel.get_origin() == pytest.approx(
+        (-1.8203499755859376, 51.6243984375, -99.5)
+    )
+    assert panel.get_distance() == pytest.approx(99.5)
+
+    assert imageset.get_goniometer() is None
+    assert imageset.get_scan() is None
+
+    assert beam.get_wavelength() == pytest.approx(1.2452843833238922)
+    assert beam.get_direction() == (0, 0, 1)
+
+
+def test_MPCCD_RECONST_MODE(dials_data, monkeypatch):
+    for MPCCD_RECONST_MODE in (0, 1):
+        if MPCCD_RECONST_MODE:
+            monkeypatch.setenv("MPCCD_RECONST_MODE", str(MPCCD_RECONST_MODE))
+        else:
+            monkeypatch.delenv("MPCCD_RECONST_MODE", raising=False)
+
+        master_h5 = (
+            dials_data("sacla_mpccd_phase3")
+            .join("MPCCD-Phase3-21528-5images.h5")
+            .strpath
+        )
+        expts = ExperimentListFactory.from_filenames([master_h5])
+        imageset = expts[0].imageset
+        # Horrible hack to work around format_instance caching
+        imageset.reader().nullify_format_instance()
+        raw_data = imageset.get_raw_data(0)
+        mmm = raw_data[0].as_double().as_1d().min_max_mean()
+        mmm.show()
+        if MPCCD_RECONST_MODE:
+            assert mmm.min == -1
+            assert mmm.max == 14102
+            assert mmm.mean == pytest.approx(2.93752665030144)
+        else:
+            assert mmm.min == 0
+            assert mmm.max == 3610.0
+            assert mmm.mean == pytest.approx(3.397266387939453)

--- a/tests/format/test_FormatHDF5SaclaMPCCD.py
+++ b/tests/format/test_FormatHDF5SaclaMPCCD.py
@@ -8,11 +8,6 @@ from dxtbx.model.experiment_list import ExperimentListFactory
 pytest.importorskip("h5py")
 
 
-@pytest.mark.xfail(
-    raises=AssertionError,
-    reason="static mask isn't set correctly when reading experiment list from dictionary",
-)
-# https://github.com/cctbx/dxtbx/issues/70#issuecomment-520060797
 def test_static_mask(dials_data):
     master_h5 = (
         dials_data("sacla_mpccd_phase3").join("MPCCD-Phase3-21528-5images.h5").strpath

--- a/tests/format/test_FormatHDF5SaclaMPCCD.py
+++ b/tests/format/test_FormatHDF5SaclaMPCCD.py
@@ -12,7 +12,7 @@ pytest.importorskip("h5py")
     reason="static mask isn't set correctly when reading experiment list from dictionary"
 )
 # https://github.com/cctbx/dxtbx/issues/70#issuecomment-520060797
-def test_static_mask(dials_data, tmpdir):
+def test_static_mask(dials_data):
     master_h5 = (
         dials_data("sacla_mpccd_phase3").join("MPCCD-Phase3-21528-5images.h5").strpath
     )

--- a/tests/format/test_FormatHDF5SaclaMPCCD.py
+++ b/tests/format/test_FormatHDF5SaclaMPCCD.py
@@ -1,0 +1,29 @@
+from __future__ import absolute_import, division, print_function
+
+import pytest
+
+from dxtbx.format.FormatHDF5SaclaMPCCD import FormatHDF5SaclaMPCCD
+from dxtbx.model.experiment_list import ExperimentListFactory
+
+pytest.importorskip("h5py")
+
+
+@pytest.mark.xfail(
+    reason="static mask isn't set correctly when reading experiment list from dictionary"
+)
+# https://github.com/cctbx/dxtbx/issues/70#issuecomment-520060797
+def test_static_mask(dials_data, tmpdir):
+    master_h5 = (
+        dials_data("sacla_mpccd_phase3").join("MPCCD-Phase3-21528-5images.h5").strpath
+    )
+    assert FormatHDF5SaclaMPCCD.understand(master_h5)
+
+    expts_from_filename = ExperimentListFactory.from_filenames([master_h5])
+    expts_from_dict = ExperimentListFactory.from_dict(expts_from_filename.to_dict())
+    for expts in (expts_from_filename, expts_from_dict):
+        assert len(expts) == 5
+        imageset = expts[0].imageset
+        assert imageset.get_format_class() == FormatHDF5SaclaMPCCD
+        mask = imageset.get_mask(0)
+        assert len(mask) == 8
+        assert [m.count(False) for m in mask] == [24296] * 8

--- a/tests/format/test_FormatHDF5SaclaMPCCD.py
+++ b/tests/format/test_FormatHDF5SaclaMPCCD.py
@@ -9,7 +9,8 @@ pytest.importorskip("h5py")
 
 
 @pytest.mark.xfail(
-    reason="static mask isn't set correctly when reading experiment list from dictionary"
+    raises=AssertionError,
+    reason="static mask isn't set correctly when reading experiment list from dictionary",
 )
 # https://github.com/cctbx/dxtbx/issues/70#issuecomment-520060797
 def test_static_mask(dials_data):
@@ -94,3 +95,7 @@ def test_MPCCD_RECONST_MODE(dials_data, monkeypatch):
             assert mmm.min == 0
             assert mmm.max == 3610.0
             assert mmm.mean == pytest.approx(3.397266387939453)
+    # Horrible hack to work around format_instance caching
+    # This is needed to prevent an incorrect format_instance affecting
+    # other tests that are run after this one.
+    imageset.reader().nullify_format_instance()

--- a/tests/format/test_FormatHDF5SaclaMPCCD.py
+++ b/tests/format/test_FormatHDF5SaclaMPCCD.py
@@ -117,7 +117,7 @@ def test_combine_with_user_static_mask(dials_data, tmpdir):
             mask.append(m)
         mask = tuple(mask)
         # exact number of masked pixels varies with wavelength between experiments
-        assert [m.count(False) for m in mask] == pytest.approx(
+        assert [_.count(False) for _ in mask] == pytest.approx(
             [50643, 0, 0, 48003, 48356, 0, 0, 52191], abs=1e3
         )
         mask_file = tmpdir.join("pixel_%i.mask" % i)
@@ -130,7 +130,7 @@ def test_combine_with_user_static_mask(dials_data, tmpdir):
     imageset = expts_from_dict[0].imageset
     mask = imageset.get_mask(0)
     assert len(mask) == 8
-    assert [m.count(False) for m in mask] == [
+    assert [_.count(False) for _ in mask] == [
         65333,
         24296,
         24296,

--- a/tests/format/test_FormatPYunspecified.py
+++ b/tests/format/test_FormatPYunspecified.py
@@ -2,8 +2,12 @@ from __future__ import absolute_import, division, print_function
 
 import os
 import pytest
+import six.moves.cPickle as pickle
 
-from dxtbx.format.FormatPYunspecifiedStill import FormatPYunspecifiedStill
+from dxtbx.format.FormatPYunspecifiedStill import (
+    FormatPYunspecifiedStill,
+    FormatPYunspecifiedStillInMemory,
+)
 from dxtbx.model.experiment_list import ExperimentListFactory
 
 
@@ -27,3 +31,16 @@ def test_static_mask(dials_regression):
         mask = imageset.get_mask(0)
         assert len(mask) == 1
         assert mask[0].count(False) == 867109
+
+
+@pytest.mark.xfail
+def test_FormatPYunspecifiedStillInMemory(dials_regression):
+    filename = os.path.join(
+        dials_regression,
+        "image_examples/LCLS_CXI/shot-s00-2011-12-02T21_07Z29.723_00569.pickle",
+    )
+    assert not FormatPYunspecifiedStillInMemory.understand(filename)
+    with open(filename, "rb") as f:
+        d = pickle.load(f)
+    assert FormatPYunspecifiedStillInMemory.understand(d)
+    mem_imageset = FormatPYunspecifiedStillInMemory.get_imageset(d)  # noqa F841

--- a/tests/format/test_FormatPYunspecified.py
+++ b/tests/format/test_FormatPYunspecified.py
@@ -8,6 +8,7 @@ from dxtbx.format.FormatPYunspecifiedStill import (
     FormatPYunspecifiedStill,
     FormatPYunspecifiedStillInMemory,
 )
+from dxtbx.imageset import ImageSet, ImageSetData, MemReader
 from dxtbx.model.experiment_list import ExperimentListFactory
 
 
@@ -43,4 +44,8 @@ def test_FormatPYunspecifiedStillInMemory(dials_regression):
     with open(filename, "rb") as f:
         d = pickle.load(f)
     assert FormatPYunspecifiedStillInMemory.understand(d)
-    mem_imageset = FormatPYunspecifiedStillInMemory.get_imageset(d)  # noqa F841
+    img = FormatPYunspecifiedStillInMemory(d)
+    imageset = ImageSet(ImageSetData(MemReader([img]), None))
+    mask = imageset.get_mask(0)
+    assert len(mask) == 1
+    assert mask[0].count(False) == 867109

--- a/tests/format/test_FormatPYunspecified.py
+++ b/tests/format/test_FormatPYunspecified.py
@@ -1,0 +1,29 @@
+from __future__ import absolute_import, division, print_function
+
+import os
+import pytest
+
+from dxtbx.format.FormatPYunspecifiedStill import FormatPYunspecifiedStill
+from dxtbx.model.experiment_list import ExperimentListFactory
+
+
+@pytest.mark.xfail(
+    reason="static mask isn't set correctly when reading experiment list from dictionary"
+)
+# https://github.com/cctbx/dxtbx/issues/70#issuecomment-520060797
+def test_static_mask(dials_regression, tmpdir):
+    filename = os.path.join(
+        dials_regression,
+        "image_examples/LCLS_CXI/shot-s00-2011-12-02T21_07Z29.723_00569.pickle",
+    )
+    assert FormatPYunspecifiedStill.understand(filename)
+
+    expts_from_filename = ExperimentListFactory.from_filenames([filename])
+    expts_from_dict = ExperimentListFactory.from_dict(expts_from_filename.to_dict())
+    for expts in (expts_from_filename, expts_from_dict):
+        assert len(expts) == 1
+        imageset = expts[0].imageset
+        assert imageset.get_format_class() == FormatPYunspecifiedStill
+        mask = imageset.get_mask(0)
+        assert len(mask) == 1
+        assert mask[0].count(False) == 867109

--- a/tests/format/test_FormatPYunspecified.py
+++ b/tests/format/test_FormatPYunspecified.py
@@ -12,10 +12,6 @@ from dxtbx.imageset import ImageSet, ImageSetData, MemReader
 from dxtbx.model.experiment_list import ExperimentListFactory
 
 
-@pytest.mark.xfail(
-    reason="static mask isn't set correctly when reading experiment list from dictionary"
-)
-# https://github.com/cctbx/dxtbx/issues/70#issuecomment-520060797
 def test_static_mask(dials_regression):
     filename = os.path.join(
         dials_regression,

--- a/tests/format/test_FormatPYunspecified.py
+++ b/tests/format/test_FormatPYunspecified.py
@@ -11,7 +11,7 @@ from dxtbx.model.experiment_list import ExperimentListFactory
     reason="static mask isn't set correctly when reading experiment list from dictionary"
 )
 # https://github.com/cctbx/dxtbx/issues/70#issuecomment-520060797
-def test_static_mask(dials_regression, tmpdir):
+def test_static_mask(dials_regression):
     filename = os.path.join(
         dials_regression,
         "image_examples/LCLS_CXI/shot-s00-2011-12-02T21_07Z29.723_00569.pickle",


### PR DESCRIPTION
This pull requests resolves #70 (see also #65).

- Add an optional Format.get_static_mask() method to allow format classes to define a static mask to be used on all images.
- Add tests for static masks in FormatHDF5SaclaMPCCD and FormatPYunspecifiedStill.
- Remove superfluous Format.get_mask() functions - these are no longer called and the functionality they used to provide are provided elsewhere.