### PR TITLE
Add ExperimentList.from_file

### DIFF
--- a/model/__init__.py
+++ b/model/__init__.py
@@ -784,7 +784,7 @@ class _(object):
 
         # Write the file
         if filename:
-            with open(filename, "wb") as outfile:
+            with open(str(filename), "wb") as outfile:
                 outfile.write(text)
         else:
             return text
@@ -801,6 +801,21 @@ class _(object):
         else:
             ext_str = "|".join(j_ext + p_ext)
             raise RuntimeError("expected extension {%s}, got %s" % (ext_str, ext))
+
+    @staticmethod
+    def from_file(filename, check_format=True):
+        # type: (str, bool) -> ExperimentList
+        """
+        Load an ExperimentList from a serialized file.
+
+        Args:
+            filename: The filename to load an ExperimentList from
+            check_format: If True, will attempt to verify image data type
+        """
+        # Inline to avoid recursive imports
+        from .experiment_list import ExperimentListFactory
+
+        return ExperimentListFactory.from_serialized_format(str(filename), check_format)
 
 
 @boost.python.inject_into(Beam)

--- a/newsfragments/100.feature
+++ b/newsfragments/100.feature
@@ -1,0 +1,2 @@
+Added ``ExperimentList.from_file`` for easily loading data. This means
+that experiment lists and reflection tables can now load the same way.

--- a/tests/model/test_experiment_list.py
+++ b/tests/model/test_experiment_list.py
@@ -787,3 +787,19 @@ def compare_experiment(exp1, exp2):
         and exp1.scaling_model == exp2.scaling_model
         and exp1.identifier == exp2.identifier
     )
+
+
+def test_experimentlist_from_file(dials_regression, tmpdir):
+    # This allows expansion of environment variables in regression files
+    os.environ["DIALS_REGRESSION"] = dials_regression
+
+    exp_list = ExperimentList.from_file(
+        os.path.join(dials_regression, "experiment_test_data", "experiment_1.json")
+    )
+    assert len(exp_list) == 1
+    assert exp_list[0].beam
+    # Try loading from a pickle
+    exp_list.as_pickle(tmpdir / "el.pickle")
+    exp_list_pk = ExperimentList.from_file(tmpdir / "el.pickle")
+    assert len(exp_list_pk) == 1
+    assert exp_list[0].beam


### PR DESCRIPTION
To try and make writing scripts more discoverable. As long as you know you want an ExperimentList, you should be work out how to load it.

Inline import used because at the moment there are recursive imports between ExperimentList injections and ExperimentListFactory.