### PR TITLE
Remove unnecessary format subclass methods

### DIFF
--- a/format/FormatBruker.py
+++ b/format/FormatBruker.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 from builtins import range
 from dxtbx.format.Format import Format
+from dxtbx import IncorrectFormatError
 
 
 class FormatBruker(Format):
@@ -92,12 +93,9 @@ class FormatBruker(Format):
     def __init__(self, image_file, **kwargs):
         """Initialise the image structure from the given file."""
 
-        from dxtbx import IncorrectFormatError
-
         if not self.understand(image_file):
             raise IncorrectFormatError(self, image_file)
-
-        Format.__init__(self, image_file, **kwargs)
+        super(FormatBruker, self).__init__(str(image_file), **kwargs)
 
     def detectorbase_start(self):
         pass

--- a/format/FormatBrukerFixedChi.py
+++ b/format/FormatBrukerFixedChi.py
@@ -26,18 +26,6 @@ class FormatBrukerFixedChi(FormatBruker):
 
         return True
 
-    def __init__(self, image_file, **kwargs):
-        """Initialise the image structure from the given file, including a
-        proper model of the experiment. Easy from Rigaku Saturn images as
-        they contain everything pretty much we need..."""
-        from dxtbx import IncorrectFormatError
-
-        if not self.understand(image_file):
-            raise IncorrectFormatError(self, image_file)
-
-        self._image_file = image_file
-        FormatBruker.__init__(self, image_file, **kwargs)
-
     def _start(self):
         self.header_dict = {}
         header_text = open(self._image_file).read().split("......")[0]

--- a/format/FormatBrukerPhotonII.py
+++ b/format/FormatBrukerPhotonII.py
@@ -46,17 +46,6 @@ class FormatBrukerPhotonII(FormatBruker):
 
         return True
 
-    def __init__(self, image_file, **kwargs):
-        """Initialise the image structure from the given file, including a
-        proper model of the experiment. Easy from Rigaku Saturn images as
-        they contain everything pretty much we need..."""
-
-        if not self.understand(image_file):
-            raise IncorrectFormatError(self, image_file)
-
-        self._image_file = image_file
-        FormatBruker.__init__(self, image_file, **kwargs)
-
     def _start(self):
 
         try:

--- a/format/FormatCBF.py
+++ b/format/FormatCBF.py
@@ -12,6 +12,7 @@ from __future__ import absolute_import, division, print_function
 
 import six
 from dxtbx.format.Format import Format
+from dxtbx import IncorrectFormatError
 
 
 class FormatCBF(Format):
@@ -58,12 +59,10 @@ class FormatCBF(Format):
     def __init__(self, image_file, **kwargs):
         """Initialise the image structure from the given file."""
 
-        from dxtbx import IncorrectFormatError
-
         if not self.understand(image_file):
             raise IncorrectFormatError(self, image_file)
 
-        Format.__init__(self, image_file, **kwargs)
+        super(FormatCBF, self).__init__(str(image_file), **kwargs)
 
     @staticmethod
     def _parse_cbf_header(cbf_header):

--- a/format/FormatCBF.py
+++ b/format/FormatCBF.py
@@ -96,8 +96,6 @@ class FormatCBF(Format):
         """Open the image file, read the image header, copy it into memory
         for future inspection."""
 
-        Format._start(self)
-
         self._cif_header = FormatCBF.get_cbf_header(self._image_file)
 
         self._mime_header = ""

--- a/format/FormatCBFFull.py
+++ b/format/FormatCBFFull.py
@@ -42,12 +42,6 @@ class FormatCBFFull(FormatCBF):
     def __del__(self):
         self._cbf_handle.__swig_destroy__(self._cbf_handle)
 
-    def _start(self):
-        """Open the image file as a cbf file handle, and keep this somewhere
-        safe."""
-
-        FormatCBF._start(self)
-
     def _get_cbf_handle(self):
         try:
             return self._cbf_handle

--- a/format/FormatCBFFull.py
+++ b/format/FormatCBFFull.py
@@ -36,14 +36,8 @@ class FormatCBFFull(FormatCBF):
         """Initialise the image structure from the given file."""
 
         # It appears Pycbf can not handle unicode filenames (see dials/dials#256)
-        image_file = str(image_file)
-        from dxtbx import IncorrectFormatError
-
-        if not self.understand(image_file):
-            raise IncorrectFormatError(self, image_file)
-
-        FormatCBF.__init__(self, image_file, **kwargs)
         self._raw_data = None
+        super(FormatCBFFull, self).__init__(str(image_file), **kwargs)
 
     def __del__(self):
         self._cbf_handle.__swig_destroy__(self._cbf_handle)

--- a/format/FormatCBFFullPilatus.py
+++ b/format/FormatCBFFullPilatus.py
@@ -32,18 +32,6 @@ class FormatCBFFullPilatus(FormatCBFFull):
 
         return False
 
-    def __init__(self, image_file, **kwargs):
-        """Initialise the image structure from the given file."""
-
-        from dxtbx import IncorrectFormatError
-
-        if not self.understand(image_file):
-            raise IncorrectFormatError(self, image_file)
-
-        FormatCBFFull.__init__(self, image_file, **kwargs)
-
-        self._raw_data = None
-
     def _start(self):
         """Open the image file as a cbf file handle, and keep this somewhere
         safe."""

--- a/format/FormatCBFFullPilatus.py
+++ b/format/FormatCBFFullPilatus.py
@@ -32,12 +32,6 @@ class FormatCBFFullPilatus(FormatCBFFull):
 
         return False
 
-    def _start(self):
-        """Open the image file as a cbf file handle, and keep this somewhere
-        safe."""
-
-        FormatCBFFull._start(self)
-
     def _beam(self):
         """Return a working beam instance. Override polarization to be 0.999."""
 

--- a/format/FormatCBFFullPilatusDLS300KSN104.py
+++ b/format/FormatCBFFullPilatusDLS300KSN104.py
@@ -49,11 +49,8 @@ class FormatCBFFullPilatusDLS300KSN104(FormatCBFFullPilatus):
 
     def __init__(self, image_file, **kwargs):
         """Initialise the image structure from the given file."""
-
-        assert self.understand(image_file)
-
         self._dynamic_shadowing = self.has_dynamic_shadowing(**kwargs)
-        FormatCBFFullPilatus.__init__(self, image_file, **kwargs)
+        super(FormatCBFFullPilatusDLS300KSN104, self).__init__(image_file, **kwargs)
 
     def get_mask(self, goniometer=None):
         mask = super(FormatCBFFullPilatusDLS300KSN104, self).get_mask()

--- a/format/FormatCBFFullPilatusDLS6MSN100.py
+++ b/format/FormatCBFFullPilatusDLS6MSN100.py
@@ -43,13 +43,9 @@ class FormatCBFFullPilatusDLS6MSN100(FormatCBFFullPilatus):
 
     def __init__(self, image_file, **kwargs):
         """Initialise the image structure from the given file."""
-        from dxtbx import IncorrectFormatError
-
-        if not self.understand(image_file):
-            raise IncorrectFormatError(self, image_file)
 
         self._dynamic_shadowing = self.has_dynamic_shadowing(**kwargs)
-        FormatCBFFullPilatus.__init__(self, image_file, **kwargs)
+        super(FormatCBFFullPilatusDLS6MSN100, self).__init__(image_file, **kwargs)
 
     def get_mask(self, goniometer=None):
         mask = super(FormatCBFFullPilatusDLS6MSN100, self).get_mask()

--- a/format/FormatCBFFullPilatusDLS6MSN126.py
+++ b/format/FormatCBFFullPilatusDLS6MSN126.py
@@ -48,13 +48,9 @@ class FormatCBFFullPilatusDLS6MSN126(FormatCBFFullPilatus):
 
     def __init__(self, image_file, **kwargs):
         """Initialise the image structure from the given file."""
-        from dxtbx import IncorrectFormatError
-
-        if not self.understand(image_file):
-            raise IncorrectFormatError(self, image_file)
 
         self._dynamic_shadowing = self.has_dynamic_shadowing(**kwargs)
-        FormatCBFFullPilatus.__init__(self, image_file, **kwargs)
+        super(FormatCBFFullPilatusDLS6MSN126, self).__init__(image_file, **kwargs)
 
     def get_mask(self, goniometer=None):
         mask = super(FormatCBFFullPilatusDLS6MSN126, self).get_mask()

--- a/format/FormatCBFMini.py
+++ b/format/FormatCBFMini.py
@@ -62,14 +62,8 @@ class FormatCBFMini(FormatCBF):
     def __init__(self, image_file, **kwargs):
         """Initialise the image structure from the given file."""
 
-        from dxtbx import IncorrectFormatError
-
-        if not self.understand(image_file):
-            raise IncorrectFormatError(self, image_file)
-
-        FormatCBF.__init__(self, image_file, **kwargs)
-
         self._raw_data = None
