### PR TITLE
Reduce the number of file operations in dxtbx

### DIFF
--- a/datablock.py
+++ b/datablock.py
@@ -784,7 +784,7 @@ def _create_imagesweep(record, format_class, format_kwargs=None):
         goniometer=record.goniometer,
         scan=record.scan,
         format_kwargs=format_kwargs,
-        check_format=False,
+        # check_format=False,
     )
     return sweep
 

--- a/datablock.py
+++ b/datablock.py
@@ -819,7 +819,6 @@ def _convert_to_imagesets(records, format_class, format_kwargs=None):
 
     # Iterate over images/sets such that template=None are clustered
     for setgroup in _groupby_template_is_none(records):
-#       print("SG", format_class, "x" + str(len(setgroup)))
         if setgroup[0].template is not None:
             # If we have a template, then it's a sweep
             assert len(setgroup) == 1, "Got group of metadata records in template?"
@@ -961,8 +960,7 @@ class DataBlockFilenameImporter(object):
             # Validate this datablock and store it
             assert imagesets, "Datablock got no imagesets?"
             for i in imagesets:
-#               print(i, len(i))
-                self.datablocks.append(DataBlock([i]))
+                append_to_datablocks(i)
 
         # Now we are done. since in an __init__, the caller can now pick the
         # results out of the .datablocks and .unhandled instance attributes.

--- a/datablock.py
+++ b/datablock.py
@@ -61,7 +61,6 @@ class DataBlock(object):
 
     def append(self, imageset):
         """ Add an imageset to the block. """
-        print(imageset)
         if self._format_class is None:
             self._format_class = imageset.get_format_class()
         elif not self._format_class == imageset.get_format_class():
@@ -372,7 +371,7 @@ class DataBlockTemplateImporter(object):
         def append_to_datablocks(iset):
             try:
                 self.datablocks[-1].append(iset)
-            except TypeError:
+            except (IndexError, TypeError):
                 # This happens when we already have a datablock with a different format
                 self.datablocks.append(DataBlock([iset]))
             logger.debug("Added imageset to datablock %d", len(self.datablocks) - 1)

--- a/datablock.py
+++ b/datablock.py
@@ -687,8 +687,10 @@ def _merge_model_metadata(
 ):
     """
     Merge metadata between consecutive record objects.
+
     This will compare each record with the previous one, and make sure
     the metadata instances are shared where appropriate.
+
     :param  records:  Records for the images to merge into imagesets
     :type records:    Iterable[ImageMetadataRecord]
     :param Callable compare_beam:        The function to to compare beams
@@ -709,8 +711,10 @@ def _merge_model_metadata(
 def _merge_scans(records, scan_tolerance=None):
     """
     Merge consecutive scan records with identical metadata.
+
     The records should have previously had their model metadata merged,
     as identity will be used to compare metadata identity at this stage.
+
     :param  records:              Records to merge
     :param float scan_tolerance:  Percentage of oscillation range to tolerate
                                   when merging scan records
@@ -763,7 +767,8 @@ def _merge_scans(records, scan_tolerance=None):
 
 def _create_imagesweep(record, format_class, format_kwargs=None):
     """
-    Create an ImageSweep object from a single rotation data image
+    Create an ImageSweep object from a single rotation data image.
+
     :param record: Single-image metadata records to merge into a single imageset
     :type records: ImageMetadataRecord
     :param format_class:  The format class object for these image records
@@ -791,7 +796,8 @@ def _create_imagesweep(record, format_class, format_kwargs=None):
 
 def _groupby_template_is_none(records):
     """
-    Specialization of groupby that groups records by format=None
+    Specialization of groupby that groups records by format=None.
+
     :rtype: Generator
     """
     for _, group in itertools.groupby(
@@ -803,11 +809,13 @@ def _groupby_template_is_none(records):
 def _convert_to_imagesets(records, format_class, format_kwargs=None):
     """
     Convert records into imagesets.
+
     The records should have been metadata- and scan-merged by this point.
     Rules:
     - Any groups of template=None where any of the metadata objects
       are shared, go into a single imageset
     - Anything with a template goes into a single sweep
+
     :param Iterable[ImageMetadataRecord] records: The records to convert
     :param format_class:  The format class for the data in this record
     :type param:          Type[dxtbx.format.Format]
