### PR TITLE
Disable libtbx testing for dxtbx

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -1,18 +1,10 @@
 from __future__ import absolute_import, division, print_function
 
-from libtbx.test_utils.pytest import discover
+exit(
+    """
+To run dxtbx tests please run 'pytest' inside the dxtbx directory
 
-tst_list = discover()
-
-# To write tests for dxtbx:
-
-# 1. Test file should be named test_*.py
-# 2. Test methods should be named test_*()
-# 3. Nothing else needed. Rest happens by magic.
-
-# To run dxtbx tests:
-
-# run 'pytest' inside dxtbx directory
-
-# For more information see:
-#   https://github.com/dials/dials/wiki/pytest
+For more information see:
+  https://github.com/dials/dials/wiki/pytest
+"""
+)


### PR DESCRIPTION
following dials/dials#890 we should also disable the ability to run tests via `libtbx.run_tests_parallel module=dxtbx`.

Reasons:
1. libtbx testing is entirely superseded by pytest.
2. test results are misclassified. libtbx testing only crudely recognizes skipped tests, and does not tell this information to the user. It indicates `OK` instead. Some passing tests that are perfectly fine are shown as `WARNING`. Expected failures are also shown as `OK`/`WARNING`.
3. optional tests depending on the `--regression` flag are not run, results are again shown as `OK`
4. none of the relevant explanatory text for test skipping or failure makes it into the output.
5. libtbx testing does not show any warnings/deprecationwarnings
6. none of the above is obvious to anyone running libtbx tests and people will therefore assume that "_they ran the tests_" when really they did not.