+        super(FormatCBFMini, self).__init__(image_file, **kwargs)
 
     def _start(self):
         """Open the image file, read the image header, copy it into a

--- a/format/FormatCBFMini.py
+++ b/format/FormatCBFMini.py
@@ -69,8 +69,7 @@ class FormatCBFMini(FormatCBF):
         """Open the image file, read the image header, copy it into a
         dictionary for future reference."""
 
-        FormatCBF._start(self)
-
+        super(FormatCBFMini, self)._start()
         cif_header = FormatCBF.get_cbf_header(self._image_file)
 
         self._cif_header_dictionary = {}

--- a/format/FormatCBFMiniADSCHF4M.py
+++ b/format/FormatCBFMiniADSCHF4M.py
@@ -51,19 +51,6 @@ class FormatCBFMiniADSCHF4M(FormatCBFMini):
 
         return False
 
-    def __init__(self, image_file, **kwargs):
-        """Initialise the image structure from the given file, including a
-        proper model of the experiment."""
-
-        from dxtbx import IncorrectFormatError
-
-        if not self.understand(image_file):
-            raise IncorrectFormatError(self, image_file)
-
-        FormatCBFMini.__init__(self, image_file, **kwargs)
-
-        self._raw_data = None
-
     def _start(self):
         FormatCBFMini._start(self)
 

--- a/format/FormatCBFMiniADSCHF4M.py
+++ b/format/FormatCBFMiniADSCHF4M.py
@@ -51,9 +51,6 @@ class FormatCBFMiniADSCHF4M(FormatCBFMini):
 
         return False
 
-    def _start(self):
-        FormatCBFMini._start(self)
-
     def _detector(self):
         """Return a model for a simple detector, presuming no one has
         one of these on a two-theta stage. Assert that the beam centre is

--- a/format/FormatCBFMiniEiger.py
+++ b/format/FormatCBFMiniEiger.py
@@ -40,19 +40,6 @@ class FormatCBFMiniEiger(FormatCBFMini):
 
         return False
 
-    def __init__(self, image_file, **kwargs):
-        """Initialise the image structure from the given file, including a
-        proper model of the experiment."""
-
-        from dxtbx import IncorrectFormatError
-
-        if not self.understand(image_file):
-            raise IncorrectFormatError(self, image_file)
-
-        FormatCBFMini.__init__(self, image_file, **kwargs)
-
-        self._raw_data = None
-
     def _start(self):
         FormatCBFMini._start(self)
 

--- a/format/FormatCBFMiniEiger.py
+++ b/format/FormatCBFMiniEiger.py
@@ -40,9 +40,6 @@ class FormatCBFMiniEiger(FormatCBFMini):
 
         return False
 
-    def _start(self):
-        FormatCBFMini._start(self)
-
     def _detector(self):
         distance = float(self._cif_header_dictionary["Detector_distance"].split()[0])
 

--- a/format/FormatCBFMiniEigerDLS16MSN160.py
+++ b/format/FormatCBFMiniEigerDLS16MSN160.py
@@ -45,10 +45,6 @@ class FormatCBFMiniEigerDLS16MSN160(FormatCBFMiniEiger):
 
     def __init__(self, image_file, **kwargs):
         """Initialise the image structure from the given file."""
-        from dxtbx import IncorrectFormatError
-
-        if not self.understand(image_file):
-            raise IncorrectFormatError(self, image_file)
 
         self._dynamic_shadowing = self.has_dynamic_shadowing(**kwargs)
         super(FormatCBFMiniEigerDLS16MSN160, self).__init__(image_file, **kwargs)

--- a/format/FormatCBFMiniEigerPetraP14.py
+++ b/format/FormatCBFMiniEigerPetraP14.py
@@ -33,19 +33,6 @@ class FormatCBFMiniEigerPetraP14(FormatCBFMiniEiger):
 
         return False
 
-    def __init__(self, image_file, **kwargs):
-        """Initialise the image structure from the given file, including a
-        proper model of the experiment."""
-
-        from dxtbx import IncorrectFormatError
-
-        if not self.understand(image_file):
-            raise IncorrectFormatError(self, image_file)
-
-        FormatCBFMiniEiger.__init__(self, image_file, **kwargs)
-
-        self._raw_data = None
-
     def _goniometer(self):
         return self._goniometer_factory.known_axis((0, 1, 0))
 

--- a/format/FormatCBFMiniEigerPhotonFactory.py
+++ b/format/FormatCBFMiniEigerPhotonFactory.py
@@ -37,19 +37,6 @@ class FormatCBFMiniEigerPhotonFactory(FormatCBFMini):
             return True
         return False
 
-    def __init__(self, image_file, **kwargs):
-        """Initialise the image structure from the given file, including a
-        proper model of the experiment."""
-
-        from dxtbx import IncorrectFormatError
-
-        if not self.understand(image_file):
-            raise IncorrectFormatError(self, image_file)
-
-        FormatCBFMini.__init__(self, image_file, **kwargs)
-
-        return
-
     def _start(self):
         FormatCBFMini._start(self)
 

--- a/format/FormatCBFMiniEigerPhotonFactory.py
+++ b/format/FormatCBFMiniEigerPhotonFactory.py
@@ -37,9 +37,6 @@ class FormatCBFMiniEigerPhotonFactory(FormatCBFMini):
             return True
         return False
 