@@ -833,6 +841,7 @@ def _convert_to_imagesets(records, format_class, format_kwargs=None):
 def _create_imageset(records, format_class, format_kwargs=None):
     """
     Create an ImageSet object from a set of single-image records.
+
     :param records: Single-image metadata records to merge into a single imageset
     :type records:  Iterable[ImageMetadataRecord]
     :param format_class:  The format class object for these image records

--- a/datablock.py
+++ b/datablock.py
@@ -318,7 +318,6 @@ class FormatChecker(object):
             warnings.warn(
                 "The verbose parameter is deprecated.", DeprecationWarning, stacklevel=2
             )
-        self._verbose = verbose
 
     def find_format(self, filename):
         """Search the registry for the image format class.
@@ -898,7 +897,7 @@ class DataBlockFilenameImporter(object):
 
         # Process each file given by this path list
         to_process = OpeningPathIterator(filenames)
-        find_format = FormatChecker(verbose=True)  # verbose)
+        find_format = FormatChecker()
 
         format_groups = {}
         #        with progress(total=len(filenames)) as pbar:

--- a/datablock.py
+++ b/datablock.py
@@ -920,7 +920,7 @@ class DataBlockFilenameImporter(object):
                 format_groups.setdefault(format_class, []).append(imageset)
                 logger.debug("Loaded file: %s", filename)
             else:
-                format_object = format_class(filename, **format_kwargs)
+                format_object = format_class(filename, format_kwargs=format_kwargs)
                 meta = ImageMetadataRecord.from_format(format_object)
                 assert meta.filename == filename
 

--- a/datablock.py
+++ b/datablock.py
@@ -819,7 +819,7 @@ def _convert_to_imagesets(records, format_class, format_kwargs=None):
 
     # Iterate over images/sets such that template=None are clustered
     for setgroup in _groupby_template_is_none(records):
-        print("SG", format_class, "x" + str(len(setgroup)))
+#       print("SG", format_class, "x" + str(len(setgroup)))
         if setgroup[0].template is not None:
             # If we have a template, then it's a sweep
             assert len(setgroup) == 1, "Got group of metadata records in template?"
@@ -886,13 +886,10 @@ class DataBlockFilenameImporter(object):
 
         # A function to append or create a new datablock
         def append_to_datablocks(iset):
-            if self.datablocks:
-                try:
-                    self.datablocks[-1].append(iset)
-                except TypeError:
-                    # This happens when we already have a datablock with a different format
-                    self.datablocks.append(DataBlock([iset]))
-            else:
+            try:
+                self.datablocks[-1].append(iset)
+            except (IndexError, TypeError):
+                # This happens when we already have a datablock with a different format
                 self.datablocks.append(DataBlock([iset]))
             logger.debug("Added imageset to datablock %d", len(self.datablocks) - 1)
 
@@ -937,9 +934,9 @@ class DataBlockFilenameImporter(object):
 
         # Now, build datablocks from these files. Duplicating the logic of
         # the previous implementation:
-        # - Each change in format goes into it's own Datablock
+        # - Each change in format goes into its own Datablock
         # - FormatMultiImage files each have their own ImageSet
-        # - Every set of images forming a scan goes into it's own ImageSweep
+        # - Every set of images forming a scan goes into its own ImageSweep
         # - Any consecutive still frames that share any metadata with the
         #   previous still fram get collected into one ImageSet
 
@@ -964,7 +961,7 @@ class DataBlockFilenameImporter(object):
             # Validate this datablock and store it
             assert imagesets, "Datablock got no imagesets?"
             for i in imagesets:
-                print(i, len(i))
+#               print(i, len(i))
                 self.datablocks.append(DataBlock([i]))
 
         # Now we are done. since in an __init__, the caller can now pick the

--- a/datablock.py
+++ b/datablock.py
@@ -10,7 +10,7 @@ import operator
 import os.path
 import warnings
 from builtins import range
-from os.path import abspath, dirname, isdir, isfile, join, normpath, splitext
+from os.path import abspath, dirname, normpath, splitext
 
 import six
 import six.moves.cPickle as pickle
@@ -1474,25 +1474,8 @@ class DataBlockFactory(object):
         format_kwargs=None,
     ):
         """ Create a list of data blocks from a list of directory or file names. """
