### PR TITLE
Clean dxtbx file headers

### DIFF
--- a/command_line/detector_superpose.py
+++ b/command_line/detector_superpose.py
@@ -1,14 +1,3 @@
-#!/usr/bin/env python
-#
-# cspad_detector_shifts.py
-#
-#  Copyright (C) 2016 Lawrence Berkeley National Laboratory (LBNL)
-#
-#  Author: Aaron Brewster
-#
-#  This code is distributed under the X license, a copy of which is
-#  included in the root directory of this package.
-#
 from __future__ import absolute_import, division, print_function
 
 from builtins import range

--- a/command_line/import_datablock.py
+++ b/command_line/import_datablock.py
@@ -1,13 +1,3 @@
-#!/usr/bin/env python
-#
-# import.py
-#
-#  Copyright (C) 2013 Diamond Light Source
-#
-#  Author: James Parkhurst
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
 from __future__ import absolute_import, division, print_function
 
 from dxtbx.datablock import DataBlockDumper, DataBlockFactory

--- a/command_line/plot_detector_models.py
+++ b/command_line/plot_detector_models.py
@@ -1,6 +1,6 @@
+# LIBTBX_PRE_DISPATCHER_INCLUDE_SH export PHENIX_GUI_ENVIRONMENT=1
 from __future__ import absolute_import, division, print_function
 
-# LIBTBX_PRE_DISPATCHER_INCLUDE_SH export PHENIX_GUI_ENVIRONMENT=1
 
 usage = """Plot dxtbx detector models. Provide multiple json files if desired
 Example: dxtbx.plot_detector_models datablock1.json datablock2.json

--- a/command_line/print_beam_centre.py
+++ b/command_line/print_beam_centre.py
@@ -1,16 +1,12 @@
+# LIBTBX_SET_DISPATCHER_NAME dev.dxtbx.print_beam_centre
+"""
+Print out the contents of the dxtbx understanding of a bunch of images to
+an example XDS.INP file. This should illustrate the usage of the dxtbx
+classes.
+"""
 from __future__ import absolute_import, division, print_function
 
 import sys
-
-#   Copyright (C) 2015 Diamond Light Source, Graeme Winter
-#
-#   This code is distributed under the BSD license, a copy of which is
-#   included in the root directory of this package.
-#
-# Print out the contents of the dxtbx understanding of a bunch of images to
-# an example XDS.INP file. This should illustrate the usage of the dxtbx
-# classes.
-# LIBTBX_SET_DISPATCHER_NAME dev.dxtbx.print_beam_centre
 
 
 def run(file_names):

--- a/command_line/read_sweep.py
+++ b/command_line/read_sweep.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 # LIBTBX_SET_DISPATCHER_NAME dev.dxtbx.read_sweep
 
 """Tool to benchmark overall time cost for simply reading data"""

--- a/command_line/read_sweep.py
+++ b/command_line/read_sweep.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # LIBTBX_SET_DISPATCHER_NAME dev.dxtbx.read_sweep
-# tool to benchmark overall time cost for simply reading data
+
+"""Tool to benchmark overall time cost for simply reading data"""
 
 from __future__ import absolute_import, division, print_function
 

--- a/command_line/serialize.py
+++ b/command_line/serialize.py
@@ -1,12 +1,5 @@
 from __future__ import absolute_import, division, print_function
 
-#  Copyright (C) 2013 Diamond Light Source
-#
-#  Author: James Parkhurst
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-
 if __name__ == "__main__":
     from optparse import OptionParser
     from dxtbx.serialize import dump

--- a/command_line/to_xds.py
+++ b/command_line/to_xds.py
@@ -1,11 +1,3 @@
-#!/usr/bin/env python
-# to_xds.py
-#
-#   Copyright (C) 2011 Diamond Light Source, Graeme Winter
-#
-#   This code is distributed under the BSD license, a copy of which is
-#   included in the root directory of this package.
-#
 """
 Print out the contents of the dxtbx understanding of a bunch of images to
 an example XDS.INP file. This should illustrate the usage of the dxtbx

--- a/command_line/to_xds.py
+++ b/command_line/to_xds.py
@@ -6,9 +6,12 @@
 #   This code is distributed under the BSD license, a copy of which is
 #   included in the root directory of this package.
 #
-# Print out the contents of the dxtbx understanding of a bunch of images to
-# an example XDS.INP file. This should illustrate the usage of the dxtbx
-# classes.
+"""
+Print out the contents of the dxtbx understanding of a bunch of images to
+an example XDS.INP file. This should illustrate the usage of the dxtbx
+classes.
+"""
+
 from __future__ import absolute_import, division, print_function
 
 import sys

--- a/example/resolution_corners.py
+++ b/example/resolution_corners.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 from __future__ import absolute_import, division, print_function
 
 # resolution_corners.py

--- a/example/resolution_corners.py
+++ b/example/resolution_corners.py
@@ -1,13 +1,6 @@
-from __future__ import absolute_import, division, print_function
+"""Print out the resolution (two-theta) of the corners of the detector"""
 
-# resolution_corners.py
-#
-#   Copyright (C) 2013 Diamond Light Source, Graeme Winter
-#
-#   This code is distributed under the BSD license, a copy of which is
-#   included in the root directory of this package.
-#
-# Print out the resolution (two-theta) of the corners of the detector
+from __future__ import absolute_import, division, print_function
 
 
 def resolution_corners(frame):

--- a/example/to_xds.py
+++ b/example/to_xds.py
@@ -1,15 +1,11 @@
 #!/usr/bin/env python
+"""
+Print out the contents of the dxtbx understanding of a bunch of images to
+an example XDS.INP file. This should illustrate the usage of the dxtbx
+classes.
+"""
 
 from __future__ import absolute_import, division, print_function
-
-#   Copyright (C) 2011 Diamond Light Source, Graeme Winter
-#
-#   This code is distributed under the BSD license, a copy of which is
-#   included in the root directory of this package.
-#
-# Print out the contents of the dxtbx understanding of a bunch of images to
-# an example XDS.INP file. This should illustrate the usage of the dxtbx
-# classes.
 
 from builtins import object
 

--- a/filecache.py
+++ b/filecache.py
@@ -1,37 +1,40 @@
-# A shared caching layer for file-like objects.
-# pseudo_file objects can be used as drop-in replacements for actual file
-# handles to provide a transparent caching layer to avoid reading multiple
-# times from disk or network.
-#
-# To create a pseudo_file instance, encapsulate a 'real' file handler
-# inside a lazy cache object:
-#   from dxtbx.filecache import lazy_file_cache
-#   cache = lazy_file_cache(open(filename, 'rb'))
-#
-# Finally use a reference to the cache object to create one or many pseudo_file
-# instances:
-#   fh1 = cache.open()
-#   from dxtbx.filecache import pseudo_file
-#   fh2 = pseudo_file(cache) # equivalent
-#   fh3 = pseudo_file(cache)
-#   ...
-#
-# Each pseudo_file instance can then be treated as a proper read-only
-# file handle, but will benefit from a shared cache:
-#   with cache.open() as fh:
-#     fh.read(100)
-#     fh.readline()
-#     fh.seek(500)
-#     fh.read()
-#     fh.readlines()
-#     fh.close()
-#
-# To flush the cache and free the memory you can use
-#     cache.close()
-# This will drop the cache when all associated file handles are closed.
-# To instantly drop the cache you can use
-#     cache.force_close()
-# Any further access attempts will then result in an exception.
+"""
+A shared caching layer for file-like objects.
+
+pseudo_file objects can be used as drop-in replacements for actual file
+handles to provide a transparent caching layer to avoid reading multiple
+times from disk or network.
+
+To create a pseudo_file instance, encapsulate a 'real' file handler
+inside a lazy cache object:
+  from dxtbx.filecache import lazy_file_cache
+  cache = lazy_file_cache(open(filename, 'rb'))
+
+Finally use a reference to the cache object to create one or many pseudo_file
+instances:
+  fh1 = cache.open()
+  from dxtbx.filecache import pseudo_file
+  fh2 = pseudo_file(cache) # equivalent
+  fh3 = pseudo_file(cache)
+  ...
+
+Each pseudo_file instance can then be treated as a proper read-only
+file handle, but will benefit from a shared cache:
+  with cache.open() as fh:
+    fh.read(100)
+    fh.readline()
+    fh.seek(500)
+    fh.read()
+    fh.readlines()
+    fh.close()
+
+To flush the cache and free the memory you can use
+    cache.close()
+This will drop the cache when all associated file handles are closed.
+To instantly drop the cache you can use
+    cache.force_close()
+Any further access attempts will then result in an exception.
+"""
 
 from __future__ import absolute_import, division, print_function
 from builtins import object

--- a/filecache_controller.py
+++ b/filecache_controller.py
@@ -1,4 +1,4 @@
-# A simple cache controller. Caching only one file at a time.
+"""A simple cache controller. Caching only one file at a time."""
 
 from __future__ import absolute_import, division, print_function
 

--- a/format/Format.py
+++ b/format/Format.py
@@ -1,9 +1,11 @@
-# A top-level class to represent image formats which does little else but
-# (i) establish an abstract class for what needs to be implemented and
-# (ii) include the format registration code for any image formats which
-# inherit from this. This will also contain links to the static methods
-# from the X(component)Factories which will allow construction of e.g.
-# goniometers etc. from the headers and hence a format specific factory.
+"""
+A top-level class to represent image formats which does little else but
+(i) establish an abstract class for what needs to be implemented and
+(ii) include the format registration code for any image formats which
+inherit from this. This will also contain links to the static methods
+from the X(component)Factories which will allow construction of e.g.
+goniometers etc. from the headers and hence a format specific factory.
+"""
 
 from __future__ import absolute_import, division, print_function
 

--- a/format/FormatBrukerFixedChi.py
+++ b/format/FormatBrukerFixedChi.py
@@ -1,10 +1,3 @@
-#!/usr/bin/env python
-# FormatBrukerFixedChi.py
-#   Copyright (C) 2016 Diamond Light Source, Graeme Winter
-#
-#   This code is distributed under the BSD license, a copy of which is
-#   included in the root directory of this package.
-
 from __future__ import absolute_import, division, print_function
 
 from builtins import range

--- a/format/FormatBrukerPhotonII.py
+++ b/format/FormatBrukerPhotonII.py
@@ -1,12 +1,3 @@
-#!/usr/bin/env python
-# FormatBrukerPhotonII.py
-#  Copyright (C) (2017) STFC Rutherford Appleton Laboratory, UK.
-#
-#  Author: David Waterman.
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-
 from __future__ import absolute_import, division, print_function
 
 import sys