-    def _start(self):
-        FormatCBFMini._start(self)
-
     def _goniometer(self):
         return self._goniometer_factory.make_goniometer(
             (1, 0, 0), (1, 0, 0, 0, 1, 0, 0, 0, 1)

--- a/format/FormatCBFMiniPilatus.py
+++ b/format/FormatCBFMiniPilatus.py
@@ -50,9 +50,6 @@ class FormatCBFMiniPilatus(FormatCBFMini):
 
         return False
 
-    def _start(self):
-        FormatCBFMini._start(self)
-
     def _detector(self):
         """Return a model for a simple detector, presuming no one has
         one of these on a two-theta stage. Assert that the beam centre is

--- a/format/FormatCBFMiniPilatus.py
+++ b/format/FormatCBFMiniPilatus.py
@@ -50,19 +50,6 @@ class FormatCBFMiniPilatus(FormatCBFMini):
 
         return False
 
-    def __init__(self, image_file, **kwargs):
-        """Initialise the image structure from the given file, including a
-        proper model of the experiment."""
-
-        from dxtbx import IncorrectFormatError
-
-        if not self.understand(image_file):
-            raise IncorrectFormatError(self, image_file)
-
-        FormatCBFMini.__init__(self, image_file, **kwargs)
-
-        return
-
     def _start(self):
         FormatCBFMini._start(self)
 

--- a/format/FormatCBFMiniPilatus3APS19ID6MSN132.py
+++ b/format/FormatCBFMiniPilatus3APS19ID6MSN132.py
@@ -31,19 +31,6 @@ class FormatCBFMiniPilatus3AOS19ID6MSN132(FormatCBFMiniPilatus):
 
         return False
 
-    def __init__(self, image_file, **kwargs):
-        """Initialise the image structure from the given file, including a
-        proper model of the experiment."""
-
-        from dxtbx import IncorrectFormatError
-
-        if not self.understand(image_file):
-            raise IncorrectFormatError(self, image_file)
-
-        FormatCBFMiniPilatus.__init__(self, image_file, **kwargs)
-
-        return
-
     def _goniometer(self):
         """19ID has reversed goniometer"""
 

--- a/format/FormatCBFMiniPilatusCHESS_6MSN127.py
+++ b/format/FormatCBFMiniPilatusCHESS_6MSN127.py
@@ -31,19 +31,6 @@ class FormatCBFMiniPilatusCHESS_6MSN127(FormatCBFMiniPilatus):
 
         return False
 
-    def __init__(self, image_file, **kwargs):
-        """Initialise the image structure from the given file, including a
-        proper model of the experiment."""
-
-        from dxtbx import IncorrectFormatError
-
-        if not self.understand(image_file):
-            raise IncorrectFormatError(self, image_file)
-
-        FormatCBFMiniPilatus.__init__(self, image_file, **kwargs)
-
-        return
-
     def _goniometer(self):
         """Return a model for a simple single-axis reversed direction goniometer."""
 

--- a/format/FormatCBFMiniPilatusDLS12M.py
+++ b/format/FormatCBFMiniPilatusDLS12M.py
@@ -49,20 +49,13 @@ class FormatCBFMiniPilatusDLS12M(FormatCBFMiniPilatus):
         """Initialise the image structure from the given file, including a
         proper model of the experiment."""
 
-        from dxtbx import IncorrectFormatError
-
-        if not self.understand(image_file):
-            raise IncorrectFormatError(self, image_file)
-
         # if multi_panel == False, then interpret data as 24 panels, where each
         # row of 5 panels is grouped as one "panel"
         # elif multi_panel == True, then interpret data as 120 panels,
         # 24 rows * 5 columns
         self._dynamic_shadowing = self.has_dynamic_shadowing(**kwargs)
         self._multi_panel = kwargs.get("multi_panel", False)
-        FormatCBFMiniPilatus.__init__(self, image_file, **kwargs)
-
-        self._raw_data = None
+        super(FormatCBFMiniPilatusDLS12M, self).__init__(image_file, **kwargs)
 
     def _detector(self):
 

--- a/format/FormatCBFMiniPilatusDLS6MSN100.py
+++ b/format/FormatCBFMiniPilatusDLS6MSN100.py
@@ -181,16 +181,9 @@ class FormatCBFMiniPilatusDLS6MSN100(FormatCBFMiniPilatus):
         """Initialise the image structure from the given file, including a
         proper model of the experiment."""
 
-        from dxtbx import IncorrectFormatError
-
-        if not self.understand(image_file):
-            raise IncorrectFormatError(self, image_file)
-
         self._dynamic_shadowing = self.has_dynamic_shadowing(**kwargs)
         self._multi_panel = kwargs.get("multi_panel", False)
-        FormatCBFMiniPilatus.__init__(self, image_file, **kwargs)
-
-        self._raw_data = None
+        super(FormatCBFMiniPilatusDLS6MSN100, self).__init__(image_file, **kwargs)
 
     def _goniometer(self):
         """Return a model for a simple single-axis goniometer. This should

--- a/format/FormatCBFMiniPilatusDLS6MSN114.py
+++ b/format/FormatCBFMiniPilatusDLS6MSN114.py
@@ -46,19 +46,6 @@ class FormatCBFMiniPilatusDLS6MSN114(FormatCBFMiniPilatus):
 
         return False
 
-    def __init__(self, image_file, **kwargs):
-        """Initialise the image structure from the given file, including a
-        proper model of the experiment."""
-
-        from dxtbx import IncorrectFormatError
-
-        if not self.understand(image_file):
-            raise IncorrectFormatError(self, image_file)
-
-        FormatCBFMiniPilatus.__init__(self, image_file, **kwargs)
-
-        self._raw_data = None
-
     def _goniometer(self):
         return self._goniometer_factory.known_axis((0, 1, 0))
 

--- a/format/FormatCBFMiniPilatusDLS6MSN114DMM.py
+++ b/format/FormatCBFMiniPilatusDLS6MSN114DMM.py
@@ -41,11 +41,6 @@ class FormatCBFMiniPilatusDLS6MSN114DMM(FormatCBFMiniPilatus, FormatStill):
         """Initialise the image structure from the given file, including a
         proper model of the experiment."""
 
-        from dxtbx import IncorrectFormatError
-
-        if not self.understand(image_file):
-            raise IncorrectFormatError(self, image_file)
-
         FormatCBFMiniPilatus.__init__(self, image_file, **kwargs)
         FormatStill.__init__(self, image_file, **kwargs)
 

--- a/format/FormatCBFMiniPilatusDLS6MSN119.py
+++ b/format/FormatCBFMiniPilatusDLS6MSN119.py
@@ -46,19 +46,6 @@ class FormatCBFMiniPilatusDLS6MSN119(FormatCBFMiniPilatus):
 
         return False
 
-    def __init__(self, image_file, **kwargs):
-        """Initialise the image structure from the given file, including a
-        proper model of the experiment."""
-
-        from dxtbx import IncorrectFormatError
-
-        if not self.understand(image_file):
-            raise IncorrectFormatError(self, image_file)
-
-        FormatCBFMiniPilatus.__init__(self, image_file, **kwargs)
-
-        self._raw_data = None
-
     def _goniometer(self):
         """Return a model for a simple single-axis goniometer. This should
         probably be checked against the image header, though for miniCBF

--- a/format/FormatCBFMiniPilatusDLS6MSN126.py
+++ b/format/FormatCBFMiniPilatusDLS6MSN126.py
@@ -169,14 +169,8 @@ class FormatCBFMiniPilatusDLS6MSN126(FormatCBFMiniPilatus):
         """Initialise the image structure from the given file, including a
         proper model of the experiment."""
 
-        from dxtbx import IncorrectFormatError
-
-        if not self.understand(image_file):
-            raise IncorrectFormatError(self, image_file)
-
-        self._raw_data = None
         self._multi_panel = kwargs.get("multi_panel", False)
-        FormatCBFMiniPilatus.__init__(self, image_file, **kwargs)
+        super(FormatCBFMiniPilatusDLS6MSN126, self).__init__(image_file, **kwargs)
 
     def _goniometer(self):
         """Return a model for a simple single-axis goniometer. This should

--- a/format/FormatCBFMiniPilatusSOLEILPX16MSN106.py
+++ b/format/FormatCBFMiniPilatusSOLEILPX16MSN106.py
@@ -36,19 +36,6 @@ class FormatCBFMiniPilatusSOLEILPX16MSN106(FormatCBFMiniPilatus):
 
         return False
 
-    def __init__(self, image_file, **kwargs):
-        """Initialise the image structure from the given file, including a
-        proper model of the experiment."""
-
-        from dxtbx import IncorrectFormatError
-
-        if not self.understand(image_file):
-            raise IncorrectFormatError(self, image_file)
-
-        FormatCBFMiniPilatus.__init__(self, image_file, **kwargs)
-
-        self._raw_data = None
-
     def _goniometer(self):
         """Construct a goniometer from the records in the mini CBF header."""
 

--- a/format/FormatCBFMiniPilatusSPring8_6MSN125.py
+++ b/format/FormatCBFMiniPilatusSPring8_6MSN125.py
@@ -38,19 +38,6 @@ class FormatCBFMiniPilatusSPring8_6MSN125(FormatCBFMiniPilatus):
 
         return False
 
-    def __init__(self, image_file, **kwargs):
-        """Initialise the image structure from the given file, including a
-        proper model of the experiment."""
-
-        from dxtbx import IncorrectFormatError
-
-        if not self.understand(image_file):
-            raise IncorrectFormatError(self, image_file)
-
-        FormatCBFMiniPilatus.__init__(self, image_file, **kwargs)
-
-        return
-
     def _goniometer(self):
         """Return a model for a simple single-axis reversed direction goniometer."""
 

--- a/format/FormatCBFMiniPilatusXXX.py
+++ b/format/FormatCBFMiniPilatusXXX.py
@@ -31,17 +31,6 @@ class FormatCBFMiniPilatusXXX(FormatCBFMiniPilatus):
 
         return False
 
-    def __init__(self, image_file, **kwargs):
-        """Initialise the image structure from the given file, including a
-        proper model of the experiment."""
-
-        from dxtbx import IncorrectFormatError
-
-        if not self.understand(image_file):
-            raise IncorrectFormatError(self, image_file)
-
-        FormatCBFMiniPilatus.__init__(self, image_file, **kwargs)
-
     def _goniometer(self):
         """Return a model for a simple single-axis goniometer. This should
         probably be checked against the image header, though for miniCBF

--- a/format/FormatCBFMultiTile.py
+++ b/format/FormatCBFMultiTile.py
@@ -70,17 +70,6 @@ class FormatCBFMultiTile(FormatCBFFull):
             if "CBFlib Error" in str(e):
                 return False
 
-    def __init__(self, image_file, **kwargs):
-        """Initialise the image structure from the given file."""
-        from dxtbx import IncorrectFormatError
-
-        if not self.understand(image_file):
-            raise IncorrectFormatError(self, image_file)
-
-        FormatCBFFull.__init__(self, image_file, **kwargs)
-
-        self._raw_data = None
-
     def _start(self):
         """Open the image file as a cbf file handle, and keep this somewhere
         safe."""

--- a/format/FormatCBFMultiTileHierarchy.py
+++ b/format/FormatCBFMultiTileHierarchy.py
@@ -46,11 +46,6 @@ class FormatCBFMultiTileHierarchy(FormatCBFMultiTile):
             raise e
         return True
 
-    def _start(self):
-        """Parent class will open the image file as a cbf file handle, and keep
-        the handle somewhere safe."""
-        FormatCBFMultiTile._start(self)
-
     def _get_change_of_basis(self, axis_id):
         """Get the 4x4 homogenous coordinate matrix for a given axis.  Assumes
         the cbf handle has been intialized

--- a/format/FormatCBFMultiTileHierarchy.py
+++ b/format/FormatCBFMultiTileHierarchy.py
@@ -46,15 +46,6 @@ class FormatCBFMultiTileHierarchy(FormatCBFMultiTile):
             raise e
         return True
 
-    def __init__(self, image_file, **kwargs):
-        """Initialise the image structure from the given file."""
-        from dxtbx import IncorrectFormatError
-
-        if not self.understand(image_file):
-            raise IncorrectFormatError(self, image_file)
-
-        FormatCBFMultiTile.__init__(self, image_file, **kwargs)
-
     def _start(self):
         """Parent class will open the image file as a cbf file handle, and keep
         the handle somewhere safe."""

--- a/format/FormatDIP2030b.py
+++ b/format/FormatDIP2030b.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 from dxtbx.format.Format import Format
+from dxtbx import IncorrectFormatError
 
 
 class FormatDIP2030b(Format):
@@ -21,12 +22,9 @@ class FormatDIP2030b(Format):
     def __init__(self, image_file, **kwargs):
         """Initialise the image structure from the given file."""
 
-        from dxtbx import IncorrectFormatError
-
         if not self.understand(image_file):
             raise IncorrectFormatError(self, image_file)
-
-        Format.__init__(self, image_file, **kwargs)
+        super(FormatDIP2030b, self).__init__(image_file, **kwargs)
 
     def detectorbase_start(self):
         pass

--- a/format/FormatEDFALS733.py
+++ b/format/FormatEDFALS733.py
@@ -3,6 +3,7 @@
 from __future__ import absolute_import, division, print_function
 
 from dxtbx.format.Format import Format
+from dxtbx import IncorrectFormatError
 
 
 class FormatEDFALS733(Format):
@@ -22,12 +23,10 @@ class FormatEDFALS733(Format):
 
     def __init__(self, image_file, **kwargs):
         """Initialise the image structure from the given file."""
-        from dxtbx import IncorrectFormatError
 
         if not self.understand(image_file):
             raise IncorrectFormatError(self, image_file)
-
-        Format.__init__(self, image_file, **kwargs)
+        super(FormatEDFALS733, self).__init__(image_file, **kwargs)
 
     def detectorbase_start(self):
         pass

--- a/format/FormatEiger0MQDump.py
+++ b/format/FormatEiger0MQDump.py
@@ -14,9 +14,6 @@ from dxtbx.format.Format import Format
 
 
 class FormatEiger0MQDump(Format):
-    def __init__(self, image_file, **kwargs):
-        Format.__init__(self, image_file)
-
     @staticmethod
     def understand(image_file):
         if os.path.exists(os.path.join(os.path.split(image_file)[0], "header")):

--- a/format/FormatGatanDM4.py
+++ b/format/FormatGatanDM4.py
@@ -9,6 +9,7 @@ import struct
 
 from dxtbx.format.Format import Format
 from dxtbx.format.FormatMultiImage import FormatMultiImage
+from dxtbx import IncorrectFormatError
 
 
 class FormatGatanDM4(FormatMultiImage, Format):
@@ -57,8 +58,6 @@ class FormatGatanDM4(FormatMultiImage, Format):
     }
 
     def __init__(self, image_file, **kwargs):
