### PR TITLE
New visitor implementation

### DIFF
--- a/format/nexus.py
+++ b/format/nexus.py
@@ -151,10 +151,15 @@ class check_attr(object):
 
 
 def local_visit(nxfile, visitor):
-    """
-    Implementation of visitor pattern which will dereference soft links but
-    should avoid walking down into external files, I think - not a property
-    that NXgroup.visititems(visitor) has. https://github.com/cctbx/dxtbx/issues/74
+    """Implementation of visitor to replace node.visititems
+
+    Will dereference soft links but should avoid walking down into external files, 
+    I think - not a property that NXgroup.visititems(visitor) has. 
+    https://github.com/cctbx/dxtbx/issues/74
+
+    Args:
+      nxfile: hdf5 file node
+      visitor: visitor function to act on node and children
     """
     visitor(nxfile.name, nxfile)
     for k in nxfile:

--- a/newsfragments/75.bugfix
+++ b/newsfragments/75.bugfix
@@ -1,0 +1,1 @@
+Replace h5py `visititems` with `local_visit` implementation to work around using soft links in Eiger / hdf5 files.


### PR DESCRIPTION
To fix https://github.com/cctbx/dxtbx/issues/74 - `NXgroup.visititems()`
does not follow soft links but probably it should, certainly this is a known
issue on the h5py lists. Added new implementation `local_visit` which behaves
as expected. Also found that `saturation_value` missing so worked around. Following up with SLS on that one. 