### PR TITLE
Load before heat death

### DIFF
--- a/imageset.py
+++ b/imageset.py
@@ -228,9 +228,10 @@ class _(object):
         if isinstance(item, slice):
             start = item.start or 0
             stop = item.stop or len(self)
+            offset = self.get_scan().get_batch_offset()
             if item.step is not None:
                 raise IndexError("Sequences must be sequential")
-            return self.partial_set(start, stop)
+            return self.partial_set(start - offset, stop - offset)
         else:
             return self.get_corrected_data(item)
 
@@ -541,6 +542,7 @@ class ImageSetFactory(object):
         array_range = (min(indices) - 1, max(indices))
         if scan is not None:
             assert array_range == scan.get_array_range()
+        scan.set_batch_offset(array_range[0])
 
         # Get the format object and reader
         if format_class is None:

--- a/imageset.py
+++ b/imageset.py
@@ -542,7 +542,7 @@ class ImageSetFactory(object):
         array_range = (min(indices) - 1, max(indices))
         if scan is not None:
             assert array_range == scan.get_array_range()
-        scan.set_batch_offset(array_range[0])
+            scan.set_batch_offset(array_range[0])
 
         # Get the format object and reader
         if format_class is None:

--- a/model/experiment_list.py
+++ b/model/experiment_list.py
@@ -291,7 +291,7 @@ class ExperimentListDict(object):
             if imageset_ref in eobj_scan:
                 eobj_scan[imageset_ref] += scan
             else:
-                eobj_scan[imageset_ref] = scan
+                eobj_scan[imageset_ref] = copy.deepcopy(scan)
 
         # Map of imageset/scan pairs
         imagesets = {}

--- a/model/experiment_list.py
+++ b/model/experiment_list.py
@@ -285,7 +285,8 @@ class ExperimentListDict(object):
         eobj_scan = {}
 
         for eobj in self._obj["experiment"]:
-
+            if self._lookup_model("imageset", eobj) is None:
+                continue
             imageset_ref = eobj.get("imageset")
             scan = self._lookup_model("scan", eobj)
 
@@ -330,9 +331,9 @@ class ExperimentListDict(object):
             # If not already cached, load this imageset
             if imageset_ref not in imagesets:
                 imageset_data = self._lookup_model("imageset", eobj)
-                models["scan"] = eobj_scan[imageset_ref]
                 if imageset_data is not None:
                     # Create the imageset from the input data
+                    models["scan"] = eobj_scan[imageset_ref]
                     imageset = self._imageset_from_imageset_data(imageset_data, models)
                     imagesets[imageset_ref] = imageset
                 else:

--- a/model/experiment_list.py
+++ b/model/experiment_list.py
@@ -319,7 +319,6 @@ class ExperimentListDict(object):
             elif ikey in raw_imagesets:
                 # update with correct scan since ths is the only special key
                 imageset = raw_imagesets[ikey]
-                imageset.set_scan(scan)
             else:
                 # This imageset hasn't been loaded yet - create it
                 imageset_data = self._lookup_model("imageset", eobj)

--- a/model/experiment_list.py
+++ b/model/experiment_list.py
@@ -178,6 +178,105 @@ class ExperimentListDict(object):
 
         return filename or "", None
 