-
-        from dxtbx import IncorrectFormatError
 
         if not self.understand(image_file):
             raise IncorrectFormatError(self, image_file)

--- a/format/FormatHDF5.py
+++ b/format/FormatHDF5.py
@@ -2,12 +2,11 @@ from __future__ import absolute_import, division, print_function
 
 from dxtbx.format.Format import Format
 from dxtbx.format.FormatMultiImage import FormatMultiImage
+from dxtbx import IncorrectFormatError
 
 
 class FormatHDF5(FormatMultiImage, Format):
     def __init__(self, image_file, **kwargs):
-        from dxtbx import IncorrectFormatError
-
         if not self.understand(image_file):
             raise IncorrectFormatError(self, image_file)
         FormatMultiImage.__init__(self, **kwargs)

--- a/format/FormatHDF5Dectris.py
+++ b/format/FormatHDF5Dectris.py
@@ -24,15 +24,6 @@ class FormatHDF5Dectris(FormatHDF5):
         #
         # return tag == "\211HDF\r\n\032\n"
 
-    def __init__(self, image_file, **kwargs):
-
-        from dxtbx import IncorrectFormatError
-
-        if not self.understand(image_file):
-            raise IncorrectFormatError(self, image_file)
-
-        FormatHDF5.__init__(self, image_file, **kwargs)
-
     def _start(self):
         from iotbx.detectors.eiger import EIGERImage
 

--- a/format/FormatHDF5EigerNearlyNexus.py
+++ b/format/FormatHDF5EigerNearlyNexus.py
@@ -304,13 +304,6 @@ class EigerNXmxFixer(object):
 
 
 class FormatHDF5EigerNearlyNexus(FormatHDF5):
-    def __init__(self, image_file, **kwargs):
-        from dxtbx import IncorrectFormatError
-
-        if not self.understand(image_file):
-            raise IncorrectFormatError(self, image_file)
-        FormatHDF5.__init__(self, image_file, **kwargs)
-
     @staticmethod
     def understand(image_file):
         try:

--- a/format/FormatHDF5Lambda.py
+++ b/format/FormatHDF5Lambda.py
@@ -47,13 +47,6 @@ class FormatHDF5Lambda(FormatHDF5):
 
         return False
 
-    def __init__(self, image_file, **kwargs):
-        from dxtbx import IncorrectFormatError
-
-        if not self.understand(image_file):
-            raise IncorrectFormatError(self, image_file)
-        FormatHDF5.__init__(self, image_file, **kwargs)
-
     def _start(self):
         import h5py
 

--- a/format/FormatHDF5PAL.py
+++ b/format/FormatHDF5PAL.py
@@ -8,13 +8,6 @@ Format class for the PAL XFEL raw data format
 
 
 class FormatHDF5PAL(FormatHDF5):
-    def __init__(self, image_file, **kwargs):
-        from dxtbx import IncorrectFormatError
-
-        if not self.understand(image_file):
-            raise IncorrectFormatError(self, image_file)
-        FormatHDF5.__init__(self, image_file, **kwargs)
-
     @staticmethod
     def understand(image_file):
         import h5py

--- a/format/FormatHDF5RawData.py
+++ b/format/FormatHDF5RawData.py
@@ -4,13 +4,6 @@ from dxtbx.format.FormatHDF5 import FormatHDF5
 
 
 class FormatRawData(FormatHDF5):
-    def __init__(self, image_file, **kwargs):
-        from dxtbx import IncorrectFormatError
-
-        if not self.understand(image_file):
-            raise IncorrectFormatError(self, image_file)
-        FormatHDF5.__init__(self, image_file, **kwargs)
-
     @staticmethod
     def understand(image_file):
         import h5py

--- a/format/FormatHDF5Sacla.py
+++ b/format/FormatHDF5Sacla.py
@@ -27,13 +27,6 @@ class FormatHDF5Sacla(FormatHDF5, FormatStill):
                 understood = True
         return understood
 
-    def __init__(self, image_file, **kwargs):
-        from dxtbx import IncorrectFormatError
-
-        if not self.understand(image_file):
-            raise IncorrectFormatError(self, image_file)
-        FormatHDF5.__init__(self, image_file, **kwargs)
-
     def _start(self):
         import h5py
 

--- a/format/FormatHDF5SaclaMPCCD.py
+++ b/format/FormatHDF5SaclaMPCCD.py
@@ -46,14 +46,10 @@ class FormatHDF5SaclaMPCCD(FormatHDF5, FormatStill):
         return False
 
     def __init__(self, image_file, index=0, reconst_mode=False, **kwargs):
-        from dxtbx import IncorrectFormatError
-
-        if not self.understand(image_file):
-            raise IncorrectFormatError(self, image_file)
         self._raw_data = None
         self.index = index
         self.image_filename = image_file
-        FormatHDF5.__init__(self, image_file, **kwargs)
+        super(FormatHDF5SaclaMPCCD, self).__init__(image_file, **kwargs)
 
         self.PIXEL_SIZE = 50 / 1000  # 50 um
         self.RECONST_SIZE = 2398  # compatible with DataConvert3 -reconst mode

--- a/format/FormatHDF5SaclaRayonix.py
+++ b/format/FormatHDF5SaclaRayonix.py
@@ -27,14 +27,10 @@ class FormatHDF5SaclaRayonix(FormatHDF5, FormatStill):
         return False
 
     def __init__(self, image_file, index=0, reconst_mode=False, **kwargs):
-        from dxtbx import IncorrectFormatError
-
-        if not self.understand(image_file):
-            raise IncorrectFormatError(self, image_file)
         self._raw_data = None
         self.index = index
         self.image_filename = image_file
-        FormatHDF5.__init__(self, image_file, **kwargs)
+        super(FormatHDF5SaclaRayonix, self).__init__(image_file, **kwargs)
 
         # This hard-coded value can be overwritten
         # by RAYONIX_DISTANCE

--- a/format/FormatNexus.py
+++ b/format/FormatNexus.py
@@ -14,13 +14,6 @@ from dxtbx.format.nexus import MaskFactory
 
 
 class FormatNexus(FormatHDF5):
-    def __init__(self, image_file, **kwargs):
-        from dxtbx import IncorrectFormatError
-
-        if not self.understand(image_file):
-            raise IncorrectFormatError(self, image_file)
-        FormatHDF5.__init__(self, image_file, **kwargs)
-
     @staticmethod
     def understand(image_file):
         try:

--- a/format/FormatNexusEigerDLS16M.py
+++ b/format/FormatNexusEigerDLS16M.py
@@ -48,10 +48,6 @@ class FormatNexusEigerDLS16M(FormatNexus):
 
     def __init__(self, image_file, **kwargs):
         """Initialise the image structure from the given file."""
-        from dxtbx import IncorrectFormatError
-
-        if not self.understand(image_file):
-            raise IncorrectFormatError(self, image_file)
 
         super(FormatNexusEigerDLS16M, self).__init__(image_file, **kwargs)
         self._dynamic_shadowing = self.has_dynamic_shadowing(**kwargs)

--- a/format/FormatNexusExternalDataFile.py
+++ b/format/FormatNexusExternalDataFile.py
@@ -47,13 +47,6 @@ def is_nexus_external_data_file(filename):
 
 
 class FormatNexusExternalDataFile(FormatHDF5):
-    def __init__(self, image_file, **kwargs):
-        from dxtbx import IncorrectFormatError
-
-        if not self.understand(image_file):
-            raise IncorrectFormatError(self, image_file)
-        FormatHDF5.__init__(self, image_file, **kwargs)
-
     @staticmethod
     def understand(image_file):
         try:

--- a/format/FormatPY.py
+++ b/format/FormatPY.py
@@ -3,6 +3,7 @@
 from __future__ import absolute_import, division, print_function
 
 from dxtbx.format.Format import Format
+from dxtbx import IncorrectFormatError
 
 
 class FormatPY(Format):
@@ -24,11 +25,9 @@ class FormatPY(Format):
     def __init__(self, image_file, **kwargs):
         """Initialise the image structure from the given file."""
 
-        from dxtbx import IncorrectFormatError
-
         if not self.understand(image_file):
             raise IncorrectFormatError(self, image_file)