--- a/format/FormatCBF.py
+++ b/format/FormatCBF.py
@@ -1,10 +1,3 @@
-#!/usr/bin/env python
-# FormatCBF.py
-#   Copyright (C) 2011 Diamond Light Source, Graeme Winter
-#
-#   This code is distributed under the BSD license, a copy of which is
-#   included in the root directory of this package.
-#
 """
 Base implementation of CBF formats - which is just really a place holder
 which will tell you whether something is a CBF file (or no.)

--- a/format/FormatCBF.py
+++ b/format/FormatCBF.py
@@ -5,8 +5,10 @@
 #   This code is distributed under the BSD license, a copy of which is
 #   included in the root directory of this package.
 #
-# Base implementation of CBF formats - which is just really a place holder
-# which will tell you whether something is a CBF file (or no.)
+"""
+Base implementation of CBF formats - which is just really a place holder
+which will tell you whether something is a CBF file (or no.)
+"""
 
 from __future__ import absolute_import, division, print_function
 

--- a/format/FormatCBFCspad.py
+++ b/format/FormatCBFCspad.py
@@ -1,4 +1,4 @@
-# Contains class methods specific to interacting with CSPAD images
+"""Methods specific to interacting with CSPAD images"""
 
 from __future__ import absolute_import, division, print_function
 

--- a/format/FormatCBFFull.py
+++ b/format/FormatCBFFull.py
@@ -1,9 +1,3 @@
-#!/usr/bin/env python
-#   Copyright (C) 2011 Diamond Light Source, Graeme Winter
-#
-#   This code is distributed under the BSD license, a copy of which is
-#   included in the root directory of this package.
-#
 """
 Base implementation of fullCBF format - as used with Dectris detectors
 amongst others - this will read the header and construct the full model,

--- a/format/FormatCBFFull.py
+++ b/format/FormatCBFFull.py
@@ -4,9 +4,11 @@
 #   This code is distributed under the BSD license, a copy of which is
 #   included in the root directory of this package.
 #
-# Base implementation of fullCBF format - as used with Dectris detectors
-# amongst others - this will read the header and construct the full model,
-# but will allow for extension for specific implementations of CBF.
+"""
+Base implementation of fullCBF format - as used with Dectris detectors
+amongst others - this will read the header and construct the full model,
+but will allow for extension for specific implementations of CBF.
+"""
 
 from __future__ import absolute_import, division, print_function
 

--- a/format/FormatCBFFullPilatus.py
+++ b/format/FormatCBFFullPilatus.py
@@ -5,7 +5,7 @@
 #   This code is distributed under the BSD license, a copy of which is
 #   included in the root directory of this package.
 #
-# Pilatus implementation of fullCBF format, for use with Dectris detectors.
+"""Pilatus implementation of fullCBF format, for use with Dectris detectors."""
 
 from __future__ import absolute_import, division, print_function
 

--- a/format/FormatCBFFullPilatus.py
+++ b/format/FormatCBFFullPilatus.py
@@ -1,10 +1,3 @@
-#!/usr/bin/env python
-# FormatCBFFullPilatus.py
-#   Copyright (C) 2011 Diamond Light Source, Graeme Winter
-#
-#   This code is distributed under the BSD license, a copy of which is
-#   included in the root directory of this package.
-#
 """Pilatus implementation of fullCBF format, for use with Dectris detectors."""
 
 from __future__ import absolute_import, division, print_function

--- a/format/FormatCBFFullPilatusDLS300KSN104.py
+++ b/format/FormatCBFFullPilatusDLS300KSN104.py
@@ -1,11 +1,3 @@
-#!/usr/bin/env python
-# FormatCBFFullPilatusDLS300KSN104.py
-#
-#   Copyright (C) 2017 Diamond Light Source, Richard Gildea
-#
-#   This code is distributed under the BSD license, a copy of which is
-#   included in the root directory of this package.
-
 from __future__ import absolute_import, division, print_function
 
 import math

--- a/format/FormatCBFFullPilatusDLS6MSN100.py
+++ b/format/FormatCBFFullPilatusDLS6MSN100.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 from __future__ import absolute_import, division, print_function
 
 import sys

--- a/format/FormatCBFMini.py
+++ b/format/FormatCBFMini.py
@@ -1,10 +1,3 @@
-#!/usr/bin/env python
-# FormatCBFMini.py
-#   Copyright (C) 2011 Diamond Light Source, Graeme Winter
-#
-#   This code is distributed under the BSD license, a copy of which is
-#   included in the root directory of this package.
-#
 """
 Base implementation of miniCBF format - as used with Dectris detectors -
 this will read the header and populate a dictionary of the keyword / value

--- a/format/FormatCBFMini.py
+++ b/format/FormatCBFMini.py
@@ -5,9 +5,11 @@
 #   This code is distributed under the BSD license, a copy of which is
 #   included in the root directory of this package.
 #
-# Base implementation of miniCBF format - as used with Dectris detectors -
-# this will read the header and populate a dictionary of the keyword / value
-# pairs.
+"""
+Base implementation of miniCBF format - as used with Dectris detectors -
+this will read the header and populate a dictionary of the keyword / value
+pairs.
+"""
 
 from __future__ import absolute_import, division, print_function
 

--- a/format/FormatCBFMiniADSCHF4M.py
+++ b/format/FormatCBFMiniADSCHF4M.py
@@ -5,9 +5,12 @@
 #   This code is distributed under the BSD license, a copy of which is
 #   included in the root directory of this package.
 #
-# An implementation of the CBF image reader for ADSC images, from the ADSC
-# HF-4M SN H401 currently on APS sector 24 (NE-CAT).
-# Located in dxtbx/format
+
+"""
+An implementation of the CBF image reader for ADSC images, from the ADSC
+HF-4M SN H401 currently on APS sector 24 (NE-CAT).
+Located in dxtbx/format
+"""
 
 from __future__ import absolute_import, division, print_function
 

--- a/format/FormatCBFMiniADSCHF4M.py
+++ b/format/FormatCBFMiniADSCHF4M.py
@@ -1,11 +1,3 @@
-#!/usr/bin/env python
-# FormatCBFMiniADSCHF4M.py
-#   Copyright (C) 2014 Diamond Light Source, Graeme Winter
-#
-#   This code is distributed under the BSD license, a copy of which is
-#   included in the root directory of this package.
-#
-
 """
 An implementation of the CBF image reader for ADSC images, from the ADSC
 HF-4M SN H401 currently on APS sector 24 (NE-CAT).

--- a/format/FormatCBFMiniEiger.py
+++ b/format/FormatCBFMiniEiger.py
@@ -5,8 +5,7 @@
 #   This code is distributed under the BSD license, a copy of which is
 #   included in the root directory of this package.
 #
-# An implementation of the CBF image reader for Eiger images. Inherits from
-# FormatCBFMini.
+"""An implementation of the CBF image reader for Eiger images"""
 
 from __future__ import absolute_import, division, print_function
 

--- a/format/FormatCBFMiniEiger.py
+++ b/format/FormatCBFMiniEiger.py
@@ -1,10 +1,3 @@
-#!/usr/bin/env python
-# FormatCBFMiniEiger.py
-#   Copyright (C) 2011 Diamond Light Source, Graeme Winter
-#
-#   This code is distributed under the BSD license, a copy of which is
-#   included in the root directory of this package.
-#
 """An implementation of the CBF image reader for Eiger images"""
 
 from __future__ import absolute_import, division, print_function

--- a/format/FormatCBFMiniEigerMaxIVBio.py
+++ b/format/FormatCBFMiniEigerMaxIVBio.py
@@ -1,9 +1,3 @@
-#!/usr/bin/env python
-#  Author: Nick Sauter.
-#
-#   This code is distributed under the BSD license, a copy of which is
-#   included in the root directory of this package.
-#
 """
 An implementation of the FormatCBFMiniEiger image reader for the Eiger16M
 detector at the MaxIV BioMAX beamline, which has a vertical goniometer.

--- a/format/FormatCBFMiniEigerMaxIVBio.py
+++ b/format/FormatCBFMiniEigerMaxIVBio.py
@@ -4,9 +4,10 @@
 #   This code is distributed under the BSD license, a copy of which is
 #   included in the root directory of this package.
 #
-# An implementation of the FormatCBFMiniEiger image reader for the Eiger16M
-# detector at the MaxIV BioMAX beamline, which has a vertical goniometer.
-
+"""
+An implementation of the FormatCBFMiniEiger image reader for the Eiger16M
+detector at the MaxIV BioMAX beamline, which has a vertical goniometer.
+"""
 from __future__ import absolute_import, division, print_function
 
 from dxtbx.format.FormatCBFMiniEiger import FormatCBFMiniEiger

--- a/format/FormatCBFMiniEigerPetraP14.py
+++ b/format/FormatCBFMiniEigerPetraP14.py
@@ -1,9 +1,3 @@
-#!/usr/bin/env python
-#   Copyright (C) 2018 Diamond Light Source, Graeme Winter
-#
-#   This code is distributed under the BSD license, a copy of which is
-#   included in the root directory of this package.
-#
 """An implementation of the CBF image reader for Eiger images"""
 
 from __future__ import absolute_import, division, print_function

--- a/format/FormatCBFMiniEigerPetraP14.py
+++ b/format/FormatCBFMiniEigerPetraP14.py
@@ -4,8 +4,7 @@
 #   This code is distributed under the BSD license, a copy of which is
 #   included in the root directory of this package.
 #
-# An implementation of the CBF image reader for Eiger images. Inherits from
-# FormatCBFMiniEiger.
+"""An implementation of the CBF image reader for Eiger images"""
 
 from __future__ import absolute_import, division, print_function
 

--- a/format/FormatCBFMiniEigerPhotonFactory.py
+++ b/format/FormatCBFMiniEigerPhotonFactory.py
@@ -6,8 +6,6 @@ import os
 
 from dxtbx.format.FormatCBFMini import FormatCBFMini
 
-# from dxtbx.format.FormatPilatusHelpers import determine_pilatus_mask
-
 
 class FormatCBFMiniEigerPhotonFactory(FormatCBFMini):
     """A class for reading mini CBF format Eiger images, and correctly

--- a/format/FormatCBFMiniEigerPhotonFactory.py
+++ b/format/FormatCBFMiniEigerPhotonFactory.py
@@ -5,8 +5,7 @@
 #   This code is distributed under the BSD license, a copy of which is
 #   included in the root directory of this package.
 #
-# An implementation of the CBF image reader for Eiger images. Inherits from
-# FormatCBFMini.
+"""An implementation of the CBF image reader for Eiger images"""
 
 from __future__ import absolute_import, division, print_function
 

