### PR TITLE
Allow compressed FullCBF files to be read

### DIFF
--- a/SConscript
+++ b/SConscript
@@ -136,7 +136,10 @@ if not env_etc.no_boost_python and hasattr(env_etc, "boost_adaptbx_include"):
 
     image = env.SharedLibrary(
         target="#/lib/dxtbx_format_image_ext",
-        source=["format/boost_python/image_ext.cc"],
+        source=[
+            "format/boost_python/image_ext.cc",
+            "format/boost_python/cbf_read_buffer.cpp",
+        ],
         LIBS=env_etc.libs_python
         + env_etc.libm
         + env_etc.dxtbx_libs

--- a/filecache.py
+++ b/filecache.py
@@ -188,7 +188,6 @@ class lazy_file_cache(object):
                 % self._cache_size
             )
             self._file.close()
-            self._file = None
 
     def open(self):
         """Create and return a new pseudo_file object for this cache."""

--- a/format/boost_python/cbf_read_buffer.cpp
+++ b/format/boost_python/cbf_read_buffer.cpp
@@ -1,0 +1,72 @@
+
+#include <memory>
+
+#include <stdio.h>
+
+#include <boost/python.hpp>
+#include <boost/move/unique_ptr.hpp>
+
+#include <cbf.h>
+
+namespace py = boost::python;
+
+struct PySwigObject {
+  PyObject_HEAD void *ptr;
+  const char *desc;
+};
+
+// Unwrapping SWIG pointer from
+// https://wiki.python.org/moin/boost.python/HowTo#SWIG_exposed_C.2B-.2B-_object_from_Python
+void *extract_swig_wrapped_pointer(PyObject *obj) {
+  char thisStr[] = "this";
+  // first we need to get the this attribute from the Python Object
+  if (!PyObject_HasAttrString(obj, thisStr)) return NULL;
+
+  PyObject *thisAttr = PyObject_GetAttrString(obj, thisStr);
+  if (thisAttr == NULL) return NULL;
+  // This Python Object is a SWIG Wrapper and contains our pointer
+  void *pointer = ((PySwigObject *)thisAttr)->ptr;
+  Py_DECREF(thisAttr);
+  return pointer;
+}
+
+namespace dxtbx { namespace format { namespace boost_python {
+
+  /// Access the internal buffer and pass it to cbflib
+  py::object cbf_read_buffer(py::object handle, py::object data, int flags = 0) {
+    if (!PyBytes_Check(data.ptr())) {
+      PyErr_SetString(PyExc_ValueError, "buffer must be a bytes-like object");
+      py::throw_error_already_set();
+    }
+
+    // Extract the opaque CBF object from the SWIG wrapper
+    cbf_handle_struct *cbf_handle =
+      reinterpret_cast<cbf_handle_struct *>(extract_swig_wrapped_pointer(handle.ptr()));
+
+    int buffer_length = PyBytes_Size(data.ptr());
+    char *buffer = PyBytes_AsString(data.ptr());
+
+    int err = cbf_read_buffered_file(
+      cbf_handle, NULL /*nullptr*/, flags, buffer, buffer_length);
+
+    if (err) {
+      PyErr_Format(PyExc_RuntimeError, "cbflib read_file returned error %d", err);
+      py::throw_error_already_set();
+    }
+    return data;
+  }
+
+  /// Declare the cbf-reading classes
+  void export_cbf_read_buffer() {
+    using namespace boost::python;
+
+    def("cbf_read_buffer",
+        cbf_read_buffer,
+        args("handle", "data", "flags"),
+        "Open a buffer as a CBF file with CBFlib.\n\n"
+        "Args:\n"
+        "    handle (pycbf.cbf_handle_struct): The CBF handle object\n"
+        "    data (bytes): The data buffer containing the CBF file\n"
+        "    flags (int): The flags to pass to");
+  }
+}}}  // namespace dxtbx::format::boost_python

--- a/format/boost_python/cbf_read_buffer.h
+++ b/format/boost_python/cbf_read_buffer.h
@@ -1,0 +1,8 @@
+#ifndef CBF_READ_BUFFER_H
+#define CBF_READ_BUFFER_H
+
+namespace dxtbx { namespace format { namespace boost_python {
+  void export_cbf_read_buffer();
+}}}  // namespace dxtbx::format::boost_python
+
+#endif

--- a/format/boost_python/image_ext.cc
+++ b/format/boost_python/image_ext.cc
@@ -25,6 +25,8 @@
 #include <vector>
 #include <hdf5.h>
 
+#include "cbf_read_buffer.h"
+
 namespace dxtbx { namespace format { namespace boost_python {
 
   using namespace boost::python;
@@ -205,6 +207,8 @@ namespace dxtbx { namespace format { namespace boost_python {
     image_list_reader_suite<TIFFReader>("TIFFImageListReader");
     image_list_reader_suite<CBFFastReader>("CBFFastImageListReader");
     image_list_reader_suite<CBFReader>("CBFImageListReader");
+
+    export_cbf_read_buffer();
   }
 
 }}}  // namespace dxtbx::format::boost_python

--- a/newsfragments/72.feature
+++ b/newsfragments/72.feature
@@ -1,0 +1,1 @@
+Reading compressed FullCBF files - .gz or .bz2 - is now supported

--- a/tests/test_image_readers.py
+++ b/tests/test_image_readers.py
@@ -5,10 +5,13 @@ import os
 
 import dxtbx.ext
 import dxtbx.tests.imagelist
+import pycbf
 import pytest
 from dxtbx.format.FormatSMV import FormatSMV
-from dxtbx.format.image import CBFReader
+from dxtbx.format.image import CBFReader, cbf_read_buffer
 from scitbx.array_family import flex
+
+from dxtbx.model.detector import DetectorFactory
 
 
 def read_smv_image(image_file):
@@ -291,3 +294,16 @@ def test_hdf5(dials_regression, hdf5_image):
     assert data1.all()[1] == data2.all()[1]
     diff = flex.abs(data1 - data2)
     assert flex.max(diff) < 1e-7
+
+
+def test_cbf_buffer(dials_regression):
+    filename = os.path.join(
+        dials_regression, "image_examples", "dials-190", "whatev1_01_00001.cbf"
+    )
+    with open(filename, "rb") as f:
+        contents = f.read()
+
+    handle = pycbf.cbf_handle_struct()
+    cbf_read_buffer(handle, contents, pycbf.MSG_DIGEST)
+    det = DetectorFactory.imgCIF_H(handle, "unknown")
+    assert det


### PR DESCRIPTION
Previously, miniCBF files could be read from a gzipped/bzipped file, but
fullcbf files could not, because they passed the filename through to
cbflib.

This patch writes some custom cbflib interaction code and uses an API
call that is unexposed via pycbf to pass through a data buffer when a
compressed file is detected. It also reintroduces a limited form of a
test to compress regression image data and verify reading.

Fixes #72.