-        Format.__init__(self, image_file, **kwargs)
+        super(FormatPY, self).__init__(image_file, **kwargs)
 
 
 if __name__ == "__main__":

--- a/format/FormatPYmultitile.py
+++ b/format/FormatPYmultitile.py
@@ -4,7 +4,6 @@ from dxtbx.format.FormatPY import FormatPY
 
 import six
 import six.moves.cPickle as pickle
-from dxtbx import IncorrectFormatError
 from xfel.cftbx.detector.cspad_detector import CSPadDetector
 from dxtbx.model import Detector
 from calendar import timegm
@@ -35,14 +34,6 @@ class FormatPYmultitile(FormatPY):
             return False
 
         return True
-
-    def __init__(self, image_file, **kwargs):
-        """Initialise the image structure from the given file."""
-
-        if not self.understand(image_file):
-            raise IncorrectFormatError(self, image_file)
-
-        FormatPY.__init__(self, image_file, **kwargs)
 
     def _start(self):
         # this Format class depends on stuff from detectorbase

--- a/format/FormatPYunspecified.py
+++ b/format/FormatPYunspecified.py
@@ -10,7 +10,6 @@ import six.moves.cPickle as pickle
 from past.builtins import basestring
 from iotbx.detectors.cspad_detector_formats import reverse_timestamp
 from iotbx.detectors.cspad_detector_formats import detector_format_version
-from dxtbx import IncorrectFormatError
 from spotfinder.applications.xfel import cxi_phil
 from scitbx.array_family import flex
 from iotbx.detectors.npy import NpyImage
@@ -38,14 +37,6 @@ class FormatPYunspecified(FormatPY):
         wanted_header_items = {"SIZE1", "SIZE2", "TIMESTAMP"}
 
         return wanted_header_items.issubset(headers)
-
-    def __init__(self, image_file, **kwargs):
-        """Initialise the image structure from the given file."""
-
-        if not self.understand(image_file):
-            raise IncorrectFormatError(self, image_file)
-
-        FormatPY.__init__(self, image_file, **kwargs)
 
     def detectorbase_start(self):
         pass
@@ -231,8 +222,7 @@ class FormatPYunspecifiedInMemory(FormatPYunspecified):
 
     def __init__(self, data, **kwargs):
         """ @param data In memory image dictionary, alredy initialized """
-        FormatPYunspecified.__init__(self, data, **kwargs)
-
+        super(FormatPYunspecifiedInMemory, self).__init__(data, **kwargs)
         self._image_file = copy.deepcopy(data)
 
 

--- a/format/FormatPYunspecifiedStill.py
+++ b/format/FormatPYunspecifiedStill.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
 from future import standard_library
-from dxtbx import IncorrectFormatError
 import sys
 
 standard_library.install_aliases()
@@ -40,14 +39,6 @@ class FormatPYunspecifiedStill(FormatStill, FormatPYunspecified):
 
         return data["OSC_RANGE"] <= 0
 
-    def __init__(self, image_file, **kwargs):
-        """Initialise the image structure from the given file."""
-
-        if not self.understand(image_file):
-            raise IncorrectFormatError(self, image_file)
-
-        FormatPYunspecified.__init__(self, image_file, **kwargs)
-
 
 class FormatPYunspecifiedStillInMemory(FormatStill, FormatPYunspecifiedInMemory):
     """Overrides the Format object's init method to accept an image dictionary
@@ -70,8 +61,7 @@ class FormatPYunspecifiedStillInMemory(FormatStill, FormatPYunspecifiedInMemory)
 
     def __init__(self, data, **kwargs):
         """ @param data In memory image dictionary, alredy initialized """
-        FormatPYunspecifiedInMemory.__init__(self, data, **kwargs)
-
+        super(FormatPYunspecifiedStillInMemory, self).__init__(data, **kwargs)
         self._image_file = copy.deepcopy(data)
 
 

--- a/format/FormatSER.py
+++ b/format/FormatSER.py
@@ -18,12 +18,11 @@ import struct
 import dxtbx.ext
 from dxtbx.format.Format import Format
 from dxtbx.format.FormatMultiImage import FormatMultiImage
+from dxtbx import IncorrectFormatError
 
 
 class FormatSER(FormatMultiImage, Format):
     def __init__(self, image_file, **kwargs):
-
-        from dxtbx import IncorrectFormatError
 
         if not self.understand(image_file):
             raise IncorrectFormatError(self, image_file)

--- a/format/FormatSEReBIC.py
+++ b/format/FormatSEReBIC.py
@@ -16,12 +16,6 @@ from dxtbx.format.FormatSER import FormatSER
 
 
 class FormatSEReBIC(FormatSER):
-    def __init__(self, image_file, **kwargs):
-
-        if not self.understand(image_file):
-            raise IncorrectFormatError(self, image_file)
-        FormatSER.__init__(self, image_file, **kwargs)
-
     @staticmethod
     def understand(image_file):
 

--- a/format/FormatSMV.py
+++ b/format/FormatSMV.py
@@ -13,6 +13,7 @@ from __future__ import absolute_import, division, print_function
 
 from boost.python import streambuf
 from dxtbx.format.Format import Format
+from dxtbx import IncorrectFormatError
 from dxtbx.ext import read_uint16, read_uint16_bs, is_big_endian
 from scitbx.array_family import flex
 
@@ -82,12 +83,9 @@ class FormatSMV(Format):
     def __init__(self, image_file, **kwargs):
         """Initialise the image structure from the given file."""
 
-        from dxtbx import IncorrectFormatError
-
         if not self.understand(image_file):
             raise IncorrectFormatError(self, image_file)
-
-        Format.__init__(self, image_file, **kwargs)
+        super(FormatSMV, self).__init__(image_file, **kwargs)
 
     def _start(self):
         """Open the image file, read the image header, copy the key / value

--- a/format/FormatSMVADSC.py
+++ b/format/FormatSMVADSC.py
@@ -59,17 +59,6 @@ class FormatSMVADSC(FormatSMV):
 
         return True
 
-    def __init__(self, image_file, **kwargs):
-        """Initialise the image structure from the given file, including a
-        proper model of the experiment."""
-
-        from dxtbx import IncorrectFormatError
-
-        if not self.understand(image_file):
-            raise IncorrectFormatError(self, image_file)
-
-        FormatSMV.__init__(self, image_file, **kwargs)
-
     def _start(self):
 
         FormatSMV._start(self)

--- a/format/FormatSMVADSC.py
+++ b/format/FormatSMVADSC.py
@@ -59,10 +59,6 @@ class FormatSMVADSC(FormatSMV):
 
         return True
 
-    def _start(self):
-
-        FormatSMV._start(self)
-
     def detectorbase_start(self):
         if not hasattr(self, "detectorbase") or self.detectorbase is None:
             from iotbx.detectors import SMVImage

--- a/format/FormatSMVADSCNoDateStamp.py
+++ b/format/FormatSMVADSCNoDateStamp.py
@@ -28,10 +28,6 @@ class FormatSMVADSCNoDateStamp(FormatSMVADSC):
 
         return True
 
-    def _start(self):
-
-        FormatSMVADSC._start(self)
-
     def _scan(self):
         """Return the scan information for this image, using the timestamp
         from the file rather than the header."""

--- a/format/FormatSMVADSCNoDateStamp.py
+++ b/format/FormatSMVADSCNoDateStamp.py
@@ -28,17 +28,6 @@ class FormatSMVADSCNoDateStamp(FormatSMVADSC):
 
         return True
 
-    def __init__(self, image_file, **kwargs):
-        """Initialise the image structure from the given file, including a
-        proper model of the experiment."""
-
-        from dxtbx import IncorrectFormatError
-
-        if not self.understand(image_file):
-            raise IncorrectFormatError(self, image_file)
-
-        FormatSMVADSC.__init__(self, image_file, **kwargs)
-
     def _start(self):
 
         FormatSMVADSC._start(self)

--- a/format/FormatSMVADSCSN.py
+++ b/format/FormatSMVADSCSN.py
@@ -26,11 +26,6 @@ class FormatSMVADSCSN(FormatSMVADSC):
         """Initialise the image structure from the given file, including a
         proper model of the experiment."""
 
-        from dxtbx import IncorrectFormatError
-
-        if not self.understand(image_file):
-            raise IncorrectFormatError(self, image_file)
-
         # Mapping of serial numbers to models for known detectors
         self._sn_to_model = {
             401: "Q4U",
@@ -64,7 +59,7 @@ class FormatSMVADSCSN(FormatSMVADSC):
             933: "Q315R",
         }
 
-        FormatSMVADSC.__init__(self, image_file, **kwargs)
+        super(FormatSMVADSCSN, self).__init__(image_file, **kwargs)
 
     def _adsc_module_gain(self, model=None):
         """Overload to look the model number up from the serial number table"""

--- a/format/FormatSMVADSCSN.py
+++ b/format/FormatSMVADSCSN.py
@@ -69,10 +69,6 @@ class FormatSMVADSCSN(FormatSMVADSC):
             model = self._sn_to_model.get(sn)
         return super(FormatSMVADSCSN, self)._adsc_module_gain(model=model)
 
-    def _start(self):
-
-        FormatSMVADSC._start(self)
-
     def detectorbase_start(self):
 
         from iotbx.detectors.adsc import ADSCImage

