### PR TITLE
Add double version of dataset_as_flex_int

### DIFF
--- a/format/boost_python/image_ext.cc
+++ b/format/boost_python/image_ext.cc
@@ -168,6 +168,7 @@ namespace dxtbx { namespace format { namespace boost_python {
       .def("is_int", &ImageBuffer::is_int)
       .def("is_double", &ImageBuffer::is_double)
       .def("as_int", &ImageBuffer::as_int)
+      .def("as_float", &ImageBuffer::as_float)
       .def("as_double", &ImageBuffer::as_double);
 
     class_<ImageReader>("ImageReader", no_init)

--- a/format/boost_python/nexus_ext.cc
+++ b/format/boost_python/nexus_ext.cc
@@ -34,6 +34,16 @@ namespace dxtbx { namespace format { namespace boost_python {
   }
 
   /**
+   * Custom read function for floats
+   */
+  template<>
+  inline herr_t custom_read<float>(hid_t dataset_id, hid_t mem_space_id, hid_t file_space_id,
+                          scitbx::af::versa<float, scitbx::af::flex_grid<> > data) {
+    return H5Dread(
+      dataset_id, H5T_NATIVE_FLOAT, mem_space_id, file_space_id, H5P_DEFAULT, &data[0]);
+  }
+
+  /**
    * Custom read function for doubles
    */
   template<>
@@ -106,6 +116,7 @@ namespace dxtbx { namespace format { namespace boost_python {
   BOOST_PYTHON_MODULE(dxtbx_format_nexus_ext) {
     def("dataset_as_flex_int", &dataset_as_flex<int>);
     def("dataset_as_flex_double", &dataset_as_flex<double>);
+    def("dataset_as_flex_float", &dataset_as_flex<float>);
   }
 
 }}}  // namespace dxtbx::format::boost_python

--- a/format/image.h
+++ b/format/image.h
@@ -158,16 +158,17 @@ namespace dxtbx { namespace format {
   };
 
   /**
-   * A class to hold image data which can be either int or double
+   * A class to hold image data which can be either int, float, or double
    */
   class ImageBuffer {
   public:
     typedef int empty_type;
     typedef Image<int> int_image_type;
+    typedef Image<float> float_image_type;
     typedef Image<double> double_image_type;
 
     // The variant type
-    typedef boost::variant<empty_type, int_image_type, double_image_type> variant_type;
+    typedef boost::variant<empty_type, int_image_type, float_image_type, double_image_type> variant_type;
 
     /**
      * A visitor class to convert from/to different types.
@@ -233,6 +234,21 @@ namespace dxtbx { namespace format {
     };
 
     /**
+     * Is the data a float type
+     */
+    class IsFloatVisitor : public boost::static_visitor<bool> {
+    public:
+      bool operator()(const float_image_type &v) const {
+        return true;
+      }
+
+      template <typename OtherImageType>
+      bool operator()(const OtherImageType &v) const {
+        return false;
+      }
+    };
+
+    /**
      * Is the data a double type
      */
     class IsDoubleVisitor : public boost::static_visitor<bool> {
@@ -272,6 +288,13 @@ namespace dxtbx { namespace format {
     }
 
     /**
+     * @returns Is the buffer a float
+     */
+    bool is_float() const {
+      return boost::apply_visitor(IsFloatVisitor(), data_);
+    }
+
+    /**
      * @returns Is the buffer a double
      */
     bool is_double() const {
@@ -283,6 +306,13 @@ namespace dxtbx { namespace format {
      */
     Image<int> as_int() const {
       return boost::apply_visitor(ConverterVisitor<Image<int> >(), data_);
+    }
+
+    /**
+     * @returns The buffer as a float image
+     */
+    Image<float> as_float() const {
+      return boost::apply_visitor(ConverterVisitor<Image<float> >(), data_);
     }
 
     /**

--- a/imageset.h
+++ b/imageset.h
@@ -448,6 +448,8 @@ protected:
     ImageBuffer buffer;
     if (name == "double") {
       buffer = ImageBuffer(get_image_from_tuple<double>(obj));
+    } else if (name == "float") {
+      buffer = ImageBuffer(get_image_from_tuple<float>(obj));
     } else if (name == "int") {
       buffer = ImageBuffer(get_image_from_tuple<int>(obj));
     } else {
@@ -465,6 +467,8 @@ protected:
     ImageBuffer buffer;
     if (name == "double") {
       buffer = ImageBuffer(Image<double>(get_image_tile_from_object<double>(obj)));
+    } else if (name == "float") {
+      buffer = ImageBuffer(Image<float>(get_image_tile_from_object<float>(obj)));
     } else if (name == "int") {
       buffer = ImageBuffer(Image<int>(get_image_tile_from_object<int>(obj)));
     } else {

--- a/tests/test_image_readers.py
+++ b/tests/test_image_readers.py
@@ -189,6 +189,8 @@ def test_smv(dials_regression, smv_image):
     image = SMVReader(filename).image()
     if image.is_double():
         image = image.as_double()
+    elif image.is_float():
+        image = image.as_float()
     else:
         image = image.as_int()
     assert image.n_tiles() == 1
@@ -211,6 +213,8 @@ def test_tiff(dials_regression, tiff_image):
     image = TIFFReader(filename).image()
     if image.is_double():
         image = image.as_double()
+    elif image.is_float():
+        image = image.as_float()
     else:
         image = image.as_int()
     assert image.n_tiles() == 1


### PR DESCRIPTION
This allows reading NeXus data saved with double precision, such as either the JF16M corrected data or the JF16M gain map/pedestals.

Would appreciate a quick check from @graeme-winter ensuring this doesn't break DLS Eiger datasets.  Thanks :)