### PR TITLE
local_visit should not check self

### DIFF
--- a/format/nexus.py
+++ b/format/nexus.py
@@ -176,15 +176,13 @@ def local_visit(nxfile, visitor):
 
     Args:
       nxfile: hdf5 file node
-      visitor: visitor function to act on node and children
+      visitor: visitor function to act on children
     """
-    visitor(nxfile.name, nxfile)
-    for k in nxfile:
-        try:
-            if "NX_class" in nxfile[k].attrs:
-                local_visit(nxfile[k], visitor)
-        except KeyError:
-            pass
+    for k in nxfile.values():
+        if "NX_class" not in k.attrs:
+            continue
+        visitor(k.name, k)
+        local_visit(k, visitor)
 
 
 def find_entries(nx_file, entry):


### PR DESCRIPTION
Issue found testing data in prep for SwissFEL experiment.

Example dataset for the Jungfrau 16M detector is here:
https://zenodo.org/record/3352358#.XYJrbtNKj2I

local_visit was added in #75 to fix #74.  It's a replacement for h5py's visititems function, working around h5py/h5py#671.  The documentation for visititems says "Recursively visit all objects in this group and subgroups. You supply a callable...".  Note it doesn't say it visits itself (http://docs.h5py.org/en/stable/high/group.html).

So why wasn't this noticed before?  Because I think the only code that cares that self isn't visited is here:
https://github.com/cctbx/dxtbx/blob/master/format/nexus.py#L1200-L1202.

That's DetectorFactoryFromGroup, a function only used by multi-panel detectors that group modules into groups, which I suppose the Eiger is not doing at DLS?  Regardless, it appears DetectorFactoryFromGroup isn't tested anywhere.  I'll open a different issue about that.

I've tested this pull request with the above JF 16M data and with an DLS Eiger NeXus dataset on viper that @graeme-winter provided.