--- a/format/FormatCBFMiniEigerPhotonFactory.py
+++ b/format/FormatCBFMiniEigerPhotonFactory.py
@@ -1,10 +1,3 @@
-#!/usr/bin/env python
-# FormatCBFMiniEigerPhotonFactory.py
-#   Copyright (C) 2015 Diamond Light Source, Richard Gildea
-#
-#   This code is distributed under the BSD license, a copy of which is
-#   included in the root directory of this package.
-#
 """An implementation of the CBF image reader for Eiger images"""
 
 from __future__ import absolute_import, division, print_function

--- a/format/FormatCBFMiniPilatus.py
+++ b/format/FormatCBFMiniPilatus.py
@@ -5,8 +5,7 @@
 #   This code is distributed under the BSD license, a copy of which is
 #   included in the root directory of this package.
 #
-# An implementation of the CBF image reader for Pilatus images. Inherits from
-# FormatCBFMini.
+"""An implementation of the CBF image reader for Pilatus images"""
 
 from __future__ import absolute_import, division, print_function
 

--- a/format/FormatCBFMiniPilatus.py
+++ b/format/FormatCBFMiniPilatus.py
@@ -1,10 +1,3 @@
-#!/usr/bin/env python
-# FormatCBFMiniPilatus.py
-#   Copyright (C) 2011 Diamond Light Source, Graeme Winter
-#
-#   This code is distributed under the BSD license, a copy of which is
-#   included in the root directory of this package.
-#
 """An implementation of the CBF image reader for Pilatus images"""
 
 from __future__ import absolute_import, division, print_function

--- a/format/FormatCBFMiniPilatus3APS19ID6MSN132.py
+++ b/format/FormatCBFMiniPilatus3APS19ID6MSN132.py
@@ -1,11 +1,3 @@
-#!/usr/bin/env python
-# FormatCBFMiniPilatus3AOS19ID6MSN132.py
-#   Copyright (C) 2016 Diamond Light Source, Graeme Winter
-#
-#   This code is distributed under the BSD license, a copy of which is
-#   included in the root directory of this package.
-#
-
 from __future__ import absolute_import, division, print_function
 
 from dxtbx.format.FormatCBFMiniPilatus import FormatCBFMiniPilatus

--- a/format/FormatCBFMiniPilatusCHESS_6MSN127.py
+++ b/format/FormatCBFMiniPilatusCHESS_6MSN127.py
@@ -1,10 +1,3 @@
-#!/usr/bin/env python
-# FormatCBFMiniPilatusCHESS_6MSN127.py
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-#
-
 from __future__ import absolute_import, division, print_function
 
 from dxtbx.format.FormatCBFMiniPilatus import FormatCBFMiniPilatus

--- a/format/FormatCBFMiniPilatusDESY6MSN115.py
+++ b/format/FormatCBFMiniPilatusDESY6MSN115.py
@@ -8,8 +8,10 @@
 #   This code is distributed under the BSD license, a copy of which is
 #   included in the root directory of this package.
 #
-# An implementation of the FormatCBFMiniPilatus image reader for the P6M
-# detector at PETRA III beamline P14, which has a vertical goniometer.
+"""
+An implementation of the FormatCBFMiniPilatus image reader for the P6M
+detector at PETRA III beamline P14, which has a vertical goniometer.
+"""
 
 from __future__ import absolute_import, division, print_function
 

--- a/format/FormatCBFMiniPilatusDESY6MSN115.py
+++ b/format/FormatCBFMiniPilatusDESY6MSN115.py
@@ -1,13 +1,3 @@
-#!/usr/bin/env python
-# FormatCBFMiniPilatusDESY6MSN115.py
-#
-#  Copyright (C) (2016) STFC Rutherford Appleton Laboratory, UK.
-#
-#  Author: David Waterman.
-#
-#   This code is distributed under the BSD license, a copy of which is
-#   included in the root directory of this package.
-#
 """
 An implementation of the FormatCBFMiniPilatus image reader for the P6M
 detector at PETRA III beamline P14, which has a vertical goniometer.

--- a/format/FormatCBFMiniPilatusDLS12M.py
+++ b/format/FormatCBFMiniPilatusDLS12M.py
@@ -1,11 +1,3 @@
-#!/usr/bin/env python
-# FormatCBFMiniPilatusDLS12M.py
-#
-#   Copyright (C) 2014 Diamond Light Source, Graeme Winter
-#
-#   This code is distributed under the BSD license, a copy of which is
-#   included in the root directory of this package.
-#
 """An implementation of the CBF image reader for Pilatus images, for the P12M-DLS"""
 
 from __future__ import absolute_import, division, print_function

--- a/format/FormatCBFMiniPilatusDLS12M.py
+++ b/format/FormatCBFMiniPilatusDLS12M.py
@@ -6,7 +6,7 @@
 #   This code is distributed under the BSD license, a copy of which is
 #   included in the root directory of this package.
 #
-# An implementation of the CBF image reader for Pilatus images, for the P12M-DLS
+"""An implementation of the CBF image reader for Pilatus images, for the P12M-DLS"""
 
 from __future__ import absolute_import, division, print_function
 

--- a/format/FormatCBFMiniPilatusDLS6MSN100.py
+++ b/format/FormatCBFMiniPilatusDLS6MSN100.py
@@ -5,8 +5,10 @@
 #   This code is distributed under the BSD license, a copy of which is
 #   included in the root directory of this package.
 #
-# An implementation of the CBF image reader for Pilatus images, from the Pilatus
-# 6M SN 100 currently on Diamond I04.
+"""
+An implementation of the CBF image reader for Pilatus images, from the Pilatus
+6M SN 100 currently on Diamond I04.
+"""
 
 from __future__ import absolute_import, division, print_function
 

--- a/format/FormatCBFMiniPilatusDLS6MSN100.py
+++ b/format/FormatCBFMiniPilatusDLS6MSN100.py
@@ -1,10 +1,3 @@
-#!/usr/bin/env python
-# FormatCBFMiniPilatusDLS6MSN100.py
-#   Copyright (C) 2014 Diamond Light Source, Graeme Winter
-#
-#   This code is distributed under the BSD license, a copy of which is
-#   included in the root directory of this package.
-#
 """
 An implementation of the CBF image reader for Pilatus images, from the Pilatus
 6M SN 100 currently on Diamond I04.

--- a/format/FormatCBFMiniPilatusDLS6MSN114.py
+++ b/format/FormatCBFMiniPilatusDLS6MSN114.py
@@ -1,10 +1,3 @@
-#!/usr/bin/env python
-# FormatCBFMiniPilatusDLS6MSN114.py
-#   Copyright (C) 2014 Diamond Light Source, Graeme Winter
-#
-#   This code is distributed under the BSD license, a copy of which is
-#   included in the root directory of this package.
-#
 """
 An implementation of the CBF image reader for Pilatus images, from the Pilatus
 6M SN 114 currently on Diamond VMXi.

--- a/format/FormatCBFMiniPilatusDLS6MSN114.py
+++ b/format/FormatCBFMiniPilatusDLS6MSN114.py
@@ -5,9 +5,10 @@
 #   This code is distributed under the BSD license, a copy of which is
 #   included in the root directory of this package.
 #
-# An implementation of the CBF image reader for Pilatus images, from the Pilatus
-# 6M SN 114 currently on Diamond VMXi.
-
+"""
+An implementation of the CBF image reader for Pilatus images, from the Pilatus
+6M SN 114 currently on Diamond VMXi.
+"""
 from __future__ import absolute_import, division, print_function
 
 from dxtbx.format.FormatCBFMiniPilatus import FormatCBFMiniPilatus

--- a/format/FormatCBFMiniPilatusDLS6MSN114DMM.py
+++ b/format/FormatCBFMiniPilatusDLS6MSN114DMM.py
@@ -5,8 +5,10 @@
 #   This code is distributed under the BSD license, a copy of which is
 #   included in the root directory of this package.
 #
-# An implementation of the CBF image reader for Pilatus images, from the Pilatus
-# 6M SN 100 currently on Diamond I04.
+"""
+An implementation of the CBF image reader for Pilatus images, from the Pilatus
+6M SN 100 currently on Diamond I04.
+"""
 
 from __future__ import absolute_import, division, print_function
 

--- a/format/FormatCBFMiniPilatusDLS6MSN114DMM.py
+++ b/format/FormatCBFMiniPilatusDLS6MSN114DMM.py
@@ -1,10 +1,3 @@
-#!/usr/bin/env python
-# FormatCBFMiniPilatusDLS6MSN100.py
-#   Copyright (C) 2014 Diamond Light Source, Graeme Winter
-#
-#   This code is distributed under the BSD license, a copy of which is
-#   included in the root directory of this package.
-#
 """
 An implementation of the CBF image reader for Pilatus images, from the Pilatus
 6M SN 100 currently on Diamond I04.

--- a/format/FormatCBFMiniPilatusDLS6MSN119.py
+++ b/format/FormatCBFMiniPilatusDLS6MSN119.py
@@ -5,8 +5,10 @@
 #   This code is distributed under the BSD license, a copy of which is
 #   included in the root directory of this package.
 #
-# An implementation of the CBF image reader for Pilatus images, from the Pilatus
-# 6M SN 119 currently on Diamond I24.
+"""
+An implementation of the CBF image reader for Pilatus images, from the Pilatus
+6M SN 119 currently on Diamond I24.
+"""
 
 from __future__ import absolute_import, division, print_function
 

--- a/format/FormatCBFMiniPilatusDLS6MSN119.py
+++ b/format/FormatCBFMiniPilatusDLS6MSN119.py
@@ -1,10 +1,3 @@
-#!/usr/bin/env python
-# FormatCBFMiniPilatusDLS6MSN119.py
-#   Copyright (C) 2014 Diamond Light Source, Graeme Winter
-#
-#   This code is distributed under the BSD license, a copy of which is
-#   included in the root directory of this package.
-#
 """
 An implementation of the CBF image reader for Pilatus images, from the Pilatus
 6M SN 119 currently on Diamond I24.

--- a/format/FormatCBFMiniPilatusDLS6MSN126.py
+++ b/format/FormatCBFMiniPilatusDLS6MSN126.py
@@ -1,9 +1,3 @@
-#!/usr/bin/env python
-#   Copyright (C) 2014 Diamond Light Source, Graeme Winter
-#
-#   This code is distributed under the BSD license, a copy of which is
-#   included in the root directory of this package.
-#
 """
 An implementation of the CBF image reader for Pilatus images, from the Pilatus
 6M SN 100 currently on Diamond I03.