--- a/format/FormatSMVADSCSN445.py
+++ b/format/FormatSMVADSCSN445.py
@@ -26,17 +26,6 @@ class FormatSMVADSCSN445(FormatSMVADSCSN):
 
         return int(header["DETECTOR_SN"]) == 445
 
-    def __init__(self, image_file, **kwargs):
-        """Initialise the image structure from the given file, including a
-        proper model of the experiment."""
-
-        from dxtbx import IncorrectFormatError
-
-        if not self.understand(image_file):
-            raise IncorrectFormatError(self, image_file)
-
-        FormatSMVADSCSN.__init__(self, image_file, **kwargs)
-
     def _detector(self):
         """Return a model for a simple detector, presuming no one has
         one of these on a two-theta stage. Assert that the beam centre is

--- a/format/FormatSMVADSCSN457.py
+++ b/format/FormatSMVADSCSN457.py
@@ -26,17 +26,6 @@ class FormatSMVADSCSNSN457(FormatSMVADSCSN):
 
         return int(header["DETECTOR_SN"]) == 457
 
-    def __init__(self, image_file, **kwargs):
-        """Initialise the image structure from the given file, including a
-        proper model of the experiment."""
-
-        from dxtbx import IncorrectFormatError
-
-        if not self.understand(image_file):
-            raise IncorrectFormatError(self, image_file)
-
-        FormatSMVADSCSN.__init__(self, image_file, **kwargs)
-
     def _goniometer(self):
         """Return a model for a simple single-axis goniometer. This should
         probably be checked against the image header."""

--- a/format/FormatSMVADSCSN905.py
+++ b/format/FormatSMVADSCSN905.py
@@ -29,17 +29,6 @@ class FormatSMVADSCSN905(FormatSMVADSCSN):
 
         return True
 
-    def __init__(self, image_file, **kwargs):
-        """Initialise the image structure from the given file, including a
-        proper model of the experiment."""
-
-        from dxtbx import IncorrectFormatError
-
-        if not self.understand(image_file):
-            raise IncorrectFormatError(self, image_file)
-
-        FormatSMVADSCSN.__init__(self, image_file, **kwargs)
-
     def _detector(self):
         """Return a model for a simple detector, presuming no one has
         one of these on a two-theta stage. Assert that the beam centre is

--- a/format/FormatSMVADSCSN915.py
+++ b/format/FormatSMVADSCSN915.py
@@ -27,17 +27,6 @@ class FormatSMVADSCSN915(FormatSMVADSCSN):
 
         return int(header["DETECTOR_SN"]) == 915
 
-    def __init__(self, image_file, **kwargs):
-        """Initialise the image structure from the given file, including a
-        proper model of the experiment."""
-
-        from dxtbx import IncorrectFormatError
-
-        if not self.understand(image_file):
-            raise IncorrectFormatError(self, image_file)
-
-        FormatSMVADSCSN.__init__(self, image_file, **kwargs)
-
     def get_raw_data(self):
         """Get the pixel intensities (i.e. read the image and return as a
         flex array of integers.)"""

--- a/format/FormatSMVADSCSN920.py
+++ b/format/FormatSMVADSCSN920.py
@@ -26,17 +26,6 @@ class FormatSMVADSCSN920(FormatSMVADSCSN):
 
         return int(header["DETECTOR_SN"]) == 920
 
-    def __init__(self, image_file, **kwargs):
-        """Initialise the image structure from the given file, including a
-        proper model of the experiment."""
-
-        from dxtbx import IncorrectFormatError
-
-        if not self.understand(image_file):
-            raise IncorrectFormatError(self, image_file)
-
-        FormatSMVADSCSN.__init__(self, image_file, **kwargs)
-
     def get_raw_data(self):
         """Get the pixel intensities (i.e. read the image and return as a
         flex array of integers.)"""

--- a/format/FormatSMVADSCSN926.py
+++ b/format/FormatSMVADSCSN926.py
@@ -32,17 +32,6 @@ class FormatSMVADSCSN926(FormatSMVADSCSN):
 
         return True
 
-    def __init__(self, image_file, **kwargs):
-        """Initialise the image structure from the given file, including a
-        proper model of the experiment."""
-
-        from dxtbx import IncorrectFormatError
-
-        if not self.understand(image_file):
-            raise IncorrectFormatError(self, image_file)
-
-        FormatSMVADSCSN.__init__(self, image_file, **kwargs)
-
     def _detector(self):
         """Return a model for a simple detector, allowing for the installation
         on on a two-theta stage. Assert that the beam centre is provided in

--- a/format/FormatSMVADSCSN928.py
+++ b/format/FormatSMVADSCSN928.py
@@ -23,17 +23,6 @@ class FormatSMVADSCSN928(FormatSMVADSCSN):
 
         return True
 
-    def __init__(self, image_file, **kwargs):
-        """Initialise the image structure from the given file, including a
-        proper model of the experiment."""
-
-        from dxtbx import IncorrectFormatError
-
-        if not self.understand(image_file):
-            raise IncorrectFormatError(self, image_file)
-
-        FormatSMVADSCSN.__init__(self, image_file, **kwargs)
-
     def _goniometer(self):
         """Return a model for a simple single-axis goniometer. This should
         probably be checked against the image header."""

--- a/format/FormatSMVADSCSNAPSID19.py
+++ b/format/FormatSMVADSCSNAPSID19.py
@@ -32,17 +32,6 @@ class FormatSMVADSCSNAPSID19(FormatSMVADSCSN):
 
         return True
 
-    def __init__(self, image_file, **kwargs):
-        """Initialise the image structure from the given file, including a
-        proper model of the experiment."""
-
-        from dxtbx import IncorrectFormatError
-
-        if not self.understand(image_file):
-            raise IncorrectFormatError(self, image_file)
-
-        FormatSMVADSCSN.__init__(self, image_file, **kwargs)
-
     def _detector(self):
         """Return a model for a simple detector, presuming no one has
         one of these on a two-theta stage. Assert that the beam centre is

--- a/format/FormatSMVADSCmlfsom.py
+++ b/format/FormatSMVADSCmlfsom.py
@@ -20,17 +20,6 @@ class FormatSMVADSCmlfsom(FormatSMVADSC):
 
         return True
 
-    def __init__(self, image_file, **kwargs):
-        """Initialise the image structure from the given file, including a
-        proper model of the experiment."""
-
-        from dxtbx import IncorrectFormatError
-
-        if not self.understand(image_file):
-            raise IncorrectFormatError(self, image_file)
-
-        FormatSMVADSC.__init__(self, image_file, **kwargs)
-
     def _scan(self):
         """Return the scan information for this image."""
 

--- a/format/FormatSMVCMOS1.py
+++ b/format/FormatSMVCMOS1.py
@@ -79,7 +79,7 @@ class FormatSMVCMOS1(FormatSMV):
         self._prefix = detector_prefixes[0]
 
     def _start(self):
-        FormatSMV._start(self)
+        super(FormatSMVCMOS1, self)._start()
         self._header_size = int(self._header_dictionary["HEADER_BYTES"])
 
     def _goniometer(self):

--- a/format/FormatSMVCMOS1.py
+++ b/format/FormatSMVCMOS1.py
@@ -74,13 +74,7 @@ class FormatSMVCMOS1(FormatSMV):
         """Initialise the image structure from the given file, including a
         proper model of the experiment."""
 
-        from dxtbx import IncorrectFormatError
-
-        if not self.understand(image_file):
-            raise IncorrectFormatError(self, image_file)
-
-        FormatSMV.__init__(self, image_file, **kwargs)
-
+        super(FormatSMVCMOS1, self).__init__(image_file, **kwargs)
         detector_prefixes = self._header_dictionary["DETECTOR_NAMES"].split()
         self._prefix = detector_prefixes[0]
 

--- a/format/FormatSMVHamamatsu.py
+++ b/format/FormatSMVHamamatsu.py
@@ -15,10 +15,6 @@ class FormatSMVHamamatsu(FormatSMVADSC):
 
         return "hamamatsu" in header["DETECTOR_NAME"].lower()
 
-    def _start(self):
-
-        FormatSMVADSC._start(self)
-
     def detectorbase_start(self):
         from iotbx.detectors.hamamatsu import HamamatsuImage
 

--- a/format/FormatSMVJHSim.py
+++ b/format/FormatSMVJHSim.py
@@ -39,10 +39,6 @@ class FormatSMVJHSim(FormatSMV):
         else:
             return False
 
-    def _start(self):
-
-        FormatSMV._start(self)
-
     def detectorbase_start(self):
         if not hasattr(self, "detectorbase") or self.detectorbase is None:
             from iotbx.detectors import SMVImage

--- a/format/FormatSMVJHSim.py
+++ b/format/FormatSMVJHSim.py
@@ -39,19 +39,6 @@ class FormatSMVJHSim(FormatSMV):
         else:
             return False
 
-    def __init__(self, image_file, **kwargs):
-        """Initialise the image structure from the given file, including a
-        proper model of the experiment."""
-
-        from dxtbx import IncorrectFormatError
-
-        if not self.understand(image_file):
-            raise IncorrectFormatError(self, image_file)
-
-        FormatSMV.__init__(self, image_file, **kwargs)
-
-        return
-
     def _start(self):
 
         FormatSMV._start(self)