-        filelist = []
-        for f in sorted(filenames):
-            if isfile(f):
-                filelist.append(f)
-            elif isdir(f):
-                subdir = sorted(
-                    join(f, sf) for sf in os.listdir(f) if isfile(join(f, sf))
-                )
-                filelist.extend(subdir)
-                logger.debug("Added %d files from %s", len(subdir), f)
-            else:
-                logger.debug(
-                    "Could not import %s: not a valid file or directory name", f
-                )
-                if unhandled is not None:
-                    unhandled.append(f)
-
         importer = DataBlockFilenameImporter(
-            filelist,
+            filenames,
             compare_beam=compare_beam,
             compare_detector=compare_detector,
             compare_goniometer=compare_goniometer,

--- a/datablock.py
+++ b/datablock.py
@@ -457,9 +457,11 @@ class DataBlockTemplateImporter(object):
 
 class ImageMetadataRecord(object):
     """Object to store metadata information.
-    This is used whilst building the datablocks - the metadata for each
+
+    This is used whilst building the datablocks.  The metadata for each
     image can be read once, and then any grouping/deduplication can happen
     later, without re-opening the original file.
+
     :ivar beam:           Stores a beam model
     :ivar detector:       Stores a detector model
     :ivar goniometer:     Stores a goniometer model
@@ -499,12 +501,14 @@ class ImageMetadataRecord(object):
         compare_goniometer=operator.__eq__,
     ):
         """Compare two record objects and merge equivalent data.
+
         This method will compare (with optional functions) instance data
         for beam, detector and goniometer. If any of the metadata for
-        this record is equivalent (but a different instance) than the other
+        this record is equivalent to (but a different instance from) the other
         record, then this instance will be altered to match the other.
         The function used to compare beams, detectors and goniometers can be
-        customized - but by default the normal equality operator is used.
+        customised - but by default the normal equality operator is used.
+
         :param ImageMetadataRecord other_record: Another metadata instance
         :param Callable compare_beam:            A function to compare beams
         :param Callable compare_detector:        A function to compare detectors
@@ -512,7 +516,7 @@ class ImageMetadataRecord(object):
         :returns: True if any action was taken
         :rtype:   bool
         """
-        # Allow 'defaults' of None to work - behavior from legacy implementaiton
+        # Allow 'defaults' of None to work - behavior from legacy implementation
         compare_beam = compare_beam or operator.__eq__
         compare_detector = compare_detector or operator.__eq__
         compare_goniometer = compare_goniometer or operator.__eq__
@@ -540,6 +544,7 @@ class ImageMetadataRecord(object):
     def from_format(cls, fmt):
         """
         Read metadata information from a Format instance.
+
         This will only pull information out of a single format instance while
         it is open - combining metadata records must be done separately.
         """
@@ -599,18 +604,20 @@ class ImageMetadataRecord(object):
 
 class OpeningPathIterator(object):
     """Utility class to efficiently open all paths.
+
     A path is a potential file or directory.
     Each path will be opened with :meth:`dxtbx.format.Format.open_file`,
     but in order to do so each file will only be opened once, and extraneous
     use of :func:`os.stat` will be avoided.
     Any path entries that are a directory will be recursed into, once -
     any further directories found will be ignored. Any path that is not
-    a file or directory, or IO fails for any reason, will be added to the
-    :attr:`unhandled` list.
+    a file or directory, or on which IO fails for any reason, will be added
+    to the :attr:`unhandled` list.
     The current expected length of the iterator can be found with
     `len(iterator)` - this can change while iterating, because until a
     directory is encountered it cannot be detected without extra IO
-    operations. The number of items processed can be accesed through the
+    operations. The number of items processed can be accessed through the
+
     :attr:`index` attribute.
     :ivar unhandled:  List of paths that could not be handled
     :ivar index:      Index of the next path item (alternatively, number
@@ -619,6 +626,7 @@ class OpeningPathIterator(object):
 
     def __init__(self, pathnames):
         """Initialise the path iterator.
+
         :param Iterable[str] pathnames: Paths to attempt to open
         """
         # Store a tuple of (recurse, pathname) to track what was root level
@@ -1052,7 +1060,7 @@ class DataBlockFilenameImporter(object):
 
                 # If the last was not a sweep then if the current is a sweep or none of
                 # the models are the same, increment. Otherwise if the current is not a
-                # sweep or if both sweeps don't share all models increment. If both
+                # sweep or if both sweeps don't share all models, increment. If both
                 # share, models try scan and increment if exception.
                 if last.template is None:
                     if template is not None or not any(same):

--- a/datablock.py
+++ b/datablock.py
@@ -819,6 +819,7 @@ def _convert_to_imagesets(records, format_class, format_kwargs=None):
 
     # Iterate over images/sets such that template=None are clustered
     for setgroup in _groupby_template_is_none(records):
+        print("SG", format_class, "x" + str(len(setgroup)))
         if setgroup[0].template is not None:
             # If we have a template, then it's a sweep
             assert len(setgroup) == 1, "Got group of metadata records in template?"
@@ -899,7 +900,7 @@ class DataBlockFilenameImporter(object):
         to_process = OpeningPathIterator(filenames)
         find_format = FormatChecker()
 
-        format_groups = {}
+        format_groups = collections.OrderedDict()
         #        with progress(total=len(filenames)) as pbar:
         for filename in to_process:
             # We now have a file, pre-opened by Format.open_file (therefore
@@ -963,7 +964,8 @@ class DataBlockFilenameImporter(object):
             # Validate this datablock and store it
             assert imagesets, "Datablock got no imagesets?"
             for i in imagesets:
-                append_to_datablocks(i)
+                print(i, len(i))
+                self.datablocks.append(DataBlock([i]))
 
         # Now we are done. since in an __init__, the caller can now pick the
         # results out of the .datablocks and .unhandled instance attributes.

--- a/format/Format.py
+++ b/format/Format.py
@@ -533,26 +533,6 @@ class Format(object):
         scheme = urllib.parse.urlparse(path).scheme
         return scheme and len(scheme) != 1
 
-    @staticmethod
-    def is_bz2(filename):
-        """Check if a file pointed at by filename is bzip2 format."""
-
-        if not filename.endswith(".bz2"):
-            return False
-
-        with open(filename, "rb") as fh:
-            return fh.read(3) == b"BZh"
-
-    @staticmethod
-    def is_gzip(filename):
-        """Check if a file pointed at by filename is gzip compressed."""
-
-        if not filename.endswith(".gz"):
-            return False
-
-        with open(filename, "rb") as fh:
-            return fh.read(2) == b"\x1f\x8b"
-
     @classmethod
     def open_file(cls, filename, mode="rb", url=False):
         """Open file for reading, decompressing silently if necessary,
@@ -561,12 +541,12 @@ class Format(object):
         if url and Format.is_url(filename):
             fh_func = functools.partial(urllib.request.urlopen, filename)
 
-        elif Format.is_bz2(filename):
+        elif filename.endswith(".bz2"):
             if not bz2:
                 raise RuntimeError("bz2 file provided without bz2 module")
             fh_func = functools.partial(bz2.BZ2File, filename, mode=mode)
 
-        elif Format.is_gzip(filename):
+        elif filename.endswith(".gz"):
             if not gzip:
                 raise RuntimeError("gz file provided without gzip module")
             fh_func = functools.partial(gzip.GzipFile, filename, mode=mode)

--- a/newsfragments/89.bugfix
+++ b/newsfragments/89.bugfix
@@ -1,0 +1,7 @@
+Reduce number of redundant file operations in dxtbx
+
+This includes a change in the DataBlock() construction semantics: sweeps from
+identical detectors are merged into a single DataBlock() object regardless of
+their position in the call order. Since DataBlock() is deprecated and any
+reliance on order would have to be handled explicitly downstream anyway this
+should not have any impact on users or developers.

--- a/tests/test_datablock.py
+++ b/tests/test_datablock.py
@@ -288,18 +288,26 @@ def test_extract_metadata_record():
     assert record.index is None
 
 
-class AEO(object):
-    """Always Equal Object: Simple test case class that always compares equal"""
-
-    def __eq__(self, other):
-        return True
+def _equal_but_not_same(thing):
+    object_1 = tuple([thing])
+    object_2 = tuple([thing])
+    assert object_1 == object_2
+    assert object_1 is not object_2
+    return object_1, object_2
 
 
 def test_merge_metadata_record():
     "Test that merging metadata records works correctly"
-    assert AEO() == AEO()
-    a = datablock.ImageMetadataRecord(beam=AEO(), detector=AEO(), goniometer=AEO())
-    b = datablock.ImageMetadataRecord(beam=AEO(), detector=AEO(), goniometer=AEO())
+    beam_a, beam_b = _equal_but_not_same("beam")
+    detector_a, detector_b = _equal_but_not_same("detector")
+    gonio_a, gonio_b = _equal_but_not_same("goniometer")
+
+    a = datablock.ImageMetadataRecord(
+        beam=beam_a, detector=detector_a, goniometer=gonio_a
+    )
+    b = datablock.ImageMetadataRecord(
+        beam=beam_b, detector=detector_b, goniometer=gonio_b
+    )
     pre_hash = hash(a)
     assert a.beam is not b.beam
     assert a.detector is not b.detector
@@ -318,8 +326,15 @@ def test_merge_metadata_record():
 
 def test_merge_all_metadata():
     "Test that merging metadata over a whole list of records works"
-    a = datablock.ImageMetadataRecord(beam=AEO(), detector=object(), goniometer=AEO())
-    b = datablock.ImageMetadataRecord(beam=AEO(), detector=object(), goniometer=AEO())
+    beam_a, beam_b = _equal_but_not_same("beam")
+    gonio_a, gonio_b = _equal_but_not_same("goniometer")
+
+    a = datablock.ImageMetadataRecord(
+        beam=beam_a, detector=object(), goniometer=gonio_a
+    )
+    b = datablock.ImageMetadataRecord(
+        beam=beam_b, detector=object(), goniometer=gonio_b
+    )
     records = [a, b]
     datablock._merge_model_metadata(records)
     assert a.beam is b.beam

--- a/tests/test_datablock.py
+++ b/tests/test_datablock.py
@@ -297,7 +297,7 @@ def _equal_but_not_same(thing):
 
 
 def test_merge_metadata_record():
-    "Test that merging metadata records works correctly"
+    """Test that merging metadata records works correctly"""
     beam_a, beam_b = _equal_but_not_same("beam")
     detector_a, detector_b = _equal_but_not_same("detector")
     gonio_a, gonio_b = _equal_but_not_same("goniometer")
@@ -325,7 +325,7 @@ def test_merge_metadata_record():
 
 
 def test_merge_all_metadata():
-    "Test that merging metadata over a whole list of records works"
+    """Test that merging metadata over a whole list of records works"""
     beam_a, beam_b = _equal_but_not_same("beam")
     gonio_a, gonio_b = _equal_but_not_same("goniometer")
 
@@ -364,7 +364,6 @@ def test_merge_scan():
 
 
 def test_groupby_template_none():
-    # _groupby_format_is_none
     Fo = namedtuple("Fo", ["template"])
     objs = [Fo(1), Fo(2), Fo(2), Fo(None), Fo(None), Fo("something")]
     result = list(datablock._groupby_template_is_none(objs))

--- a/tests/test_datablock.py
+++ b/tests/test_datablock.py
@@ -123,7 +123,7 @@ def test_create_multiple_blocks(multiple_block_filenames):
 
     pprint([b.num_images() for b in blocks])
 
-    assert len(blocks) == 22
+    assert len(blocks) == 24
 
 
 def test_pickling(multiple_block_filenames):

--- a/tests/test_datablock.py
+++ b/tests/test_datablock.py
@@ -113,17 +113,17 @@ def test_create_multiple_blocks(multiple_block_filenames):
     assert blocks
 
     # Block 1
-    assert blocks[0].num_images() == 9
+    assert blocks[0].num_images() == 12
     imageset = blocks[0].extract_imagesets()
-    assert len(imageset) == 1
+    assert len(imageset) == 4
     assert len(imageset[0]) == 9
     sweeps = blocks[0].extract_sweeps()
-    assert len(sweeps) == 1
+    assert len(sweeps) == 4
     assert len(sweeps[0]) == 9
 
     pprint([b.num_images() for b in blocks])
 
-    assert len(blocks) == 24
+    assert len(blocks) == 8
 
 
 def test_pickling(multiple_block_filenames):


### PR DESCRIPTION
Reduce the number of `open()` calls per file from 2 to 1 (10 to 1 for `.cbf.gz`) for `dials.import`.
Still 5 `stat()` calls per file.
Tests do not yet pass for this.
