### PR TITLE
Don't crash when finding spots in files with index 0

### DIFF
--- a/imageset.py
+++ b/imageset.py
@@ -227,8 +227,8 @@ class _(object):
         """
         if isinstance(item, slice):
             start = item.start or 0
-            stop = item.stop or len(self)
             offset = self.get_scan().get_batch_offset()
+            stop = item.stop or (len(self) + offset)
             if item.step is not None:
                 raise IndexError("Sequences must be sequential")
             return self.partial_set(start - offset, stop - offset)

--- a/newsfragments/133.bugfix
+++ b/newsfragments/133.bugfix
@@ -1,0 +1,1 @@
+Fix spot-finding on images with file names ending in '0000.cbf'


### PR DESCRIPTION
If we are grabbing a single image respect the offset (i.e. don't just use len(items) - fixes counting from 0 errors

Though we may not be fully out of the woods:

```
Extracted 538 spots
Removed 83 spots with size < 3 pixels
Removed 0 spots with size > 1000 pixels
Calculated 455 spot centroids
Calculated 455 spot intensities
Filtered 0 of 455 spots by peak-centroid distance

Histogram of per-image spot count for imageset 0:
```

Artefact? 🤔