### PR TITLE
Remove global shared state in Reader classes

### DIFF
--- a/format/Format.py
+++ b/format/Format.py
@@ -66,12 +66,9 @@ _cache_controller = dxtbx.filecache_controller.simple_controller()
 
 
 class Reader(object):
-
-    _format_class_ = None
-
-    def __init__(self, filenames, **kwargs):
+    def __init__(self, format_class, filenames, **kwargs):
         self._kwargs = kwargs
-        self.format_class = Reader._format_class_
+        self.format_class = format_class
         self._filenames = filenames
 
     def read(self, index):
@@ -90,7 +87,7 @@ class Reader(object):
         return len(self._filenames)
 
     def copy(self, filenames):
-        return Reader(filenames)
+        return Reader(self.format_class, filenames)
 
     def is_single_file_reader(self):
         return False
@@ -267,13 +264,11 @@ class Format(object):
         return Class._current_instance_
 
     @classmethod
-    def get_reader(Class):
+    def get_reader(cls):
         """
         Return a reader class
         """
-        obj = Reader
-        obj._format_class_ = Class
-        return obj
+        return functools.partial(Reader, cls)
 
     def get_masker(self, goniometer=None):
         """

--- a/format/FormatMultiImage.py
+++ b/format/FormatMultiImage.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 from __future__ import absolute_import, division, print_function
 
+import functools
 import os
 from builtins import range
 
@@ -13,12 +14,9 @@ from dxtbx.model import MultiAxisGoniometer
 
 
 class Reader(object):
-
-    _format_class_ = None
-
-    def __init__(self, filenames, num_images=None, **kwargs):
+    def __init__(self, format_class, filenames, num_images=None, **kwargs):
         self.kwargs = kwargs
-        self.format_class = Reader._format_class_
+        self.format_class = format_class
         assert len(filenames) == 1
         self._filename = filenames[0]
         if num_images is None:
@@ -48,7 +46,7 @@ class Reader(object):
         return self.num_images()
 
     def copy(self, filenames, indices=None):
-        return Reader(filenames, indices)
+        return Reader(self.format_class, filenames, indices)
 
     def identifiers(self):
         return ["%s-%d" % (self._filename, index) for index in range(len(self))]
@@ -89,17 +87,10 @@ class FormatMultiImage(Format):
     def get_reader(cls):
         """
         Return a reader class
-
         """
-        obj = Reader
-        obj._format_class_ = cls
-        return obj
+        return functools.partial(Reader, cls)
 
     def get_masker(self, goniometer=None):
-        """
-        Return a reader class
-
-        """
         if (
             isinstance(goniometer, MultiAxisGoniometer)
             and hasattr(self, "_dynamic_shadowing")

--- a/format/FormatXTC.py
+++ b/format/FormatXTC.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
+import functools
 import sys
 
 from libtbx.phil import parse
@@ -113,15 +114,11 @@ class FormatXTC(FormatMultiImageLazy, FormatStill, Format):
             return None
 
     @classmethod
-    def get_reader(Class):
+    def get_reader(cls):
         """
         Return a reader class
-
         """
-        obj = XtcReader
-        # Note, need to set this on the parent class since it's a scoped global variable
-        Reader._format_class_ = Class
-        return obj
+        return functools.partial(XtcReader, cls)
 
     def populate_events(self):
         """Read the timestamps from the XTC stream.  Assumes the psana idx mode of reading data.

--- a/newsfragments/124.misc
+++ b/newsfragments/124.misc
@@ -1,0 +1,6 @@
+format.Format.Reader() constructor changed.
+
+Format class now given as first constructor argument instead of
+injection via private property
+
+


### PR DESCRIPTION
We currently use a global shared variable, which is not a good idea for many reasons.
Move it to the constructor instead.