### PR TITLE
Handling unknown sensors.

### DIFF
--- a/format/FormatCBFMini.py
+++ b/format/FormatCBFMini.py
@@ -318,6 +318,8 @@ class FormatCBFMini(FormatCBF):
             sensor = "CdTe"
         elif panel.get_type() == "SENSOR_CCD":
             sensor = "CCD"
+        else:
+            sensor = "unknown"
 
         # maybe someday more people will do this
         flux = beam.get_flux()

--- a/model/detector.py
+++ b/model/detector.py
@@ -767,6 +767,9 @@ class DetectorFactory(object):
         if detector_helper_sensors.check_sensor(name):
             return name
 
+        if name is None:
+            return detector_helper_sensors.SENSOR_UNKNOWN
+
         if name.upper() == "PAD":
             return detector_helper_sensors.SENSOR_PAD
         elif name.upper() == "CCD":


### PR DESCRIPTION
- Ensure sensor is defined as it is used in the detector factory.
- Handle sensor name as None.

These changes were required to run dials.convert_to_cbf on images that use an experimental format:
https://github.com/dials/dxtbx_ED_formats/blob/master/FormatTIFF_DE.py