--- a/format/FormatSMVNOIR.py
+++ b/format/FormatSMVNOIR.py
@@ -77,13 +77,7 @@ class FormatSMVNOIR(FormatSMVRigaku):
         proper model of the experiment. Easy from Rigaku Saturn images as
         they contain everything pretty much we need..."""
 
-        from dxtbx import IncorrectFormatError
-
-        if not self.understand(image_file):
-            raise IncorrectFormatError(self, image_file)
-
-        FormatSMVRigaku.__init__(self, image_file, **kwargs)
-
+        super(FormatSMVNOIR, self).__init__(image_file, **kwargs)
         self.detector_class = "NOIR1"
         self.detector = "adsc"
 

--- a/format/FormatSMVRigaku.py
+++ b/format/FormatSMVRigaku.py
@@ -60,17 +60,6 @@ class FormatSMVRigaku(FormatSMV):
 
         return True
 
-    def __init__(self, image_file, **kwargs):
-        """Initialise the image structure from the given file, including a
-        proper model of the experiment."""
-
-        from dxtbx import IncorrectFormatError
-
-        if not self.understand(image_file):
-            raise IncorrectFormatError(self, image_file)
-
-        FormatSMV.__init__(self, image_file, **kwargs)
-
     def _goniometer(self):
         """Overload this method to read the image file however you like so
         long as the result is an goniometer."""

--- a/format/FormatSMVRigakuA200.py
+++ b/format/FormatSMVRigakuA200.py
@@ -79,18 +79,6 @@ class FormatSMVRigakuA200(FormatSMVRigaku):
 
         return False
 
-    def __init__(self, image_file, **kwargs):
-        """Initialise the image structure from the given file, including a
-        proper model of the experiment. Easy from Rigaku A200 images as
-        they contain everything pretty much we need..."""
-
-        from dxtbx import IncorrectFormatError
-
-        if not self.understand(image_file):
-            raise IncorrectFormatError(self, image_file)
-
-        FormatSMVRigaku.__init__(self, image_file, **kwargs)
-
     def detectorbase_start(self):
         from iotbx.detectors.dtrek import DTREKImage
 

--- a/format/FormatSMVRigakuA200SPring8BL26B1.py
+++ b/format/FormatSMVRigakuA200SPring8BL26B1.py
@@ -42,18 +42,6 @@ class FormatSMVRigakuA200SPring8BL26B1(FormatSMVRigakuA200):
 
         return True
 
-    def __init__(self, image_file, **kwargs):
-        """Initialise the image structure from the given file, including a
-        proper model of the experiment. Easy from Rigaku A200 images as
-        they contain everything pretty much we need..."""
-
-        from dxtbx import IncorrectFormatError
-
-        if not self.understand(image_file):
-            raise IncorrectFormatError(self, image_file)
-
-        FormatSMVRigakuA200.__init__(self, image_file, **kwargs)
-
     def _start(self):
 
         FormatSMVRigakuA200._start(self)

--- a/format/FormatSMVRigakuA200SPring8BL26B1.py
+++ b/format/FormatSMVRigakuA200SPring8BL26B1.py
@@ -42,10 +42,6 @@ class FormatSMVRigakuA200SPring8BL26B1(FormatSMVRigakuA200):
 
         return True
 
-    def _start(self):
-
-        FormatSMVRigakuA200._start(self)
-
     def detectorbase_start(self):
         from iotbx.detectors.dtrek import DTREKImage
 

--- a/format/FormatSMVRigakuEiger.py
+++ b/format/FormatSMVRigakuEiger.py
@@ -40,17 +40,6 @@ class FormatSMVRigakuEiger(FormatSMVRigaku):
 
         return "Eiger" in header["%sDETECTOR_DESCRIPTION" % name]
 
-    def __init__(self, image_file, **kwargs):
-        """Initialise the image structure from the given file, including a
-        proper model of the experiment."""
-
-        from dxtbx import IncorrectFormatError
-
-        if not self.understand(image_file):
-            raise IncorrectFormatError(self, image_file)
-
-        FormatSMVRigaku.__init__(self, image_file, **kwargs)
-
     def _goniometer(self):
         """Initialize the structure for the goniometer."""
 

--- a/format/FormatSMVRigakuPilatus.py
+++ b/format/FormatSMVRigakuPilatus.py
@@ -36,17 +36,6 @@ class FormatSMVRigakuPilatus(FormatSMVRigaku):
 
         return True
 
-    def __init__(self, image_file, **kwargs):
-        """Initialise the image structure from the given file, including a
-        proper model of the experiment."""
-
-        from dxtbx import IncorrectFormatError
-
-        if not self.understand(image_file):
-            raise IncorrectFormatError(self, image_file)
-
-        FormatSMVRigaku.__init__(self, image_file, **kwargs)
-
     def _goniometer(self):
         """Initialize the structure for the goniometer - this will need to
         correctly compose the axes given in the image header. In this case

--- a/format/FormatSMVRigakuSaturn.py
+++ b/format/FormatSMVRigakuSaturn.py
@@ -78,18 +78,6 @@ class FormatSMVRigakuSaturn(FormatSMVRigaku):
 
         return False
 
-    def __init__(self, image_file, **kwargs):
-        """Initialise the image structure from the given file, including a
-        proper model of the experiment. Easy from Rigaku Saturn images as
-        they contain everything pretty much we need..."""
-
-        from dxtbx import IncorrectFormatError
-
-        if not self.understand(image_file):
-            raise IncorrectFormatError(self, image_file)
-
-        FormatSMVRigaku.__init__(self, image_file, **kwargs)
-
     def detectorbase_start(self):
         from iotbx.detectors.saturn import SaturnImage
 

--- a/format/FormatSMVRigakuSaturnNoTS.py
+++ b/format/FormatSMVRigakuSaturnNoTS.py
@@ -79,18 +79,6 @@ class FormatSMVRigakuSaturnNoTS(FormatSMVRigaku):
 
         return False
 
-    def __init__(self, image_file, **kwargs):
-        """Initialise the image structure from the given file, including a
-        proper model of the experiment. Easy from Rigaku Saturn images as
-        they contain everything pretty much we need..."""
-
-        from dxtbx import IncorrectFormatError
-
-        if not self.understand(image_file):
-            raise IncorrectFormatError(self, image_file)
-
-        FormatSMVRigaku.__init__(self, image_file, **kwargs)
-
     def detectorbase_start(self):
         from iotbx.detectors.saturn import SaturnImage
 

--- a/format/FormatSMVTimePix_SU.py
+++ b/format/FormatSMVTimePix_SU.py
@@ -47,10 +47,6 @@ class FormatSMVTimePix_SU(FormatSMV):
 
         return True
 
-    def _start(self):
-
-        FormatSMV._start(self)
-
     def detectorbase_start(self):
         if not hasattr(self, "detectorbase") or self.detectorbase is None:
             from iotbx.detectors import SMVImage

--- a/format/FormatSMVTimePix_SU.py
+++ b/format/FormatSMVTimePix_SU.py
@@ -47,17 +47,6 @@ class FormatSMVTimePix_SU(FormatSMV):
 
         return True
 
-    def __init__(self, image_file, **kwargs):
-        """Initialise the image structure from the given file, including a
-        proper model of the experiment."""
-
-        from dxtbx import IncorrectFormatError
-
-        if not self.understand(image_file):
-            raise IncorrectFormatError(self, image_file)
-
-        FormatSMV.__init__(self, image_file, **kwargs)
-
     def _start(self):
 
         FormatSMV._start(self)

--- a/format/FormatTIFF.py
+++ b/format/FormatTIFF.py
@@ -10,6 +10,7 @@ from dxtbx.format.Format import Format
 from dxtbx.format.FormatTIFFHelpers import read_basic_tiff_header
 from dxtbx.format.FormatTIFFHelpers import LITTLE_ENDIAN
 from dxtbx.format.FormatTIFFHelpers import BIG_ENDIAN
+from dxtbx import IncorrectFormatError
 
 
 class FormatTIFF(Format):
@@ -41,12 +42,10 @@ class FormatTIFF(Format):
     def __init__(self, image_file, **kwargs):
         """Initialise the image structure from the given file."""
 
-        from dxtbx import IncorrectFormatError
-
         if not self.understand(image_file):
             raise IncorrectFormatError(self, image_file)
 
