### PR TITLE
Add isort to pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,12 @@
 repos:
 
+# Automatically sort imports
+- repo: https://github.com/timothycrosley/isort.git
+  rev: 4.3.21
+  hooks:
+  - id: isort
+    additional_dependencies: [toml]
+
 # Automatic source code formatting
 - repo: https://github.com/psf/black
   rev: stable


### PR DESCRIPTION
Does what it says on the tin. Helps to maintain the sorted-imports state of the repo.