--- a/format/FormatCBFMiniPilatusDLS6MSN126.py
+++ b/format/FormatCBFMiniPilatusDLS6MSN126.py
@@ -4,8 +4,10 @@
 #   This code is distributed under the BSD license, a copy of which is
 #   included in the root directory of this package.
 #
-# An implementation of the CBF image reader for Pilatus images, from the Pilatus
-# 6M SN 100 currently on Diamond I03.
+"""
+An implementation of the CBF image reader for Pilatus images, from the Pilatus
+6M SN 100 currently on Diamond I03.
+"""
 
 from __future__ import absolute_import, division, print_function
 

--- a/format/FormatCBFMiniPilatusHelpers.py
+++ b/format/FormatCBFMiniPilatusHelpers.py
@@ -1,12 +1,6 @@
-from __future__ import absolute_import, division, print_function
+"""Helpers for FormatCBFMiniPilatus..."""
 
-# FormatCBFMiniPilatus.py
-#   Copyright (C) 2011 Diamond Light Source, Graeme Winter
-#
-#   This code is distributed under the BSD license, a copy of which is
-#   included in the root directory of this package.
-#
-# Helpers for FormatCBFMiniPilatus...
+from __future__ import absolute_import, division, print_function
 
 import calendar
 import time

--- a/format/FormatCBFMiniPilatusSOLEILPX16MSN106.py
+++ b/format/FormatCBFMiniPilatusSOLEILPX16MSN106.py
@@ -5,7 +5,7 @@
 #   This code is distributed under the BSD license, a copy of which is
 #   included in the root directory of this package.
 #
-# Set up for Soleil PX1, with full kappa goniometer
+"""Set up for Soleil PX1, with full kappa goniometer"""
 
 from __future__ import absolute_import, division, print_function
 

--- a/format/FormatCBFMiniPilatusSOLEILPX16MSN106.py
+++ b/format/FormatCBFMiniPilatusSOLEILPX16MSN106.py
@@ -4,9 +4,6 @@ from __future__ import absolute_import, division, print_function
 
 from dxtbx.format.FormatCBFMiniPilatus import FormatCBFMiniPilatus
 
-# from dxtbx.model import ParallaxCorrectedPxMmStrategy
-# from dxtbx.format.FormatPilatusHelpers import determine_pilatus_mask
-
 
 class FormatCBFMiniPilatusSOLEILPX16MSN106(FormatCBFMiniPilatus):
     """A class for reading mini CBF format Pilatus images for 6M SN 106 @

--- a/format/FormatCBFMiniPilatusSOLEILPX16MSN106.py
+++ b/format/FormatCBFMiniPilatusSOLEILPX16MSN106.py
@@ -1,10 +1,3 @@
-#!/usr/bin/env python
-# FormatCBFMiniPilatusSOLEILPX16MSN106.py
-#   Copyright (C) 2014 Diamond Light Source, Graeme Winter
-#
-#   This code is distributed under the BSD license, a copy of which is
-#   included in the root directory of this package.
-#
 """Set up for Soleil PX1, with full kappa goniometer"""
 
 from __future__ import absolute_import, division, print_function

--- a/format/FormatCBFMiniPilatusSPring8_6MSN125.py
+++ b/format/FormatCBFMiniPilatusSPring8_6MSN125.py
@@ -1,14 +1,3 @@
-#!/usr/bin/env python
-# FormatCBFMiniPilatusSPring8_6MSN125.py
-#
-#  Copyright (C) (2015) STFC Rutherford Appleton Laboratory, UK.
-#
-#  Author: David Waterman.
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-#
-
 from __future__ import absolute_import, division, print_function
 
 from dxtbx.format.FormatCBFMiniPilatus import FormatCBFMiniPilatus

--- a/format/FormatCBFMiniPilatusSPring8_6MSN125.py
+++ b/format/FormatCBFMiniPilatusSPring8_6MSN125.py
@@ -2,9 +2,6 @@ from __future__ import absolute_import, division, print_function
 
 from dxtbx.format.FormatCBFMiniPilatus import FormatCBFMiniPilatus
 
-# from dxtbx.model import ParallaxCorrectedPxMmStrategy
-# from dxtbx.format.FormatPilatusHelpers import determine_pilatus_mask
-
 
 class FormatCBFMiniPilatusSPring8_6MSN125(FormatCBFMiniPilatus):
     """A class for reading mini CBF format Pilatus images for 6M SN 125, normally

--- a/format/FormatCBFMiniPilatusXXX.py
+++ b/format/FormatCBFMiniPilatusXXX.py
@@ -3,8 +3,10 @@
 #   This code is distributed under the BSD license, a copy of which is
 #   included in the root directory of this package.
 #
-# An implementation of the CBF image reader for Pilatus images, from the Pilatus
-# 6M SN 100 currently on Diamond I04.
+"""
+An implementation of the CBF image reader for Pilatus images, from the Pilatus
+6M SN 100 currently on Diamond I04.
+"""
 
 from __future__ import absolute_import, division, print_function
 

--- a/format/FormatCBFMiniPilatusXXX.py
+++ b/format/FormatCBFMiniPilatusXXX.py
@@ -1,8 +1,3 @@
-#   Copyright (C) 2014 Diamond Light Source, Graeme Winter
-#
-#   This code is distributed under the BSD license, a copy of which is
-#   included in the root directory of this package.
-#
 """
 An implementation of the CBF image reader for Pilatus images, from the Pilatus
 6M SN 100 currently on Diamond I04.

--- a/format/FormatCBFMultiTile.py
+++ b/format/FormatCBFMultiTile.py
@@ -1,5 +1,4 @@
-# Reads a multi-tile CBF image, discovering its detector geometry
-# automatically
+"""Reads a multi-tile CBF image, discovering its detector geometry automatically"""
 
 from __future__ import absolute_import, division, print_function
 

--- a/format/FormatCBFMultiTileHierarchy.py
+++ b/format/FormatCBFMultiTileHierarchy.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# FormatCBFMultiTileHierarchy.py
-#
 """
 Reads a multi-tile CBF image, discovering it's detector geometery
 automatically, and builds a hierarchy if present

--- a/format/FormatCBFMultiTileHierarchy.py
+++ b/format/FormatCBFMultiTileHierarchy.py
@@ -1,11 +1,10 @@
 #!/usr/bin/env python
 # FormatCBFMultiTileHierarchy.py
 #
-# Reads a multi-tile CBF image, discovering it's detector geometery
-# automatically, and builds a hierarchy if present
-#
-# $Id:
-#
+"""
+Reads a multi-tile CBF image, discovering it's detector geometery
+automatically, and builds a hierarchy if present
+"""
 
 from __future__ import absolute_import, division, print_function
 

--- a/format/FormatEDFALS733.py
+++ b/format/FormatEDFALS733.py
@@ -1,4 +1,4 @@
-# Implementation of an ImageFormat class to read MarIP-format image
+"""Implementation of an ImageFormat class to read MarIP-format image"""
 
 from __future__ import absolute_import, division, print_function
 

--- a/format/FormatEigerStream.py
+++ b/format/FormatEigerStream.py
@@ -7,9 +7,6 @@ from dxtbx.format.Format import Format
 from dxtbx.format.FormatMultiImage import FormatMultiImage
 
 injected_data = {}
-# import dlstbx.eiger_stream.data
-# injected_data = dlstbx.eiger_stream.data.valid_things
-# injected_data = dlstbx.eiger_stream.data.invalid_things
 
 
 class FormatEigerStream(FormatMultiImage, Format):

--- a/format/FormatGatanDM4.py
+++ b/format/FormatGatanDM4.py
@@ -1,5 +1,7 @@
-# Experimental format for Gatan Digital Micrograph DM4 files. See
-# http://www.er-c.org/cbb/info/dmformat/
+"""
+Experimental format for Gatan Digital Micrograph DM4 files. See
+http://www.er-c.org/cbb/info/dmformat/
+"""
 
 from __future__ import absolute_import, division, print_function
 

--- a/format/FormatHDF5EigerNearlyNexus.py
+++ b/format/FormatHDF5EigerNearlyNexus.py
@@ -1,14 +1,3 @@
-#!/usr/bin/env python
-#
-# FormatNexus.py
-#
-#  Copyright (C) 2013 Diamond Light Source
-#
-#  Author: James Parkhurst
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-
 from __future__ import absolute_import, division, print_function
 
 from builtins import range

--- a/format/FormatHDF5Lambda.py
+++ b/format/FormatHDF5Lambda.py
@@ -8,8 +8,10 @@
 #   This code is distributed under the BSD license, a copy of which is
 #   included in the root directory of this package.
 #
-# Experimental format for the X-Spectrum LAMBDA detector
-# http://www.x-spectrum.de/
+"""
+Experimental format for the X-Spectrum LAMBDA detector
+http://www.x-spectrum.de/
+"""
 
 from __future__ import absolute_import, division, print_function
 

--- a/format/FormatHDF5Lambda.py
+++ b/format/FormatHDF5Lambda.py
@@ -1,13 +1,3 @@
-#!/usr/bin/env python
-# FormatHDF5Lambda.py
-#
-#  Copyright (C) (2016) STFC Rutherford Appleton Laboratory, UK.
-#
-#  Author: David Waterman.
-#
-#   This code is distributed under the BSD license, a copy of which is
-#   included in the root directory of this package.
-#
 """
 Experimental format for the X-Spectrum LAMBDA detector
 http://www.x-spectrum.de/

--- a/format/FormatHDF5PAL.py
+++ b/format/FormatHDF5PAL.py
@@ -1,10 +1,9 @@
-from __future__ import absolute_import, division, print_function
-
-from dxtbx.format.FormatHDF5 import FormatHDF5
-
 """
 Format class for the PAL XFEL raw data format
 """
+from __future__ import absolute_import, division, print_function
+
+from dxtbx.format.FormatHDF5 import FormatHDF5
 
 
 class FormatHDF5PAL(FormatHDF5):

--- a/format/FormatMarIP.py
+++ b/format/FormatMarIP.py
@@ -1,4 +1,4 @@
-# Implementation of an ImageFormat class to read MarIP-format image
+"""An ImageFormat class to read MarIP-format image"""
 
 from __future__ import absolute_import, division, print_function
 

--- a/format/FormatNexusExternalDataFile.py
+++ b/format/FormatNexusExternalDataFile.py
@@ -1,14 +1,3 @@
-#!/usr/bin/env python
-#
-# FormatNexusExternalDataFile.py
-#
-#  Copyright (C) 2013 Diamond Light Source
-#
-#  Author: James Parkhurst
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-
 from __future__ import absolute_import, division, print_function
 
 from dxtbx.format.FormatHDF5 import FormatHDF5

--- a/format/FormatPY.py
+++ b/format/FormatPY.py
@@ -1,4 +1,4 @@
-# Implementation of a base class to read a pickled Python dictionary.
+"""Implementation of a base class to read a pickled Python dictionary."""
 
 from __future__ import absolute_import, division, print_function
 

--- a/format/FormatPilatusHelpers.py
+++ b/format/FormatPilatusHelpers.py
@@ -1,13 +1,14 @@
-from __future__ import absolute_import, division, print_function
-
 #   Copyright (C) 2011 Diamond Light Source, Graeme Winter
 #
 #   This code is distributed under the BSD license, a copy of which is
 #   included in the root directory of this package.
 #
-# Helper methods for class for working with Pilatus images, for instance for
-# identifying the regions to be masked.
+"""
+Helper methods for class for working with Pilatus images, for instance for
+identifying the regions to be masked.
+"""
 
+from __future__ import absolute_import, division, print_function
 
 from builtins import range
 

--- a/format/FormatPilatusHelpers.py
+++ b/format/FormatPilatusHelpers.py
@@ -1,8 +1,3 @@
-#   Copyright (C) 2011 Diamond Light Source, Graeme Winter
-#
-#   This code is distributed under the BSD license, a copy of which is
-#   included in the root directory of this package.
-#
 """
 Helper methods for class for working with Pilatus images, for instance for
 identifying the regions to be masked.