-        Format.__init__(self, image_file, **kwargs)
+        super(FormatTIFF, self).__init__(image_file, **kwargs)
 
     def _start(self):
         """Open the image file, read the image header, copy it into memory

--- a/format/FormatTIFFBruker.py
+++ b/format/FormatTIFFBruker.py
@@ -81,10 +81,6 @@ class FormatTIFFBruker(FormatTIFF):
 
         super(FormatTIFFBruker, self).__init__(image_file, **kwargs)
 
-    def _start(self):
-
-        FormatTIFF._start(self)
-
     def detectorbase_start(self):
         from iotbx.detectors.mar import MARImage
 

--- a/format/FormatTIFFBruker.py
+++ b/format/FormatTIFFBruker.py
@@ -63,11 +63,6 @@ class FormatTIFFBruker(FormatTIFF):
         """Initialise the image structure from the given file, including a
         proper model of the experiment."""
 
-        from dxtbx import IncorrectFormatError
-
-        if not self.understand(image_file):
-            raise IncorrectFormatError(self, image_file)
-
         width, height, depth, order, bytes = FormatTIFF.get_tiff_header(image_file)
 
         # comment block - where the detector serial number may (or may not) be stored
@@ -84,9 +79,7 @@ class FormatTIFFBruker(FormatTIFF):
             self._i = ">i"
             self._ii = ">ii"
 
-        FormatTIFF.__init__(self, image_file, **kwargs)
-
-        return
+        super(FormatTIFFBruker, self).__init__(image_file, **kwargs)
 
     def _start(self):
 

--- a/format/FormatTIFFRayonix.py
+++ b/format/FormatTIFFRayonix.py
@@ -83,10 +83,6 @@ class FormatTIFFRayonix(FormatTIFF):
 
         super(FormatTIFFRayonix, self).__init__(image_file, **kwargs)
 
-    def _start(self):
-
-        FormatTIFF._start(self)
-
     def detectorbase_start(self):
         from iotbx.detectors.mar import MARImage
 

--- a/format/FormatTIFFRayonix.py
+++ b/format/FormatTIFFRayonix.py
@@ -65,11 +65,6 @@ class FormatTIFFRayonix(FormatTIFF):
         """Initialise the image structure from the given file, including a
         proper model of the experiment."""
 
-        from dxtbx import IncorrectFormatError
-
-        if not self.understand(image_file):
-            raise IncorrectFormatError(self, image_file)
-
         width, height, depth, order, bytes = FormatTIFF.get_tiff_header(image_file)
 
         # comment block - where the detector serial number may (or may not) be stored
@@ -86,7 +81,7 @@ class FormatTIFFRayonix(FormatTIFF):
             self._i = ">i"
             self._ii = ">ii"
 
-        FormatTIFF.__init__(self, image_file, **kwargs)
+        super(FormatTIFFRayonix, self).__init__(image_file, **kwargs)
 
     def _start(self):
 

--- a/format/FormatTIFFRayonixESRF.py
+++ b/format/FormatTIFFRayonixESRF.py
@@ -57,18 +57,6 @@ class FormatTIFFRayonixESRF(FormatTIFFRayonix):
         )  # if header was in mm, disagreement should be
         # approximately the pixel size in mm
 
-    def __init__(self, image_file, **kwargs):
-        """Initialise the image structure from the given file, including a
-        proper model of the experiment."""
-
-        from dxtbx import IncorrectFormatError
-
-        if not self.understand(image_file):
-            raise IncorrectFormatError(self, image_file)
-        FormatTIFFRayonix.__init__(self, image_file, **kwargs)
-
-        return
-
     def _goniometer(self):
         """Return a model for goniometer corresponding to the values stored
         in the image header. In the first instance assume this is a single

--- a/format/FormatTIFFRayonixSPring8.py
+++ b/format/FormatTIFFRayonixSPring8.py
@@ -77,16 +77,6 @@ class FormatTIFFRayonixSPring8(FormatTIFFRayonix):
 
         return False
 
-    def __init__(self, image_file, **kwargs):
-        """Initialise the image structure from the given file, including a
-        proper model of the experiment."""
-
-        from dxtbx import IncorrectFormatError
-
-        if not self.understand(image_file):
-            raise IncorrectFormatError(self, image_file)
-        FormatTIFFRayonix.__init__(self, image_file, **kwargs)
-
     def _detector(self):
         """Return a model for a simple detector, which at the moment insists
         that the offsets and rotations are all 0.0."""

--- a/format/FormatTIFFRayonixXPP.py
+++ b/format/FormatTIFFRayonixXPP.py
@@ -66,15 +66,10 @@ class FormatTIFFRayonixXPP(FormatTIFFRayonix):
         """Initialise the image structure from the given file, including a
         proper model of the experiment."""
 
-        from dxtbx import IncorrectFormatError
-
-        if not self.understand(image_file):
-            raise IncorrectFormatError(self, image_file)
-
         from iotbx.detectors.mar import MARImage
 
         MARImage._read_header_asserts = lambda self: None
-        FormatTIFFRayonix.__init__(self, image_file, **kwargs)
+        super(FormatTIFFRayonixXPP, self).__init__(image_file, **kwargs)
 
     ####################################################################
     #                                                                  #

--- a/format/FormatXDS.py
+++ b/format/FormatXDS.py
@@ -10,6 +10,7 @@
 from __future__ import absolute_import, division, print_function
 
 from dxtbx.format.Format import Format
+from dxtbx import IncorrectFormatError
 
 
 class FormatXDS(Format):
@@ -26,13 +27,9 @@ class FormatXDS(Format):
     def __init__(self, image_file, **kwargs):
         """Initialise the image structure from the given file."""
 
-        Format.__init__(self, image_file, **kwargs)
-
-        from dxtbx import IncorrectFormatError
-
         if not self.understand(image_file):
             raise IncorrectFormatError(self, image_file)
-        return
+        super(FormatXDS, self).__init__(image_file, **kwargs)
 
     def _start(self):
         """Open the image file as a cbf file handle, and keep this somewhere

--- a/format/FormatXTC.py
+++ b/format/FormatXTC.py
@@ -4,6 +4,7 @@ from dxtbx.format.Format import Format
 from dxtbx.format.FormatStill import FormatStill
 from dxtbx.format.FormatMultiImage import Reader
 from dxtbx.format.FormatMultiImageLazy import FormatMultiImageLazy
+from dxtbx import IncorrectFormatError
 from libtbx.phil import parse
 
 try:
@@ -45,7 +46,6 @@ class XtcReader(Reader):
 
 class FormatXTC(FormatMultiImageLazy, FormatStill, Format):
     def __init__(self, image_file, **kwargs):
-        from dxtbx import IncorrectFormatError
 
         if not self.understand(image_file):
             raise IncorrectFormatError(self, image_file)

--- a/format/FormatXTCCspad.py
+++ b/format/FormatXTCCspad.py
@@ -39,8 +39,9 @@ cspad_locator_scope = parse(cspad_locator_str + locator_str, process_includes=Tr
 
 class FormatXTCCspad(FormatXTC):
     def __init__(self, image_file, locator_scope=cspad_locator_scope, **kwargs):
-        assert self.understand(image_file)
-        FormatXTC.__init__(self, image_file, locator_scope=locator_scope, **kwargs)
+        super(FormatXTCCspad, self).__init__(
+            image_file, locator_scope=locator_scope, **kwargs
+        )
         assert (
             self.params.cspad.detz_offset is not None
         ), "Supply a detz_offset for the cspad"

--- a/format/FormatXTCJungfrau.py
+++ b/format/FormatXTCJungfrau.py
@@ -29,9 +29,8 @@ jungfrau_locator_scope = parse(
 
 class FormatXTCJungfrau(FormatXTC):
     def __init__(self, image_file, **kwargs):
-        assert self.understand(image_file)
-        FormatXTC.__init__(
-            self, image_file, locator_scope=jungfrau_locator_scope, **kwargs
+        super(FormatXTCJungfrau, self).__init__(
+            image_file, locator_scope=jungfrau_locator_scope, **kwargs
         )
         self._ds = FormatXTC._get_datasource(image_file, self.params)
         self._env = self._ds.env()

--- a/format/FormatXTCMultipleDetectors.py
+++ b/format/FormatXTCMultipleDetectors.py
@@ -14,10 +14,6 @@ multiple_locator_scope = parse(
 
 class FormatXTCMultipleDetectors(FormatXTCRayonix, FormatXTCCspad, FormatXTCJungfrau):
     def __init__(self, image_file, **kwargs):
-        assert self.understand(image_file)
-        FormatXTC.__init__(
-            self, image_file, locator_scope=multiple_locator_scope, **kwargs
-        )
         self._ds = FormatXTCMultipleDetectors._get_datasource(image_file, self.params)
         self._env = self._ds.env()
         self.populate_events()

--- a/format/FormatXTCRayonix.py
+++ b/format/FormatXTCRayonix.py
@@ -24,9 +24,8 @@ class FormatXTCRayonix(FormatXTC):
     def __init__(self, image_file, **kwargs):
         import psana
 
-        assert self.understand(image_file)
-        FormatXTC.__init__(
-            self, image_file, locator_scope=rayonix_locator_scope, **kwargs
+        super(FormatXTCRayonix, self).__init__(
+            image_file, locator_scope=rayonix_locator_scope, **kwargs
         )
         self._ds = FormatXTCRayonix._get_datasource(image_file, self.params)
         self._env = self._ds.env()

--- a/newsfragments/76.misc
+++ b/newsfragments/76.misc
@@ -1,0 +1,9 @@
+Remove unnecessary `__init__` and `_start` methods from Format classes:
+
+- There is no need for every subclass to redefine the `__init__` method and
+call its parent's `__init__` method. As well as a lot of unnecessary code
+duplication, this also led to the subclass `self.understand()` method
+being called once for every class in the format class hierarchy.
+- There is no need for every subclass to redefine the `_start()` method and
+call its parent's `_start()` method.
+- Use `super()` where applicable.


### PR DESCRIPTION
Remove unnecessary `__init__` and `_start` methods from Format classes:

- There is no need for every subclass to redefine the `__init__` method and
call its parent's `__init__` method. As well as a lot of unnecessary code
duplication, this also led to the subclass `self.understand()` method
being called once for every class in the format class hierarchy.
- There is no need for every subclass to redefine the `_start()` method and
call its parent's `_start()` method.
- Use `super()` where applicable.