+    def _imageset_from_imageset_data(self, imageset_data, models):
+        """ Make an imageset from imageset_data - help with refactor decode. """
+        assert imageset_data is not None
+        if "params" in imageset_data:
+            format_kwargs = imageset_data["params"]
+        else:
+            format_kwargs = {}
+
+        beam = models["beam"]
+        detector = models["detector"]
+        goniometer = models["goniometer"]
+        scan = models["scan"]
+
+        # Load the external lookup data
+        mask_filename, mask = self._load_pickle_path(imageset_data, "mask")
+        gain_filename, gain = self._load_pickle_path(imageset_data, "gain")
+        pedestal_filename, pedestal = self._load_pickle_path(imageset_data, "pedestal")
+        dx_filename, dx = self._load_pickle_path(imageset_data, "dx")
+        dy_filename, dy = self._load_pickle_path(imageset_data, "dy")
+
+        if imageset_data["__id__"] == "ImageSet":
+            imageset = self._make_stills(imageset_data, format_kwargs=format_kwargs)
+        elif imageset_data["__id__"] == "ImageGrid":
+            imageset = self._make_grid(imageset_data, format_kwargs=format_kwargs)
+        elif (
+            imageset_data["__id__"] == "ImageSequence"
+            or imageset_data["__id__"] == "ImageSweep"
+        ):
+            imageset = self._make_sequence(
+                imageset_data,
+                beam=beam,
+                detector=detector,
+                goniometer=goniometer,
+                scan=scan,
+                format_kwargs=format_kwargs,
+            )
+        elif imageset_data["__id__"] == "MemImageSet":
+            imageset = self._make_mem_imageset(imageset_data)
+        else:
+            raise RuntimeError("Unknown imageset type")
+
+        if imageset is not None:
+            # Set the external lookup
+            if mask is None:
+                mask = ImageBool()
+            else:
+                mask = ImageBool(mask)
+            if gain is None:
+                gain = ImageDouble()
+            else:
+                gain = ImageDouble(gain)
+            if pedestal is None:
+                pedestal = ImageDouble()
+            else:
+                pedestal = ImageDouble(pedestal)
+            if dx is None:
+                dx = ImageDouble()
+            else:
+                dx = ImageDouble(dx)
+            if dy is None:
+                dy = ImageDouble()
+            else:
+                dy = ImageDouble(dy)
+
+            if not imageset.external_lookup.mask.data.empty():
+                if not mask.empty():
+                    mask = tuple(m.data() for m in mask)
+                    for m1, m2 in zip(mask, imageset.external_lookup.mask.data):
+                        m1 &= m2.data()
+                    imageset.external_lookup.mask.data = ImageBool(mask)
+            else:
+                imageset.external_lookup.mask.data = mask
+            imageset.external_lookup.mask.filename = mask_filename
+            imageset.external_lookup.gain.data = gain
+            imageset.external_lookup.gain.filename = gain_filename
+            imageset.external_lookup.pedestal.data = pedestal
+            imageset.external_lookup.pedestal.filename = pedestal_filename
+            imageset.external_lookup.dx.data = dx
+            imageset.external_lookup.dx.filename = dx_filename
+            imageset.external_lookup.dy.data = dy
+            imageset.external_lookup.dy.filename = dy_filename
+
+            # Update the imageset models
+            if isinstance(imageset, ImageSequence):
+                imageset.set_beam(beam)
+                imageset.set_detector(detector)
+                imageset.set_goniometer(goniometer)
+                imageset.set_scan(scan)
+            elif isinstance(imageset, (ImageSet, ImageGrid)):
+                for i in range(len(imageset)):
+                    imageset.set_beam(beam, i)
+                    imageset.set_detector(detector, i)
+                    imageset.set_goniometer(goniometer, i)
+                    imageset.set_scan(scan, i)
+
+            imageset.update_detector_px_mm_data()
+
+        return imageset
+
     def decode(self):
         """ Decode the dictionary into a list of experiments. """
         # Extract all the experiments
@@ -200,6 +299,16 @@ class ExperimentListDict(object):
             profile = self._lookup_model("profile", eobj)
             scaling_model = self._lookup_model("scaling_model", eobj)
 
+            models = {
+                "beam": beam,
+                "detector": detector,
+                "goniometer": goniometer,
+                "scan": scan,
+                "crystal": crystal,
+                "profile": profile,
+                "scaling_model": scaling_model,
+            }
+
             key = (eobj.get("imageset"), eobj.get("scan"))
 
             imageset = None
@@ -209,107 +318,15 @@ class ExperimentListDict(object):
                 # This imageset hasn't been loaded yet - create it
                 imageset_data = self._lookup_model("imageset", eobj)
 