--- a/format/FormatRAXISIVSpring8.py
+++ b/format/FormatRAXISIVSpring8.py
@@ -1,11 +1,3 @@
-#  Copyright (C) (2015) STFC Rutherford Appleton Laboratory, UK.
-#
-#  Author: David Waterman.
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-#
-
 from __future__ import absolute_import, division, print_function
 
 import calendar

--- a/format/FormatSER.py
+++ b/format/FormatSER.py
@@ -7,8 +7,10 @@
 #   This code is distributed under the BSD license, a copy of which is
 #   included in the root directory of this package.
 #
-# Experimental format for TIA .ser files used by some FEI microscopes. See
-# http://www.er-c.org/cbb/info/TIAformat/
+"""
+Experimental format for TIA .ser files used by some FEI microscopes. See
+http://www.er-c.org/cbb/info/TIAformat/
+"""
 
 from __future__ import absolute_import, division, print_function
 

--- a/format/FormatSER.py
+++ b/format/FormatSER.py
@@ -1,12 +1,3 @@
-#!/usr/bin/env python
-#
-#  Copyright (C) (2017) STFC Rutherford Appleton Laboratory, UK.
-#
-#  Author: David Waterman.
-#
-#   This code is distributed under the BSD license, a copy of which is
-#   included in the root directory of this package.
-#
 """
 Experimental format for TIA .ser files used by some FEI microscopes. See
 http://www.er-c.org/cbb/info/TIAformat/

--- a/format/FormatSEReBIC.py
+++ b/format/FormatSEReBIC.py
@@ -1,12 +1,3 @@
-#!/usr/bin/env python
-#
-#  Copyright (C) (2017) STFC Rutherford Appleton Laboratory, UK.
-#
-#  Author: David Waterman.
-#
-#   This code is distributed under the BSD license, a copy of which is
-#   included in the root directory of this package.
-#
 """Experimental format for TIA .ser files used by FEI microscope at eBIC."""
 
 from __future__ import absolute_import, division, print_function

--- a/format/FormatSEReBIC.py
+++ b/format/FormatSEReBIC.py
@@ -7,7 +7,7 @@
 #   This code is distributed under the BSD license, a copy of which is
 #   included in the root directory of this package.
 #
-# Experimental format for TIA .ser files used by FEI microscope at eBIC.
+"""Experimental format for TIA .ser files used by FEI microscope at eBIC."""
 
 from __future__ import absolute_import, division, print_function
 

--- a/format/FormatSMV.py
+++ b/format/FormatSMV.py
@@ -3,11 +3,15 @@
 #   This code is distributed under the BSD license, a copy of which is
 #   included in the root directory of this package.
 #
-# Implementation of an ImageFormat class to read SMV format image but not -
-# in the first instance - actually provide a full image representation. This
-# is simply there to set everything up for the ADSC and Rigaku Saturn image
-# readers which really will acquire the full image including header information
-# and generate the experimental model representations.
+"""
+Implementation of an ImageFormat class to read SMV format image
+
+but not - in the first instance - actually provide a full image
+representation. This is simply there to set everything up for the ADSC
+and Rigaku Saturn image readers which really will acquire the full image
+including header information and generate the experimental model
+representations.
+"""
 
 from __future__ import absolute_import, division, print_function
 

--- a/format/FormatSMV.py
+++ b/format/FormatSMV.py
@@ -1,8 +1,3 @@
-#   Copyright (C) 2011 Diamond Light Source, Graeme Winter
-#
-#   This code is distributed under the BSD license, a copy of which is
-#   included in the root directory of this package.
-#
 """
 Implementation of an ImageFormat class to read SMV format image
 

--- a/format/FormatSMVADSC.py
+++ b/format/FormatSMVADSC.py
@@ -4,8 +4,7 @@
 #   This code is distributed under the BSD license, a copy of which is
 #   included in the root directory of this package.
 #
-# An implementation of the SMV image reader for ADSC images. Inherits from
-# FormatSMV.
+"""An implementation of the SMV image reader for ADSC images"""
 
 from __future__ import absolute_import, division, print_function
 

--- a/format/FormatSMVADSC.py
+++ b/format/FormatSMVADSC.py
@@ -1,9 +1,3 @@
-#!/usr/bin/env python
-#   Copyright (C) 2011 Diamond Light Source, Graeme Winter
-#
-#   This code is distributed under the BSD license, a copy of which is
-#   included in the root directory of this package.
-#
 """An implementation of the SMV image reader for ADSC images"""
 
 from __future__ import absolute_import, division, print_function

--- a/format/FormatSMVADSCDBG.py
+++ b/format/FormatSMVADSCDBG.py
@@ -1,10 +1,3 @@
-#!/usr/bin/env python
-# FormatSMVADSCDBG.py
-#   Copyright (C) 2013 LBNL, Aaron Brewster
-#
-#   This code is distributed under the BSD license, a copy of which is
-#   included in the root directory of this package.
-#
 """
 An implementation of the SMV image reader for pseudo "ADSC" images, converted
 from Pilatus images using iotbx debug_write.

--- a/format/FormatSMVADSCDBG.py
+++ b/format/FormatSMVADSCDBG.py
@@ -5,9 +5,10 @@
 #   This code is distributed under the BSD license, a copy of which is
 #   included in the root directory of this package.
 #
-# An implementation of the SMV image reader for pseudo "ADSC" images, converted
-# from Pilatus images using iotbx debug_write.
-
+"""
+An implementation of the SMV image reader for pseudo "ADSC" images, converted
+from Pilatus images using iotbx debug_write.
+"""
 from __future__ import absolute_import, division, print_function
 
 from dxtbx.format.FormatSMVADSC import FormatSMVADSC

--- a/format/FormatSMVADSCSN445.py
+++ b/format/FormatSMVADSCSN445.py
@@ -3,9 +3,11 @@
 #   This code is distributed under the BSD license, a copy of which is
 #   included in the root directory of this package.
 #
-# An implementation of the SMV image reader for ADSC images. Inherits from
-# FormatSMVADSC, customised for example on ALS beamline 8.2.1 from back in the
-# day which had it's own way of recording beam centre.
+"""
+An implementation of the SMV image reader for ADSC images. Inherits from
+FormatSMVADSC, customised for example on ALS beamline 8.2.1 from back in the
+day which had it's own way of recording beam centre.
+"""
 
 from __future__ import absolute_import, division, print_function
 

--- a/format/FormatSMVADSCSN445.py
+++ b/format/FormatSMVADSCSN445.py
@@ -1,8 +1,3 @@
-#   Copyright (C) 2011 Diamond Light Source, Graeme Winter
-#
-#   This code is distributed under the BSD license, a copy of which is
-#   included in the root directory of this package.
-#
 """
 An implementation of the SMV image reader for ADSC images. Inherits from
 FormatSMVADSC, customised for example on ALS beamline 8.2.1 from back in the

--- a/format/FormatSMVADSCSN457.py
+++ b/format/FormatSMVADSCSN457.py
@@ -1,8 +1,3 @@
-#   Copyright (C) 2011 Diamond Light Source, Graeme Winter
-#
-#   This code is distributed under the BSD license, a copy of which is
-#   included in the root directory of this package.
-#
 """
 An implementation of the SMV image reader for ADSC images. Inherits from
 FormatSMVADSC, customised for example on Australian Synchrotron SN 457

--- a/format/FormatSMVADSCSN457.py
+++ b/format/FormatSMVADSCSN457.py
@@ -3,9 +3,11 @@
 #   This code is distributed under the BSD license, a copy of which is
 #   included in the root directory of this package.
 #
-# An implementation of the SMV image reader for ADSC images. Inherits from
-# FormatSMVADSC, customised for example on Australian Synchrotron SN 457
-# which has reversed phi.
+"""
+An implementation of the SMV image reader for ADSC images. Inherits from
+FormatSMVADSC, customised for example on Australian Synchrotron SN 457
+which has reversed phi.
+"""
 
 from __future__ import absolute_import, division, print_function
 

--- a/format/FormatSMVADSCSN905.py
+++ b/format/FormatSMVADSCSN905.py
@@ -3,9 +3,11 @@
 #   This code is distributed under the BSD license, a copy of which is
 #   included in the root directory of this package.
 #
-# An implementation of the SMV image reader for ADSC images. Inherits from
-# FormatSMVADSC, customised for example on ALS beamline 8.2.2 from back in the
-# day which had it's own way of recording beam centre.
+"""
+An implementation of the SMV image reader for ADSC images. Inherits from
+FormatSMVADSC, customised for example on ALS beamline 8.2.2 from back in the
+day which had it's own way of recording beam centre.
+"""
 
 from __future__ import absolute_import, division, print_function
 

--- a/format/FormatSMVADSCSN905.py
+++ b/format/FormatSMVADSCSN905.py
@@ -1,8 +1,3 @@
-#   Copyright (C) 2015 Diamond Light Source, Richard Gildea
-#
-#   This code is distributed under the BSD license, a copy of which is
-#   included in the root directory of this package.
-#
 """
 An implementation of the SMV image reader for ADSC images. Inherits from
 FormatSMVADSC, customised for example on ALS beamline 8.2.2 from back in the

