### PR TITLE
Remove deprecated classes/functions/parameters

### DIFF
--- a/datablock.py
+++ b/datablock.py
@@ -8,7 +8,6 @@ import logging
 import math
 import operator
 import os.path
-import warnings
 from builtins import range
 from os.path import abspath, dirname, normpath, splitext
 
@@ -315,13 +314,9 @@ class FormatChecker(object):
     """A helper class to speed up identifying the correct image format by first
     trying the last format that was used."""
 
-    def __init__(self, verbose=None):
+    def __init__(self):
         """ Set the format class to none. """
         self._format_class = None
-        if verbose is not None:
-            warnings.warn(
-                "The verbose parameter is deprecated.", DeprecationWarning, stacklevel=2
-            )
 
     def find_format(self, filename):
         """Search the registry for the image format class.
@@ -360,12 +355,9 @@ class FormatChecker(object):
 class DataBlockTemplateImporter(object):
     """ A class to import a datablock from a template. """
 
-    def __init__(self, templates, verbose=None, **kwargs):
+    def __init__(self, templates, **kwargs):
         """ Import the datablocks from the given templates. """
-        if verbose is not None:
-            warnings.warn(
-                "The verbose parameter is deprecated.", DeprecationWarning, stacklevel=2
-            )
+        assert "verbose" not in kwargs, "The verbose parameter has been removed"
         assert len(templates) > 0
 
         self.datablocks = []
@@ -923,7 +915,6 @@ class DataBlockFilenameImporter(object):
     def __init__(
         self,
         filenames,
-        verbose=None,
         compare_beam=None,
         compare_detector=None,
         compare_goniometer=None,
@@ -931,10 +922,6 @@ class DataBlockFilenameImporter(object):
         format_kwargs=None,
     ):
         """ Import the datablocks from the given filenames. """
-        if verbose is not None:
-            warnings.warn(
-                "The verbose parameter is deprecated.", DeprecationWarning, stacklevel=2
-            )
 
         # Init the datablock list
         self.unhandled = []

--- a/format/Registry.py
+++ b/format/Registry.py
@@ -6,9 +6,6 @@ of image formats.
 
 from __future__ import absolute_import, division, print_function
 
-import warnings
-from builtins import object
-
 import pkg_resources
 
 
@@ -18,15 +15,6 @@ def get_format_class_for(format_class_name):
     :return: The (uninstantiated) class object
     """
     return get_format_class_index()[format_class_name][0]()
-
-
-def lookup(format_class):
-    warnings.warn(
-        "lookup() has been renamed to get_format_class_for()",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    return get_format_class_for(format_class)
 
 
 def get_format_class_index():
@@ -121,26 +109,3 @@ def get_format_class_for_file(image_file, format_hint=None):
 
     # There is no class accepting this file, so return None instead
     return None
-
-
-class _Registry(object):
-    # deprecated class
-
-    @staticmethod
-    def get():
-        warnings.warn("Registry.get() is deprecated", DeprecationWarning, stacklevel=2)
-        return tuple(
-            get_format_class_for(format_class) for format_class in _format_dag["Format"]
-        )
-
-    @staticmethod
-    def find(image_file, format_hint=None):
-        warnings.warn(
-            "Registry.find() is deprecated, use get_format_class_for_file()",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return get_format_class_for_file(image_file, format_hint)
-
-
-Registry = _Registry()

--- a/model/__init__.py
+++ b/model/__init__.py
@@ -4,7 +4,6 @@ import collections
 import json
 import os
 import sys
-import warnings
 from builtins import range
 
 import boost.python
@@ -817,16 +816,3 @@ class _(object):
         from .experiment_list import ExperimentListFactory
 
         return ExperimentListFactory.from_serialized_format(str(filename), check_format)
-
-
-@boost.python.inject_into(Beam)
-class _(object):
-    def get_direction(self):
-        warnings.warn(
-            "Calling get_direction is deprecated. Please use "
-            ".get_sample_to_source_direction() instead. "
-            "See https://github.com/cctbx/dxtbx/issues/6",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        return self.get_sample_to_source_direction()

--- a/model/experiment_list.py
+++ b/model/experiment_list.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, division, print_function
 import copy
 import json
 import os
-import warnings
 from builtins import range
 
 import pkg_resources
@@ -434,23 +433,6 @@ def _experimentlist_from_file(filename, directory=None):
             return json.load(infile, object_hook=_decode_dict)
     except IOError:
         raise IOError("unable to read file, %s" % filename)
-
-
-class ExperimentListDumper(object):
-    """ A class to help writing JSON files. """
-
-    def __init__(self, experiment_list):
-        """ Initialise """
-        warnings.warn(
-            "class ExperimentListDumper() is deprecated. "
-            "Use experiment_list.as_json(), experiment_list.as_pickle(), experiment_list.as_file() directly",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        assert experiment_list
-        self.as_json = experiment_list.as_json
-        self.as_pickle = experiment_list.as_pickle
-        self.as_file = experiment_list.as_file
 
 
 class ExperimentListFactory(object):


### PR DESCRIPTION
These are all things that have been deprecated for a while now. I see no reason to keep them around for DIALS 2.1. Unless anyone objects I will merge this in a week or so.

* `out=` parameter removed for `xparm_xds()`
* `verbose=` parameter removed for classes
  * `FormatChecker`
  * `DataBlockTemplateImporter`
  * `DataBlockFilenameImporter`
* `Beam.get_direction()` removed (#6, #68)
* `ExperimentListDumper` removed (#54)
* `Registry.lookup()` removed (#34)
* `Registry.Registry` removed (#34)
* Add formal deprecation warning for the
  `as_str=` parameter in `XDS_INP()`
  (cf. b2533d5a4afa5479daab99595c92620e92713023)