-                # Create the imageset from the input data
-                if imageset_data is not None:
-                    if "params" in imageset_data:
-                        format_kwargs = imageset_data["params"]
-                    else:
-                        format_kwargs = {}
-
-                    # Load the external lookup data
-                    mask_filename, mask = self._load_pickle_path(imageset_data, "mask")
-                    gain_filename, gain = self._load_pickle_path(imageset_data, "gain")
-                    pedestal_filename, pedestal = self._load_pickle_path(
-                        imageset_data, "pedestal"
-                    )
-                    dx_filename, dx = self._load_pickle_path(imageset_data, "dx")
-                    dy_filename, dy = self._load_pickle_path(imageset_data, "dy")
-
-                    if imageset_data["__id__"] == "ImageSet":
-                        imageset = self._make_stills(
-                            imageset_data, format_kwargs=format_kwargs
-                        )
-                    elif imageset_data["__id__"] == "ImageGrid":
-                        imageset = self._make_grid(
-                            imageset_data, format_kwargs=format_kwargs
-                        )
-                    elif (
-                        imageset_data["__id__"] == "ImageSequence"
-                        or imageset_data["__id__"] == "ImageSweep"
-                    ):
-                        imageset = self._make_sequence(
-                            imageset_data,
-                            beam=beam,
-                            detector=detector,
-                            goniometer=goniometer,
-                            scan=scan,
-                            format_kwargs=format_kwargs,
-                        )
-                    elif imageset_data["__id__"] == "MemImageSet":
-                        imageset = self._make_mem_imageset(imageset_data)
-                    else:
-                        raise RuntimeError("Unknown imageset type")
-
-                    if imageset is not None:
-                        # Set the external lookup
-                        if mask is None:
-                            mask = ImageBool()
-                        else:
-                            mask = ImageBool(mask)
-                        if gain is None:
-                            gain = ImageDouble()
-                        else:
-                            gain = ImageDouble(gain)
-                        if pedestal is None:
-                            pedestal = ImageDouble()
-                        else:
-                            pedestal = ImageDouble(pedestal)
-                        if dx is None:
-                            dx = ImageDouble()
-                        else:
-                            dx = ImageDouble(dx)
-                        if dy is None:
-                            dy = ImageDouble()
-                        else:
-                            dy = ImageDouble(dy)
-
-                        if not imageset.external_lookup.mask.data.empty():
-                            if not mask.empty():
-                                mask = tuple(m.data() for m in mask)
-                                for m1, m2 in zip(
-                                    mask, imageset.external_lookup.mask.data
-                                ):
-                                    m1 &= m2.data()
-                                imageset.external_lookup.mask.data = ImageBool(mask)
-                        else:
-                            imageset.external_lookup.mask.data = mask
-                        imageset.external_lookup.mask.filename = mask_filename
-                        imageset.external_lookup.gain.data = gain
-                        imageset.external_lookup.gain.filename = gain_filename
-                        imageset.external_lookup.pedestal.data = pedestal
-                        imageset.external_lookup.pedestal.filename = pedestal_filename
-                        imageset.external_lookup.dx.data = dx
-                        imageset.external_lookup.dx.filename = dx_filename
-                        imageset.external_lookup.dy.data = dy
-                        imageset.external_lookup.dy.filename = dy_filename
-
-                        # Update the imageset models
-                        if isinstance(imageset, ImageSequence):
-                            imageset.set_beam(beam)
-                            imageset.set_detector(detector)
-                            imageset.set_goniometer(goniometer)
-                            imageset.set_scan(scan)
-                        elif isinstance(imageset, (ImageSet, ImageGrid)):
-                            for i in range(len(imageset)):
-                                imageset.set_beam(beam, i)
-                                imageset.set_detector(detector, i)
-                                imageset.set_goniometer(goniometer, i)
-                                imageset.set_scan(scan, i)
-
-                        imageset.update_detector_px_mm_data()
-
                 # Add the imageset to the dict - even if empty - as this will
                 # prevent a duplicated attempt at reconstruction
+
+                if imageset_data is not None:
+                    # Create the imageset from the input data
+                    imageset = self._imageset_from_imageset_data(imageset_data, models)
+                else:
+                    imageset = None
+
                 imagesets[key] = imageset
 
             # Append the experiment

--- a/model/experiment_list.py
+++ b/model/experiment_list.py
@@ -557,9 +557,30 @@ class ExperimentListFactory(object):
     @staticmethod
     def from_sequence_and_crystal(imageset, crystal, load_models=True):
         """ Create an experiment list from sequence and crystal. """
+
+        assert isinstance(imageset, ImageSequence)
+
+        experiments = ExperimentList()
+
         if load_models:
-            return ExperimentList(
-                [
+            # if imagesequence is still images, make one experiment for each
+            # all referencing into the same image set
+            if imageset.get_scan().is_still():
+                start, end = imageset.get_scan().get_array_range()
+                for j in range(start, end):
+                    subset = imageset[j : j + 1]
+                    experiments.append(
+                        Experiment(
+                            imageset=imageset,
+                            beam=imageset.get_beam(),
+                            detector=imageset.get_detector(),
+                            goniometer=imageset.get_goniometer(),
+                            scan=subset.get_scan(),
+                            crystal=crystal,
+                        )
+                    )
+            else:
+                experiments.append(
                     Experiment(
                         imageset=imageset,
                         beam=imageset.get_beam(),
@@ -568,8 +589,10 @@ class ExperimentListFactory(object):
                         scan=imageset.get_scan(),
                         crystal=crystal,
                     )
-                ]
-            )
+                )
+
+            return experiments
+
         else:
             return ExperimentList([Experiment(imageset=imageset, crystal=crystal)])
 

--- a/model/experiment_list.py
+++ b/model/experiment_list.py
@@ -284,6 +284,9 @@ class ExperimentListDict(object):
         # Map of imageset/scan pairs
         imagesets = {}
 
+        # Map of imagesets
+        raw_imagesets = {}
+
         # For every experiment, use the given input to create
         # a sensible experiment.
         el = ExperimentList()
@@ -310,11 +313,14 @@ class ExperimentListDict(object):
             }
 
             key = (eobj.get("imageset"), eobj.get("scan"))