--- a/format/FormatSMVADSCSN915.py
+++ b/format/FormatSMVADSCSN915.py
@@ -5,9 +5,10 @@
 #  This code is distributed under the BSD license, a copy of which is
 #  included in the root directory of this package.
 #
-# ADSC SMV Format for Q315 SN 915, installed at BL38B1 at SPring-8. Resembles
-# but FormatSMVADSCSN920 but returns a reverse phi goniometer
-
+"""
+ADSC SMV Format for Q315 SN 915, installed at BL38B1 at SPring-8. Resembles
+but FormatSMVADSCSN920 but returns a reverse phi goniometer
+"""
 from __future__ import absolute_import, division, print_function
 
 from dxtbx.format.FormatSMVADSCSN import FormatSMVADSCSN

--- a/format/FormatSMVADSCSN915.py
+++ b/format/FormatSMVADSCSN915.py
@@ -1,10 +1,3 @@
-#  Copyright (C) (2014) STFC Rutherford Appleton Laboratory, UK.
-#
-#  Author: David Waterman.
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-#
 """
 ADSC SMV Format for Q315 SN 915, installed at BL38B1 at SPring-8. Resembles
 but FormatSMVADSCSN920 but returns a reverse phi goniometer

--- a/format/FormatSMVADSCSN920.py
+++ b/format/FormatSMVADSCSN920.py
@@ -1,7 +1,3 @@
-#   Copyright (C) 2014 Diamond Light Source, Graeme Winter
-#
-#   This code is distributed under the BSD license, a copy of which is
-#   included in the root directory of this package.
 """
 An implementation of the SMV image reader for ADSC images. Inherits from
 FormatSMVADSC, customised for old detector on Diamond Light Source I03,

--- a/format/FormatSMVADSCSN920.py
+++ b/format/FormatSMVADSCSN920.py
@@ -2,11 +2,11 @@
 #
 #   This code is distributed under the BSD license, a copy of which is
 #   included in the root directory of this package.
-#
-# An implementation of the SMV image reader for ADSC images. Inherits from
-# FormatSMVADSC, customised for old detector on Diamond Light Source I03,
-# correctly accounting for the image pedestal & similar
-
+"""
+An implementation of the SMV image reader for ADSC images. Inherits from
+FormatSMVADSC, customised for old detector on Diamond Light Source I03,
+correctly accounting for the image pedestal & similar
+"""
 from __future__ import absolute_import, division, print_function
 
 from dxtbx.format.FormatSMVADSCSN import FormatSMVADSCSN

--- a/format/FormatSMVADSCSN926.py
+++ b/format/FormatSMVADSCSN926.py
@@ -1,7 +1,3 @@
-#   Copyright (C) 2013 Diamond Light Source, Graeme Winter
-#
-#   This code is distributed under the BSD license, a copy of which is
-#   included in the root directory of this package.
 """
 An implementation of the SMV image reader for ADSC images. Inherits from
 FormatSMVADSC, customised for beamline 8.3.1 at the ALS where J. Holton uses

--- a/format/FormatSMVADSCSN926.py
+++ b/format/FormatSMVADSCSN926.py
@@ -2,12 +2,12 @@
 #
 #   This code is distributed under the BSD license, a copy of which is
 #   included in the root directory of this package.
-#
-# An implementation of the SMV image reader for ADSC images. Inherits from
-# FormatSMVADSC, customised for beamline 8.3.1 at the ALS where J. Holton uses
-# two-theta offsets in the vertical direction, as well as idiosyncratic ways
-# of recording the beam centre... which work fine for ADXV...
-
+"""
+An implementation of the SMV image reader for ADSC images. Inherits from
+FormatSMVADSC, customised for beamline 8.3.1 at the ALS where J. Holton uses
+two-theta offsets in the vertical direction, as well as idiosyncratic ways
+of recording the beam centre... which work fine for ADXV...
+"""
 from __future__ import absolute_import, division, print_function
 
 import math

--- a/format/FormatSMVADSCSN928.py
+++ b/format/FormatSMVADSCSN928.py
@@ -1,7 +1,8 @@
-# An implementation of the SMV image reader for ADSC images. Inherits from
-# FormatSMVADSCSN, customised for example on Australian Synchrotron SN 928
-# which has reversed phi.
-
+"""
+An implementation of the SMV image reader for ADSC images. Inherits from
+FormatSMVADSCSN, customised for example on Australian Synchrotron SN 928
+which has reversed phi.
+"""
 from __future__ import absolute_import, division, print_function
 
 from dxtbx.format.FormatSMVADSCSN import FormatSMVADSCSN

--- a/format/FormatSMVADSCSNAPSID19.py
+++ b/format/FormatSMVADSCSNAPSID19.py
@@ -1,9 +1,3 @@
-#!/usr/bin/env python
-# FormatSMVADSCSNID19.py
-#   Copyright (C) 2015 Diamond Light Source, Richard Gildea
-#
-#   This code is distributed under the BSD license, a copy of which is
-#   included in the root directory of this package.
 """
 An implementation of the SMV image reader for ADSC images. Inherits from
 FormatSMVADSC, customised for example on APS ID19 SN 458 and 914

--- a/format/FormatSMVADSCSNAPSID19.py
+++ b/format/FormatSMVADSCSNAPSID19.py
@@ -4,11 +4,11 @@
 #
 #   This code is distributed under the BSD license, a copy of which is
 #   included in the root directory of this package.
-#
-# An implementation of the SMV image reader for ADSC images. Inherits from
-# FormatSMVADSC, customised for example on APS ID19 SN 458 and 914
-# which have reversed phi.
-
+"""
+An implementation of the SMV image reader for ADSC images. Inherits from
+FormatSMVADSC, customised for example on APS ID19 SN 458 and 914
+which have reversed phi.
+"""
 from __future__ import absolute_import, division, print_function
 
 from dxtbx.format.FormatSMVADSCSN import FormatSMVADSCSN

--- a/format/FormatSMVCMOS1.py
+++ b/format/FormatSMVCMOS1.py
@@ -5,7 +5,7 @@
 #   This code is distributed under the BSD license, a copy of which is
 #   included in the root directory of this package.
 #
-# An implementation of the SMV image reader for CMOS1 images, from ALS 4.2.2
+"""An implementation of the SMV image reader for CMOS1 images, from ALS 4.2.2"""
 
 from __future__ import absolute_import, division, print_function
 

--- a/format/FormatSMVCMOS1.py
+++ b/format/FormatSMVCMOS1.py
@@ -1,10 +1,3 @@
-#!/usr/bin/env python
-# FormatSMVCMOS1.py
-#   Copyright (C) 2015 Diamond Light Source, Graeme Winter
-#
-#   This code is distributed under the BSD license, a copy of which is
-#   included in the root directory of this package.
-#
 """An implementation of the SMV image reader for CMOS1 images, from ALS 4.2.2"""
 
 from __future__ import absolute_import, division, print_function

--- a/format/FormatSMVHamamatsuSPring8BL32XU.py
+++ b/format/FormatSMVHamamatsuSPring8BL32XU.py
@@ -1,11 +1,3 @@
-#  Copyright (C) (2015) STFC Rutherford Appleton Laboratory, UK.
-#
-#  Author: David Waterman.
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-#
-
 from __future__ import absolute_import, division, print_function
 
 from dxtbx.format.FormatSMVHamamatsu import FormatSMVHamamatsu

--- a/format/FormatSMVJHSim.py
+++ b/format/FormatSMVJHSim.py
@@ -1,10 +1,3 @@
-#!/usr/bin/env python
-# FormatSMVJHSim.py
-#   Copyright (C) 2011 Diamond Light Source, Graeme Winter
-#
-#   This code is distributed under the BSD license, a copy of which is
-#   included in the root directory of this package.
-#
 """An implementation of the SMV image reader for JHSim images."""
 
 from __future__ import absolute_import, division, print_function

--- a/format/FormatSMVJHSim.py
+++ b/format/FormatSMVJHSim.py
@@ -5,8 +5,7 @@
 #   This code is distributed under the BSD license, a copy of which is
 #   included in the root directory of this package.
 #
-# An implementation of the SMV image reader for JHSim images. Inherits from
-# FormatSMV.
+"""An implementation of the SMV image reader for JHSim images."""
 
 from __future__ import absolute_import, division, print_function
 

--- a/format/FormatSMVNOIR.py
+++ b/format/FormatSMVNOIR.py
@@ -1,10 +1,3 @@
-#!/usr/bin/env python
-# FormatSMVNOIR.py
-#   Copyright (C) 2011 Diamond Light Source, Graeme Winter
-#
-#   This code is distributed under the BSD license, a copy of which is
-#   included in the root directory of this package.
-#
 """
 An implementation of the SMV image reader for Rigaku Saturn images.
 Inherits from FormatSMVRigaku.

--- a/format/FormatSMVNOIR.py
+++ b/format/FormatSMVNOIR.py
@@ -5,8 +5,10 @@
 #   This code is distributed under the BSD license, a copy of which is
 #   included in the root directory of this package.
 #
-# An implementation of the SMV image reader for Rigaku Saturn images.
-# Inherits from FormatSMVRigaku.
+"""
+An implementation of the SMV image reader for Rigaku Saturn images.
+Inherits from FormatSMVRigaku.
+"""
 
 from __future__ import absolute_import, division, print_function
 

--- a/format/FormatSMVRigaku.py
+++ b/format/FormatSMVRigaku.py
@@ -3,10 +3,10 @@
 #
 #   This code is distributed under the BSD license, a copy of which is
 #   included in the root directory of this package.
-#
-# An implementation of the SMV image reader for Rigaku images.
-# Inherits from FormatSMV.
-
+"""
+An implementation of the SMV image reader for Rigaku images.
+Inherits from FormatSMV.
+"""
 from __future__ import absolute_import, division, print_function
 
 import calendar

--- a/format/FormatSMVRigaku.py
+++ b/format/FormatSMVRigaku.py
@@ -1,8 +1,3 @@
-#!/usr/bin/env python
-#   Copyright (C) 2013 Diamond Light Source, Graeme Winter
-#
-#   This code is distributed under the BSD license, a copy of which is
-#   included in the root directory of this package.
 """
 An implementation of the SMV image reader for Rigaku images.
 Inherits from FormatSMV.

--- a/format/FormatSMVRigakuA200.py
+++ b/format/FormatSMVRigakuA200.py
@@ -4,10 +4,10 @@
 #
 #   This code is distributed under the BSD license, a copy of which is
 #   included in the root directory of this package.
