### PR TITLE
Attenuation tidy

### DIFF
--- a/masking/goniometer_shadow_masking.h
+++ b/masking/goniometer_shadow_masking.h
@@ -217,6 +217,8 @@ namespace dxtbx { namespace masking {
       goniometer_.set_angles(angles);
     }
 
+    virtual ~GoniometerShadowMasker() {};
+
   protected:
     MultiAxisGoniometer goniometer_;
     scitbx::af::shared<vec3<double> > extrema_at_datum_;

--- a/model/boost_python/panel.cc
+++ b/model/boost_python/panel.cc
@@ -335,8 +335,6 @@ namespace dxtbx { namespace model { namespace boost_python {
     return panel.pixel_to_millimeter(px);
   }
 
-  // vec2<double> pixel_to_millimeter(vec2<double> xy, double attenuation_length) const
-  // {
   void export_panel() {
     using namespace boost::python;
 

--- a/model/boost_python/parallax_correction.cc
+++ b/model/boost_python/parallax_correction.cc
@@ -11,21 +11,32 @@
 #include <boost/python.hpp>
 #include <boost/python/def.hpp>
 #include <dxtbx/model/parallax_correction.h>
+#include <scitbx/vec2.h>
+#include <scitbx/vec3.h>
 
 namespace dxtbx { namespace model { namespace boost_python {
 
   using namespace boost::python;
 
+  vec2<double> parallax_correction_with_panel_data(double mu,
+                                                   double t0,
+                                                   vec2<double> xy,
+                                                   vec3<double> fast,
+                                                   vec3<double> slow,
+                                                   vec3<double> origin) {
+    return parallax_correction(mu, t0, xy, fast, slow, origin);
+  }
+
   void export_parallax_correction() {
     def("parallax_correction",
         &parallax_correction,
         (arg("d"), arg("la"), arg("xy0"), arg("xy")));
+    def("parallax_correction",
+        &parallax_correction_with_panel_data,
+        (arg("mu"), arg("t0"), arg("xy"), arg("fast"), arg("slow"), arg("origin")));
     def("parallax_correction_inv",
         &parallax_correction_inv,
         (arg("d"), arg("la"), arg("xy0"), arg("xy")));
-    def("parallax_correction2",
-        &parallax_correction2,
-        (arg("mu"), arg("t0"), arg("xy"), arg("fast"), arg("slow"), arg("origin")));
     def("parallax_correction_inv2",
         &parallax_correction_inv2,
         (arg("mu"), arg("t0"), arg("xy"), arg("fast"), arg("slow"), arg("origin")));

--- a/model/boost_python/parallax_correction.cc
+++ b/model/boost_python/parallax_correction.cc
@@ -18,50 +18,30 @@ namespace dxtbx { namespace model { namespace boost_python {
 
   using namespace boost::python;
 
-  vec2<double> parallax_correction1(double d,
-                                    double la,
-                                    vec2<double> xy0,
-                                    vec2<double> xy) {
-    return parallax_correction(d, la, xy0, xy);
-  }
-
-  vec2<double> parallax_correction2(double mu,
-                                    double t0,
-                                    vec2<double> xy,
-                                    vec3<double> fast,
-                                    vec3<double> slow,
-                                    vec3<double> origin) {
-    return parallax_correction(mu, t0, xy, fast, slow, origin);
-  }
-
-  vec2<double> parallax_correction_inv1(double d,
-                                        double la,
-                                        vec2<double> xy0,
-                                        vec2<double> xy){
-    return parallax_correction_inv(d, la, xy0, xy);
-  }
-
-  vec2<double> parallax_correction_inv2(double mu,
-                                        double t0,
-                                        vec2<double> xy,
-                                        vec3<double> fast,
-                                        vec3<double> slow,
-                                        vec3<double> origin){
-    return parallax_correction_inv(mu, t0, xy, fast, slow, origin);
-  }
+  // Parallax functions are overloaded so declare the forms for boost
+  typedef vec2<double> (*parallax_orig_type)(double d,
+                                             double la,
+                                             vec2<double> xy0,
+                                             vec2<double> xy);
+  typedef vec2<double> (*parallax_axis_type)(double mu,
+                                             double t0,
+                                             vec2<double> xy,
+                                             vec3<double> fast_axis,
+                                             vec3<double> slow_axis,
+                                             vec3<double> origin);
 
   void export_parallax_correction() {
     def("parallax_correction",
-        &parallax_correction1,
+        (parallax_orig_type)&parallax_correction,
         (arg("d"), arg("la"), arg("xy0"), arg("xy")));
     def("parallax_correction",
-        &parallax_correction2,
+        (parallax_axis_type)&parallax_correction,
         (arg("mu"), arg("t0"), arg("xy"), arg("fast"), arg("slow"), arg("origin")));
     def("parallax_correction_inv",
-        &parallax_correction_inv1,
+        (parallax_orig_type)&parallax_correction_inv,
         (arg("d"), arg("la"), arg("xy0"), arg("xy")));
     def("parallax_correction_inv",
-        &parallax_correction_inv2,
+        (parallax_axis_type)&parallax_correction_inv,
         (arg("mu"), arg("t0"), arg("xy"), arg("fast"), arg("slow"), arg("origin")));
   }
 

--- a/model/boost_python/parallax_correction.cc
+++ b/model/boost_python/parallax_correction.cc
@@ -18,6 +18,13 @@ namespace dxtbx { namespace model { namespace boost_python {
 
   using namespace boost::python;
 
+  vec2<double> parallax_correction_original(double d,
+                                            double la,
+                                            vec2<double> xy0,
+                                            vec2<double> xy) {
+    return parallax_correction(d, la, xy0, xy);
+  }
+
   vec2<double> parallax_correction_with_panel_data(double mu,
                                                    double t0,
                                                    vec2<double> xy,
@@ -29,7 +36,7 @@ namespace dxtbx { namespace model { namespace boost_python {
 
   void export_parallax_correction() {
     def("parallax_correction",
-        &parallax_correction,
+        &parallax_correction_original,
         (arg("d"), arg("la"), arg("xy0"), arg("xy")));
     def("parallax_correction",
         &parallax_correction_with_panel_data,

--- a/model/boost_python/parallax_correction.cc
+++ b/model/boost_python/parallax_correction.cc
@@ -18,33 +18,49 @@ namespace dxtbx { namespace model { namespace boost_python {
 
   using namespace boost::python;
 
-  vec2<double> parallax_correction_original(double d,
-                                            double la,
-                                            vec2<double> xy0,
-                                            vec2<double> xy) {
+  vec2<double> parallax_correction1(double d,
+                                    double la,
+                                    vec2<double> xy0,
+                                    vec2<double> xy) {
     return parallax_correction(d, la, xy0, xy);
   }
 
-  vec2<double> parallax_correction_with_panel_data(double mu,
-                                                   double t0,
-                                                   vec2<double> xy,
-                                                   vec3<double> fast,
-                                                   vec3<double> slow,
-                                                   vec3<double> origin) {
+  vec2<double> parallax_correction2(double mu,
+                                    double t0,
+                                    vec2<double> xy,
+                                    vec3<double> fast,
+                                    vec3<double> slow,
+                                    vec3<double> origin) {
     return parallax_correction(mu, t0, xy, fast, slow, origin);
+  }
+
+  vec2<double> parallax_correction_inv1(double d,
+                                        double la,
+                                        vec2<double> xy0,
+                                        vec2<double> xy){
+    return parallax_correction_inv(d, la, xy0, xy);
+  }
+
+  vec2<double> parallax_correction_inv2(double mu,
+                                        double t0,
+                                        vec2<double> xy,
+                                        vec3<double> fast,
+                                        vec3<double> slow,
+                                        vec3<double> origin){
+    return parallax_correction_inv(mu, t0, xy, fast, slow, origin);
   }
 
   void export_parallax_correction() {
     def("parallax_correction",
-        &parallax_correction_original,
+        &parallax_correction1,
         (arg("d"), arg("la"), arg("xy0"), arg("xy")));
     def("parallax_correction",
-        &parallax_correction_with_panel_data,
+        &parallax_correction2,
         (arg("mu"), arg("t0"), arg("xy"), arg("fast"), arg("slow"), arg("origin")));
     def("parallax_correction_inv",
-        &parallax_correction_inv,
+        &parallax_correction_inv1,
         (arg("d"), arg("la"), arg("xy0"), arg("xy")));
-    def("parallax_correction_inv2",
+    def("parallax_correction_inv",
         &parallax_correction_inv2,
         (arg("mu"), arg("t0"), arg("xy"), arg("fast"), arg("slow"), arg("origin")));
   }

--- a/model/parallax_correction.h
+++ b/model/parallax_correction.h
@@ -132,12 +132,12 @@ namespace dxtbx { namespace model {
    * @param slow Detector slow direction
    * @param origin Direction of detector origin
    */
-  inline vec2<double> parallax_correction_inv2(double mu,
-                                               double t0,
-                                               vec2<double> xy,
-                                               vec3<double> fast,
-                                               vec3<double> slow,
-                                               vec3<double> origin) {
+  inline vec2<double> parallax_correction_inv(double mu,
+                                              double t0,
+                                              vec2<double> xy,
+                                              vec3<double> fast,
+                                              vec3<double> slow,
+                                              vec3<double> origin) {
     double o;
     vec2<double> c_xy;
     vec3<double> s1 = origin + xy[0] * fast + xy[1] * slow;
@@ -148,13 +148,22 @@ namespace dxtbx { namespace model {
     return c_xy;
   }
 
-  inline vec2<double> parallax_correction_inv2_attenuation(double mu,
-                                                           double t0,
-                                                           vec2<double> xy,
-                                                           vec3<double> fast,
-                                                           vec3<double> slow,
-                                                           vec3<double> origin,
-                                                           double attenuation_length) {
+  /**
+   * Function to perform an inverse parallax correction on a given coordinate
+   * correctly, with a precaculated attenuation length. X corresponds to the fast
+   * direction, Y to the slow direction in input & output. Returns corrected mm
+   * position.
+   * @param xy The xy mm coordinate
+   * @param fast Detector fast direction
+   * @param slow Detector slow direction
+   * @param origin Direction of detector origin
+   * @param attenuation_length Precalculated attenuation length
+   */
+  inline vec2<double> parallax_correction_inv(vec2<double> xy,
+                                              vec3<double> fast,
+                                              vec3<double> slow,
+                                              vec3<double> origin,
+                                              double attenuation_length) {
     vec2<double> c_xy;
     vec3<double> s1 = origin + xy[0] * fast + xy[1] * slow;
     s1 = s1.normalize();

--- a/model/parallax_correction.h
+++ b/model/parallax_correction.h
@@ -150,7 +150,7 @@ namespace dxtbx { namespace model {
 
   /**
    * Function to perform an inverse parallax correction on a given coordinate
-   * correctly, with a precaculated attenuation length. X corresponds to the fast
+   * correctly, with a precalculated attenuation length. X corresponds to the fast
    * direction, Y to the slow direction in input & output. Returns corrected mm
    * position.
    * @param xy The xy mm coordinate

--- a/model/parallax_correction.h
+++ b/model/parallax_correction.h
@@ -104,7 +104,7 @@ namespace dxtbx { namespace model {
    * @param slow Detector slow direction
    * @param origin Direction of detector origin
    */
-  inline vec2<double> parallax_correction2(double mu,
+  inline vec2<double> parallax_correction(double mu,
                                            double t0,
                                            vec2<double> xy,
                                            vec3<double> fast,

--- a/model/pixel_to_millimeter.h
+++ b/model/pixel_to_millimeter.h
@@ -12,7 +12,6 @@
 #define DXTBX_MODEL_PIXEL_TO_MILLIMETER_H
 
 #include <scitbx/vec2.h>
-#include <scitbx/vec3.h>
 #include <dxtbx/model/parallax_correction.h>
 #include <dxtbx/model/panel_data.h>
 #include <dxtbx/error.h>

--- a/model/pixel_to_millimeter.h
+++ b/model/pixel_to_millimeter.h
@@ -12,6 +12,7 @@
 #define DXTBX_MODEL_PIXEL_TO_MILLIMETER_H
 
 #include <scitbx/vec2.h>
+#include <scitbx/vec3.h>
 #include <dxtbx/model/parallax_correction.h>
 #include <dxtbx/model/panel_data.h>
 #include <dxtbx/error.h>
@@ -187,7 +188,7 @@ namespace dxtbx { namespace model {
      */
     vec2<double> to_pixel(const PanelData &panel, vec2<double> xy) const {
       return SimplePxMmStrategy::to_pixel(panel,
-                                          parallax_correction2(mu_,
+                                          parallax_correction(mu_,
                                                                t0_,
                                                                xy,
                                                                panel.get_fast_axis(),

--- a/model/pixel_to_millimeter.h
+++ b/model/pixel_to_millimeter.h
@@ -160,20 +160,18 @@ namespace dxtbx { namespace model {
      * @return The (x, y) millimeter coordinate
      */
     vec2<double> to_millimeter(const PanelData &panel, vec2<double> xy) const {
-      return parallax_correction_inv2(mu_,
-                                      t0_,
-                                      SimplePxMmStrategy::to_millimeter(panel, xy),
-                                      panel.get_fast_axis(),
-                                      panel.get_slow_axis(),
-                                      panel.get_origin());
+      return parallax_correction_inv(mu_,
+                                     t0_,
+                                     SimplePxMmStrategy::to_millimeter(panel, xy),
+                                     panel.get_fast_axis(),
+                                     panel.get_slow_axis(),
+                                     panel.get_origin());
     }
 
     vec2<double> to_millimeter(const PanelData &panel,
                                vec2<double> xy,
                                double attenuation_length) const {
-      return parallax_correction_inv2_attenuation(
-        mu_,
-        t0_,
+      return parallax_correction_inv(
         SimplePxMmStrategy::to_millimeter(panel, xy, attenuation_length),
         panel.get_fast_axis(),
         panel.get_slow_axis(),


### PR DESCRIPTION
Tidy up parallax correction API so that on both the Python and C++ side only functions named `parallax_correction` or `parallax_correction_inv` exist. These functions have overloaded definitions depending on whether panel data and precalculated `attenuation_length` exist.