-
-            imageset = None
-            try:
-                imageset = imagesets[key]  # type: ImageSet
-            except KeyError:
+            ikey = eobj.get("imageset")
+            if key in imagesets:
+                imageset = imagesets[key]
+            elif ikey in raw_imagesets:
+                # update with correct scan since ths is the only special key
+                imageset = raw_imagesets[ikey]
+                imageset.set_scan(scan)
+            else:
                 # This imageset hasn't been loaded yet - create it
                 imageset_data = self._lookup_model("imageset", eobj)
 
@@ -328,6 +334,7 @@ class ExperimentListDict(object):
                     imageset = None
 
                 imagesets[key] = imageset
+                raw_imagesets[ikey] = imageset
 
             # Append the experiment
             el.append(

--- a/model/experiment_list.py
+++ b/model/experiment_list.py
@@ -290,7 +290,9 @@ class ExperimentListDict(object):
             scan = self._lookup_model("scan", eobj)
 
             if imageset_ref in eobj_scan:
-                if scan:
+                # old imageset: no scan
+                # > 1 expt sharing image sequence with same scan: do not change
+                if scan and scan != eobj_scan[imageset_ref]:
                     eobj_scan[imageset_ref] += scan
             else:
                 eobj_scan[imageset_ref] = copy.deepcopy(scan)

--- a/model/experiment_list.py
+++ b/model/experiment_list.py
@@ -288,8 +288,10 @@ class ExperimentListDict(object):
 
             imageset_ref = eobj.get("imageset")
             scan = self._lookup_model("scan", eobj)
+
             if imageset_ref in eobj_scan:
-                eobj_scan[imageset_ref] += scan
+                if scan:
+                    eobj_scan[imageset_ref] += scan
             else:
                 eobj_scan[imageset_ref] = copy.deepcopy(scan)
 

--- a/model/scan.h
+++ b/model/scan.h
@@ -233,6 +233,11 @@ namespace dxtbx { namespace model {
     /** Set the oscillation */
     void set_oscillation(vec2<double> oscillation) {
       DXTBX_ASSERT(oscillation[1] >= 0.0);
+      if (oscillation[1] != 0.0) {
+        is_still_ = false;
+      } else {
+        is_still_ = true;
+      }
       oscillation_ = oscillation;
     }
 

--- a/model/scan.py
+++ b/model/scan.py
@@ -88,6 +88,7 @@ class ScanFactory(object):
                         epochs[i] = epoch_correction
                     scan.set_epochs(epochs)
                     scan.set_exposure_times(exposure_times)
+
             if params.scan.oscillation is not None:
                 scan.set_oscillation(params.scan.oscillation)
 

--- a/newsfragments/118.feature
+++ b/newsfragments/118.feature
@@ -1,0 +1,3 @@
+With changes in dials.import sequences of stills are imported as individual 
+experiments all dereferencing one image set - this is the change set to support
+this on load. 

--- a/tests/model/test_experiment_list.py
+++ b/tests/model/test_experiment_list.py
@@ -813,6 +813,35 @@ def test_experimentlist_from_file(dials_regression, tmpdir):
     assert exp_list[0].beam
 
 
+def test_experimentlist_imagesequence_stills():
+    filenames = [
+        "/Users/rjgildea/tmp/118/Puck3_10_1_000%i.cbf.gz" % i for i in range(1, 4)
+    ]
+    for f in filenames:
+        if not os.path.exists(f):
+            pytest.skip("%s does not exist" % f)
+    experiments = ExperimentListFactory.from_filenames(filenames)
+
+    assert len(experiments) == 3
+    assert len(experiments.imagesets()) == 1
+
+    # Convert experiment list to dict
+    d = experiments.to_dict()
+
+    # Decode the dict to get a new experiment list
+    experiments2 = ExperimentListDict(d).decode()
+
+    # Verify that this experiment is as we expect
+    assert len(experiments2) == 3
+    assert len(experiments2.imagesets()) == 1
+    assert len(experiments2.goniometers()) == 1
+    assert len(experiments2.detectors()) == 1
+    assert len(experiments2.beams()) == 1
+    assert len(experiments2.scans()) == 3
+    for expt in experiments2:
+        assert expt.imageset is experiments2.imagesets()[0]
+
+
 def test_experimentlist_imagesequence_decode(mocker):
     # These models are shared between experiments
     beam = Beam(s0=(0, 0, -1))


### PR DESCRIPTION
Having looked at the loading of "proper" still image sets I found where the time was going. 

Even if we have one image set in the experiment list, the set was duplicated NN times because of the key on (imagset, scan) in the cache code. Working around this in the kinda-sorta stupid way which is in this branch makes things load in finite time. 

N.B. this still works against imageset-experiment-iterator branch in dials, though this is not strictly necessary. 

I do not think this code is worthy of merging, but it encodes some information - a map of the onion mines, if you like. 

#info @rjgildea @ndevenish @dagewa 