-#
-# An implementation of the SMV image reader for Rigaku A200 images.
-# Inherits from FormatSMVRigaku.
-
+"""
+An implementation of the SMV image reader for Rigaku A200 images.
+Inherits from FormatSMVRigaku.
+"""
 from __future__ import absolute_import, division, print_function
 
 from builtins import range

--- a/format/FormatSMVRigakuA200.py
+++ b/format/FormatSMVRigakuA200.py
@@ -1,9 +1,3 @@
-#!/usr/bin/env python
-# FormatSMVRigakuA200.py
-#   Copyright (C) 2013 Diamond Light Source, Graeme Winter
-#
-#   This code is distributed under the BSD license, a copy of which is
-#   included in the root directory of this package.
 """
 An implementation of the SMV image reader for Rigaku A200 images.
 Inherits from FormatSMVRigaku.

--- a/format/FormatSMVRigakuA200SPring8BL26B1.py
+++ b/format/FormatSMVRigakuA200SPring8BL26B1.py
@@ -1,14 +1,3 @@
-#!/usr/bin/env python
-# FormatSMVRigakuA200SPring8BL26B1.py
-#
-#  Copyright (C) (2015) STFC Rutherford Appleton Laboratory, UK.
-#
-#  Author: David Waterman.
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-#
-
 from __future__ import absolute_import, division, print_function
 
 from dxtbx.format.FormatSMVRigakuA200 import FormatSMVRigakuA200

--- a/format/FormatSMVRigakuEiger.py
+++ b/format/FormatSMVRigakuEiger.py
@@ -1,9 +1,3 @@
-#!/usr/bin/env python
-# FormatSMVRigakuEiger.py
-#   Copyright (C) 2013 Diamond Light Source, Graeme Winter
-#
-#   This code is distributed under the BSD license, a copy of which is
-#   included in the root directory of this package.
 """
 An implementation of the SMV image reader for Rigaku Eiger.
 Be aware: this is completely unrelated to the HDF5 Eiger format.

--- a/format/FormatSMVRigakuEiger.py
+++ b/format/FormatSMVRigakuEiger.py
@@ -4,10 +4,10 @@
 #
 #   This code is distributed under the BSD license, a copy of which is
 #   included in the root directory of this package.
-#
-# An implementation of the SMV image reader for Rigaku Eiger.
-# Be aware: this is completely unrelated to the HDF5 Eiger format.
-
+"""
+An implementation of the SMV image reader for Rigaku Eiger.
+Be aware: this is completely unrelated to the HDF5 Eiger format.
+"""
 from __future__ import absolute_import, division, print_function
 
 from builtins import range

--- a/format/FormatSMVRigakuPilatus.py
+++ b/format/FormatSMVRigakuPilatus.py
@@ -4,10 +4,10 @@
 #
 #   This code is distributed under the BSD license, a copy of which is
 #   included in the root directory of this package.
-#
-# An implementation of the SMV image reader for Rigaku Pilatus images.
-# Inherits from FormatSMVRigaku.
-
+"""
+An implementation of the SMV image reader for Rigaku Pilatus images.
+Inherits from FormatSMVRigaku.
+"""
 from __future__ import absolute_import, division, print_function
 
 from builtins import range

--- a/format/FormatSMVRigakuPilatus.py
+++ b/format/FormatSMVRigakuPilatus.py
@@ -1,9 +1,3 @@
-#!/usr/bin/env python
-# FormatSMVRigakuPilatus.py
-#   Copyright (C) 2013 Diamond Light Source, Graeme Winter
-#
-#   This code is distributed under the BSD license, a copy of which is
-#   included in the root directory of this package.
 """
 An implementation of the SMV image reader for Rigaku Pilatus images.
 Inherits from FormatSMVRigaku.

--- a/format/FormatSMVRigakuSaturn.py
+++ b/format/FormatSMVRigakuSaturn.py
@@ -3,10 +3,10 @@
 #
 #   This code is distributed under the BSD license, a copy of which is
 #   included in the root directory of this package.
-#
-# An implementation of the SMV image reader for Rigaku Saturn images.
-# Inherits from FormatSMVRigaku.
-
+"""
+An implementation of the SMV image reader for Rigaku Saturn images.
+Inherits from FormatSMVRigaku.
+"""
 from __future__ import absolute_import, division, print_function
 
 from builtins import range

--- a/format/FormatSMVRigakuSaturn.py
+++ b/format/FormatSMVRigakuSaturn.py
@@ -1,8 +1,3 @@
-#!/usr/bin/env python
-#   Copyright (C) 2011 Diamond Light Source, Graeme Winter
-#
-#   This code is distributed under the BSD license, a copy of which is
-#   included in the root directory of this package.
 """
 An implementation of the SMV image reader for Rigaku Saturn images.
 Inherits from FormatSMVRigaku.

--- a/format/FormatSMVRigakuSaturnNoTS.py
+++ b/format/FormatSMVRigakuSaturnNoTS.py
@@ -3,10 +3,10 @@
 #
 #   This code is distributed under the BSD license, a copy of which is
 #   included in the root directory of this package.
-#
-# An implementation of the SMV image reader for Rigaku Saturn images.
-# Inherits from FormatSMVRigaku.
-
+"""
+An implementation of the SMV image reader for Rigaku Saturn images.
+Inherits from FormatSMVRigaku.
+"""
 from __future__ import absolute_import, division, print_function
 
 from builtins import range

--- a/format/FormatSMVRigakuSaturnNoTS.py
+++ b/format/FormatSMVRigakuSaturnNoTS.py
@@ -1,8 +1,3 @@
-#!/usr/bin/env python
-#   Copyright (C) 2011 Diamond Light Source, Graeme Winter
-#
-#   This code is distributed under the BSD license, a copy of which is
-#   included in the root directory of this package.
 """
 An implementation of the SMV image reader for Rigaku Saturn images.
 Inherits from FormatSMVRigaku.

--- a/format/FormatSMVRigakuSaturnSN07400090.py
+++ b/format/FormatSMVRigakuSaturnSN07400090.py
@@ -4,12 +4,12 @@
 #
 #   This code is distributed under the BSD license, a copy of which is
 #   included in the root directory of this package.
-#
-# An implementation of the SMV image reader for Rigaku Saturn images, for
-# the instrument on Diamond Light Source I19 SN 07400090. Inherits from
-# FormatSMVRigakuSaturn customizing only the difference (incorrect definition
-# of fast and slow directions.)
-
+"""
+An implementation of the SMV image reader for Rigaku Saturn images, for
+the instrument on Diamond Light Source I19 SN 07400090. Inherits from
+FormatSMVRigakuSaturn customizing only the difference (incorrect definition
+of fast and slow directions.)
+"""
 from __future__ import absolute_import, division, print_function
 
 from builtins import range

--- a/format/FormatSMVRigakuSaturnSN07400090.py
+++ b/format/FormatSMVRigakuSaturnSN07400090.py
@@ -1,9 +1,3 @@
-#!/usr/bin/env python
-# FormatSMVRigakuSaturnSN07400090.py
-#   Copyright (C) 2011 Diamond Light Source, Graeme Winter
-#
-#   This code is distributed under the BSD license, a copy of which is
-#   included in the root directory of this package.
 """
 An implementation of the SMV image reader for Rigaku Saturn images, for
 the instrument on Diamond Light Source I19 SN 07400090. Inherits from

--- a/format/FormatSMVRigakuSaturnSN09040159.py
+++ b/format/FormatSMVRigakuSaturnSN09040159.py
@@ -1,9 +1,3 @@
-#!/usr/bin/env python
-# FormatSMVRigakuSaturnSN09040159.py
-#   Copyright (C) 2011 Diamond Light Source, Graeme Winter
-#
-#   This code is distributed under the BSD license, a copy of which is
-#   included in the root directory of this package.
 """
 An implementation of the SMV image reader for Rigaku Saturn images, for
 the instrument at CSHL, SN 09040159.

--- a/format/FormatSMVRigakuSaturnSN09040159.py
+++ b/format/FormatSMVRigakuSaturnSN09040159.py
@@ -4,10 +4,10 @@
 #
 #   This code is distributed under the BSD license, a copy of which is
 #   included in the root directory of this package.
-#
-# An implementation of the SMV image reader for Rigaku Saturn images, for
-# the instrument at CSHL, SN 09040159.
-
+"""
+An implementation of the SMV image reader for Rigaku Saturn images, for
+the instrument at CSHL, SN 09040159.
+"""
 from __future__ import absolute_import, division, print_function
 
 from builtins import range

--- a/format/FormatSMVRigakuSaturnSN11480296.py
+++ b/format/FormatSMVRigakuSaturnSN11480296.py
@@ -4,12 +4,12 @@
 #
 #   This code is distributed under the BSD license, a copy of which is
 #   included in the root directory of this package.
-#
-# An implementation of the SMV image reader for Rigaku Saturn images, for
-# the instrument at Dundee SN 11480296. Inherits from
-# FormatSMVRigakuSaturn customizing only the difference (incorrect definition
-# of fast and slow directions.)
-
+"""
+An implementation of the SMV image reader for Rigaku Saturn images, for
+the instrument at Dundee SN 11480296. Inherits from
+FormatSMVRigakuSaturn customizing only the difference (incorrect definition
+of fast and slow directions.)
+"""
 from __future__ import absolute_import, division, print_function
 
 from builtins import range

--- a/format/FormatSMVRigakuSaturnSN11480296.py
+++ b/format/FormatSMVRigakuSaturnSN11480296.py
@@ -1,9 +1,3 @@
-#!/usr/bin/env python
-# FormatSMVRigakuSaturnSN11480296.py
-#   Copyright (C) 2016 Diamond Light Source, Richard Gildea
-#
-#   This code is distributed under the BSD license, a copy of which is
-#   included in the root directory of this package.
 """
 An implementation of the SMV image reader for Rigaku Saturn images, for
 the instrument at Dundee SN 11480296. Inherits from

--- a/format/FormatStill.py
+++ b/format/FormatStill.py
@@ -1,8 +1,8 @@
 # FormatStill.py
-#
-# Root class for still shots.  A still shot has no goniomter and no
-# scan in their model, as these constructs are not meaningful.
-#
+"""
+Root class for still shots.  A still shot has no goniomter and no
+scan in their model, as these constructs are not meaningful.
+"""
 from __future__ import absolute_import, division, print_function
 from dxtbx.format.Format import Format
 from dxtbx.model.detector import Detector

--- a/format/FormatStill.py
+++ b/format/FormatStill.py
@@ -1,4 +1,3 @@
-# FormatStill.py
 """
 Root class for still shots.  A still shot has no goniomter and no
 scan in their model, as these constructs are not meaningful.

--- a/format/FormatTIFF.py
+++ b/format/FormatTIFF.py
@@ -1,8 +1,10 @@
-# Implementation of an ImageFormat class to read TIFF format image but not -
-# in the first instance - actually provide a full image representation. This
-# is simply there to set everything up for the Mar / Rayonix CCD readers
-# which really will acquire the full image including header information
-# and generate the experimental model representations.
+"""
+Implementation of an ImageFormat class to read TIFF format image but not -
+in the first instance - actually provide a full image representation. This
+is simply there to set everything up for the Mar / Rayonix CCD readers
+which really will acquire the full image including header information
+and generate the experimental model representations.
+"""
 
 from __future__ import absolute_import, division, print_function
 

--- a/format/FormatTIFFBruker.py
+++ b/format/FormatTIFFBruker.py
@@ -5,8 +5,7 @@
 #   This code is distributed under the BSD license, a copy of which is
 #   included in the root directory of this package.
 #
-# An implementation of the TIFF image reader for Bruker images. Inherits from
-# FormatTIFF.
+"""An implementation of the TIFF image reader for Bruker images"""
 
 from __future__ import absolute_import, division, print_function
 

--- a/format/FormatTIFFBruker.py
+++ b/format/FormatTIFFBruker.py
@@ -1,10 +1,3 @@
-#!/usr/bin/env python
-# FormatTIFFBruker.py
-#   Copyright (C) 2011 Diamond Light Source, Graeme Winter
-#
-#   This code is distributed under the BSD license, a copy of which is
-#   included in the root directory of this package.
-#
 """An implementation of the TIFF image reader for Bruker images"""
 
 from __future__ import absolute_import, division, print_function

--- a/format/FormatTIFFHelpers.py
+++ b/format/FormatTIFFHelpers.py
@@ -1,6 +1,7 @@
-# Helper code to assist with reading TIFF file headers, which are by their
-# nature binary so we need to mess with things like byte swapping.
-
+"""
+Helper code to assist with reading TIFF file headers, which are by their
+nature binary so we need to mess with things like byte swapping.
+"""
 from __future__ import absolute_import, division, print_function
 
 from builtins import range

--- a/format/FormatTIFFRayonix.py
+++ b/format/FormatTIFFRayonix.py
@@ -5,8 +5,7 @@
 #   This code is distributed under the BSD license, a copy of which is
 #   included in the root directory of this package.
 #
-# An implementation of the TIFF image reader for Rayonix images. Inherits from
-# FormatTIFF.
+"""An implementation of the TIFF image reader for Rayonix images."""
 
 from __future__ import absolute_import, division, print_function
 

--- a/format/FormatTIFFRayonix.py
+++ b/format/FormatTIFFRayonix.py
@@ -1,10 +1,3 @@
-#!/usr/bin/env python
-# FormatTIFFRayonix.py
-#   Copyright (C) 2011 Diamond Light Source, Graeme Winter
-#
-#   This code is distributed under the BSD license, a copy of which is
-#   included in the root directory of this package.
-#
 """An implementation of the TIFF image reader for Rayonix images."""
 
 from __future__ import absolute_import, division, print_function

--- a/format/FormatTIFFRayonixESRF.py
+++ b/format/FormatTIFFRayonixESRF.py
@@ -5,10 +5,10 @@
 #   This code is distributed under the BSD license, a copy of which is
 #   included in the root directory of this package.
 #
-# Sub class of FormatTiffRayonix to deal with images who have beam centers
-# specified in pixels
-#
-
+"""
+Subclass of FormatTiffRayonix to deal with images who have beam centers
+specified in pixels
+"""
 from __future__ import absolute_import, division, print_function
 
 import struct

--- a/format/FormatTIFFRayonixESRF.py
+++ b/format/FormatTIFFRayonixESRF.py
@@ -1,10 +1,3 @@
-#!/usr/bin/env python
-# FormatTIFFRayonixESRF.py
-#   Copyright (C) 2011 Diamond Light Source, Graeme Winter
-#
-#   This code is distributed under the BSD license, a copy of which is
-#   included in the root directory of this package.
-#
 """
 Subclass of FormatTiffRayonix to deal with images who have beam centers
 specified in pixels

--- a/format/FormatTIFFRayonixSPring8.py
+++ b/format/FormatTIFFRayonixSPring8.py
@@ -1,14 +1,3 @@
-#!/usr/bin/env python
-# FormatTIFFRayonixSPring8.py
-#
-#  Copyright (C) (2014) STFC Rutherford Appleton Laboratory, UK.
-#
-#  Author: David Waterman.
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-#
-
 from __future__ import absolute_import, division, print_function
 
 import struct

--- a/format/FormatTIFFRayonixXPP.py
+++ b/format/FormatTIFFRayonixXPP.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-# FormatTIFFRayonixXPP.py
 """
 Sub class of FormatTIFFRayonix specialized for the XPP Rayonix dectector at LCLS
 

--- a/format/FormatTIFFRayonixXPP.py
+++ b/format/FormatTIFFRayonixXPP.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python
 # FormatTIFFRayonixXPP.py
-# Sub class of FormatTIFFRayonix specialized for the XPP Rayonix dectector at LCLS
-#
-# Images from the XPP Rayonix detector have several unitialized values, such as
-# distance, wavelength, etc.  Set these values to zero so the images can be at
-# least viewed.
-#
+"""
+Sub class of FormatTIFFRayonix specialized for the XPP Rayonix dectector at LCLS
+
+Images from the XPP Rayonix detector have several unitialized values, such as
+distance, wavelength, etc.  Set these values to zero so the images can be at
+least viewed.
+"""
 
 from __future__ import absolute_import, division, print_function
 

--- a/format/FormatXDS.py
+++ b/format/FormatXDS.py
@@ -5,7 +5,7 @@
 #   This code is distributed under the BSD license, a copy of which is
 #   included in the root directory of this package.
 #
-# Format object for XDS files
+"""Format object for XDS files"""
 
 from __future__ import absolute_import, division, print_function
 

--- a/format/FormatXDS.py
+++ b/format/FormatXDS.py
@@ -1,10 +1,3 @@
-#!/usr/bin/env python
-# FormatXDS.py
-#   Copyright (C) 2016 Diamond Light Source, Richard Gildea
-#
-#   This code is distributed under the BSD license, a copy of which is
-#   included in the root directory of this package.
-#
 """Format object for XDS files"""
 
 from __future__ import absolute_import, division, print_function

--- a/format/Registry.py
+++ b/format/Registry.py
@@ -1,6 +1,8 @@
-# A registry class to handle Format classes and provide lists of them when
-# this is useful for i.e. identifying the best tool to read a given range
-# of image formats.
+"""
+A registry class to handle Format classes and provide lists of them when
+this is useful for i.e. identifying the best tool to read a given range
+of image formats.
+"""
 
 from __future__ import absolute_import, division, print_function
 

--- a/model/beam.py
+++ b/model/beam.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, division, print_function
 
-# A model for the beam for the "updated experimental model" project
-
 from builtins import object
 
 from builtins import range

--- a/model/detector.py
+++ b/model/detector.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import, division, print_function
 
-# A model for the detector for the "updated experimental model" project
 # N.B. this should probably be generalized for non
 # flat detectors, or composite detectors constructed from a number of flat
 # elements.

--- a/model/detector_helpers.py
+++ b/model/detector_helpers.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, division, print_function
 
-# Helpers for the detector class...
-
 from builtins import object
 import math
 

--- a/model/goniometer.py
+++ b/model/goniometer.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, division, print_function
 
-# A model for the goniometer for the "updated experimental model" project
-
 from builtins import range
 from builtins import object
 

--- a/model/goniometer_helpers.py
+++ b/model/goniometer_helpers.py
@@ -1,9 +1,5 @@
 from __future__ import absolute_import, division, print_function
 
-#   Copyright (C) 2011 Diamond Light Source, Graeme Winter
-#
-#   This code is distributed under the BSD license, a copy of which is
-#   included in the root directory of this package.
 
 from scitbx import matrix
 from scitbx.math import r3_rotation_axis_and_angle_from_matrix

--- a/model/scan.py
+++ b/model/scan.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, division, print_function
 
-# A model for the scan for the "updated experimental model" project
-
 from builtins import range
 from builtins import object
 

--- a/model/scan_helpers.py
+++ b/model/scan_helpers.py
@@ -1,7 +1,8 @@
+"""
+Helpers for the scan class, which are things for handling e.g. filenames,
+templates and so on.
+"""
 from __future__ import absolute_import, division, print_function
-
-# Helpers for the scan class, which are things for handling e.g. filenames,
-# templates and so on.
 
 from builtins import object
 
@@ -9,8 +10,7 @@ import math
 import os
 import re
 
-# N.B. these are reversed patterns...
-
+# These are reversed patterns...
 patterns = [
     r"([0-9]{2,12})\.(.*)",
     r"(.*)\.([0-9]{2,12})_(.*)",

--- a/serialize/dump.py
+++ b/serialize/dump.py
@@ -1,12 +1,5 @@
 from __future__ import absolute_import, division, print_function
 
-#  Copyright (C) 2013 Diamond Light Source
-#
-#  Author: James Parkhurst
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-
 import json
 import re
 import textwrap

--- a/serialize/load.py
+++ b/serialize/load.py
@@ -1,14 +1,3 @@
-#!/usr/bin/env python
-#
-# dxtbx.serialize.load.py
-#
-#  Copyright (C) 2013 Diamond Light Source
-#
-#  Author: James Parkhurst
-#
-#  This code is distributed under the BSD license, a copy of which is
-#  included in the root directory of this package.
-
 from __future__ import absolute_import, division, print_function
 
 import os

--- a/tests/model/test_scan_helpers.py
+++ b/tests/model/test_scan_helpers.py
@@ -7,8 +7,6 @@ from dxtbx.model import is_angle_in_range
 from dxtbx.model import get_range_of_mod2pi_angles
 from dxtbx.model import get_mod2pi_angles_in_range
 
-# Run tests for the scan_helpers.h module.
-
 
 def test_is_angle_in_random_range():
     """Test that for a range of angles and angular ranges, the

--- a/tests/test_scan.py
+++ b/tests/test_scan.py
@@ -1,5 +1,3 @@
-# Tests for the scan class, and its helper classes.
-
 from __future__ import absolute_import, division, print_function
 
 from builtins import range


### PR DESCRIPTION
Counterpart to https://github.com/dials/dials/pull/916, removes header copyright and shebangs in favor of git history and central licence/copyright/AUTHOR notices, that are easier to keep up-to-date and authoritative.

There was a lot of `Format*` descriptions in the header block, so I've mostly converted them to docstrings here.