### PR TITLE
Stills process py3

### DIFF
--- a/format/FormatCBFCspad.py
+++ b/format/FormatCBFCspad.py
@@ -14,6 +14,7 @@ from dxtbx.model import ParallaxCorrectedPxMmStrategy
 from dxtbx.model.beam import Beam, BeamFactory
 from dxtbx.model.detector import Detector, DetectorFactory
 
+
 class FormatCBFCspad(FormatCBFMultiTileHierarchyStill):
     """An image reading class CSPAD CBF files"""
 

--- a/format/FormatCBFMultiTile.py
+++ b/format/FormatCBFMultiTile.py
@@ -8,11 +8,12 @@ from builtins import range
 import numpy
 
 from scitbx.array_family import flex
-from dxtbx.format.cbf_wrapper import cbf_wrapper 
+from dxtbx.format.cbf_wrapper import cbf_wrapper
 from dxtbx.format.FormatCBF import FormatCBF
 from dxtbx.format.FormatCBFFull import FormatCBFFull
 from dxtbx.format.FormatStill import FormatStill
 from dxtbx.model.detector import Detector
+
 
 class FormatCBFMultiTile(FormatCBFFull):
     """An image reading class multi-tile CBF files"""

--- a/format/FormatCBFMultiTileHierarchy.py
+++ b/format/FormatCBFMultiTileHierarchy.py
@@ -18,6 +18,7 @@ from dxtbx.format.cbf_wrapper import cbf_wrapper
 from dxtbx.format.FormatCBFMultiTile import FormatCBFMultiTile, FormatCBFMultiTileStill
 from dxtbx.model import Detector
 
+
 class FormatCBFMultiTileHierarchy(FormatCBFMultiTile):
     """An image reading class multi-tile CBF files"""
 

--- a/format/FormatCBFMultiTileHierarchy.py
+++ b/format/FormatCBFMultiTileHierarchy.py
@@ -14,10 +14,9 @@ from libtbx.utils import Sorry
 from scitbx.array_family import flex
 from scitbx.matrix import col, sqr
 
-import pycbf
+from dxtbx.format.cbf_wrapper import cbf_wrapper
 from dxtbx.format.FormatCBFMultiTile import FormatCBFMultiTile, FormatCBFMultiTileStill
 from dxtbx.model import Detector
-
 
 class FormatCBFMultiTileHierarchy(FormatCBFMultiTile):
     """An image reading class multi-tile CBF files"""
@@ -27,8 +26,8 @@ class FormatCBFMultiTileHierarchy(FormatCBFMultiTile):
         """Check to see if this looks like an CBF format image, i.e. we can
         make sense of it."""
 
-        cbf_handle = pycbf.cbf_handle_struct()
-        cbf_handle.read_widefile(image_file.encode(), pycbf.MSG_DIGEST)
+        cbf_handle = cbf_wrapper()
+        cbf_handle.read_widefile(image_file)
 
         # check if multiple arrays
         if cbf_handle.count_elements() <= 1:
@@ -36,8 +35,8 @@ class FormatCBFMultiTileHierarchy(FormatCBFMultiTile):
 
         # we need the optional column equipment_component to build a hierarchy
         try:
-            cbf_handle.find_category(b"axis")
-            cbf_handle.find_column(b"equipment_component")
+            cbf_handle.find_category("axis")
+            cbf_handle.find_column("equipment_component")
         except Exception as e:
             if "CBF_NOTFOUND" in str(e):
                 return False
@@ -58,7 +57,7 @@ class FormatCBFMultiTileHierarchy(FormatCBFMultiTile):
         # change of basis matrix in homologous coordinates
         cob = None
 
-        if axis_type == b"rotation":
+        if axis_type == "rotation":
             r3 = vector.axis_and_angle_as_r3_rotation_matrix(
                 setting + increment, deg=True
             )
@@ -82,7 +81,7 @@ class FormatCBFMultiTileHierarchy(FormatCBFMultiTile):
                     1,
                 )
             )
-        elif axis_type == b"translation":
+        elif axis_type == "translation":
             translation = offset + vector * (setting + increment)
             cob = sqr(
                 (
@@ -123,7 +122,7 @@ class FormatCBFMultiTileHierarchy(FormatCBFMultiTile):
 
         parent_id = cbf.get_axis_depends_on(axis_id)
 
-        if parent_id == b".":
+        if parent_id == ".":
             return None, cob
 
         eq_comp = cbf.get_axis_equipment_component(axis_id)
@@ -146,12 +145,12 @@ class FormatCBFMultiTileHierarchy(FormatCBFMultiTile):
 
         # group_id will only be "." if the panel being worked on has the same equipment_component name as the
         # last axis in the hierarchy, which isn't really sensible
-        assert group_id != b"."
+        assert group_id != "."
 
         name = group_id
 
         for subobj in d.iter_preorder():
-            if subobj.get_name().encode() == name:
+            if subobj.get_name() == name:
                 return subobj
 
         parent, cob = self._get_cumulative_change_of_basis(group_id)
@@ -186,18 +185,18 @@ class FormatCBFMultiTileHierarchy(FormatCBFMultiTile):
         d = Detector()
 
         # find the panel elment names. Either array ids or section ids
-        cbf.find_category(b"array_structure_list")
+        cbf.find_category("array_structure_list")
         try:
-            cbf.find_column(b"array_section_id")
+            cbf.find_column("array_section_id")
         except Exception as e:
             if "CBF_NOTFOUND" not in str(e):
                 raise e
-            cbf.find_column(b"array_id")
+            cbf.find_column("array_id")
 
         panel_names = []
         for i in range(cbf.count_rows()):
             cbf.select_row(i)
-            if cbf.get_typeofvalue() == b"null":
+            if cbf.get_typeofvalue() == "null":
                 continue
 
             val = cbf.get_value()
@@ -215,16 +214,16 @@ class FormatCBFMultiTileHierarchy(FormatCBFMultiTile):
             detector_axes.append(axis0)
             cbf_detector.__swig_destroy__(cbf_detector)
         panel_names_detectororder = []
-        cbf.find_category(b"array_structure_list")
+        cbf.find_category("array_structure_list")
         for detector_axis in detector_axes:
-            cbf.find_column(b"axis_set_id")
+            cbf.find_column("axis_set_id")
             cbf.find_row(detector_axis)
             try:
-                cbf.find_column(b"array_section_id")
+                cbf.find_column("array_section_id")
             except Exception as e:
                 if "CBF_NOTFOUND" not in str(e):
                     raise e
-                cbf.find_column(b"array_id")
+                cbf.find_column("array_id")
             panel_names_detectororder.append(cbf.get_value())
 
         for panel_name in panel_names:
@@ -248,13 +247,13 @@ class FormatCBFMultiTileHierarchy(FormatCBFMultiTile):
                 if "CBF_NOTFOUND" in str(e):
                     # no array data in the file, it's probably just a cbf header.  Get the image size elsewhere
                     size = [0, 0]
-                    cbf.find_category(b"array_structure_list")
+                    cbf.find_category("array_structure_list")
                     for axis in [axis0, axis1]:
-                        cbf.find_column(b"axis_set_id")
+                        cbf.find_column("axis_set_id")
                         cbf.find_row(axis)
-                        cbf.find_column(b"precedence")
+                        cbf.find_column("precedence")
                         idx = int(cbf.get_value()) - 1
-                        cbf.find_column(b"dimension")
+                        cbf.find_column("dimension")
                         size[idx] = int(cbf.get_value())
                     assert size[0] != 0 and size[1] != 0
                 else:
@@ -273,8 +272,8 @@ class FormatCBFMultiTileHierarchy(FormatCBFMultiTile):
             p.set_local_frame(fast, slow, origin)
 
             try:
-                cbf.find_category(b"array_intensities")
-                cbf.find_column(b"undefined_value")
+                cbf.find_category("array_intensities")
+                cbf.find_column("undefined_value")
                 underload = cbf.get_doublevalue()
                 overload = cbf.get_overload(0)
                 trusted_range = (underload, overload)
@@ -301,8 +300,8 @@ class FormatCBFMultiTileHierarchy(FormatCBFMultiTile):
         if self._raw_data is None:
             self._raw_data = []
             cbf = self._get_cbf_handle()
-            cbf.find_category(b"array_structure")
-            cbf.find_column(b"encoding_type")
+            cbf.find_category("array_structure")
+            cbf.find_column("encoding_type")
             cbf.select_row(0)
             types = []
             for i in range(cbf.count_rows()):
@@ -312,21 +311,21 @@ class FormatCBFMultiTileHierarchy(FormatCBFMultiTile):
 
             # read the data
             data = collections.OrderedDict()
-            cbf.find_category(b"array_data")
+            cbf.find_category("array_data")
             for i in range(cbf.count_rows()):
-                cbf.find_column(b"array_id")
+                cbf.find_column("array_id")
                 name = cbf.get_value()
 
-                cbf.find_column(b"data")
-                assert cbf.get_typeofvalue().find(b"bnry") > -1
+                cbf.find_column("data")
+                assert cbf.get_typeofvalue().find("bnry") > -1
 
-                if types[i] == b"signed 32-bit integer":
+                if types[i] == "signed 32-bit integer":
                     array_string = cbf.get_integerarray_as_string()
                     nelem = int(len(array_string) / 4)
                     array = flex.int(struct.unpack("%di" % nelem, array_string))
                     parameters = cbf.get_integerarrayparameters_wdims_fs()
                     array_size = (parameters[11], parameters[10], parameters[9])
-                elif types[i] == b"signed 64-bit real IEEE":
+                elif types[i] == "signed 64-bit real IEEE":
                     array_string = cbf.get_realarray_as_string()
                     nelem = int(len(array_string) / 8)
                     array = flex.double(struct.unpack("%dd" % nelem, array_string))
@@ -343,22 +342,22 @@ class FormatCBFMultiTileHierarchy(FormatCBFMultiTile):
             if cbf.has_sections():
                 section_shapes = collections.OrderedDict()
                 for i in range(cbf.count_rows()):
-                    cbf.find_column(b"id")
+                    cbf.find_column("id")
                     section_name = cbf.get_value()
                     if section_name not in section_shapes:
                         section_shapes[section_name] = {}
-                    cbf.find_column(b"array_id")
+                    cbf.find_column("array_id")
                     if "array_id" not in section_shapes[section_name]:
                         section_shapes[section_name]["array_id"] = cbf.get_value()
                     else:
                         assert (
                             section_shapes[section_name]["array_id"] == cbf.get_value()
                         )
-                    cbf.find_column(b"index")
+                    cbf.find_column("index")
                     axis_index = int(cbf.get_value()) - 1
-                    cbf.find_column(b"start")
+                    cbf.find_column("start")
                     axis_start = int(cbf.get_value()) - 1
-                    cbf.find_column(b"end")
+                    cbf.find_column("end")
                     axis_end = int(cbf.get_value())
 
                     section_shapes[section_name][axis_index] = slice(

--- a/format/cbf_wrapper.py
+++ b/format/cbf_wrapper.py
@@ -1,0 +1,138 @@
+from __future__ import print_function
+import pycbf
+from libtbx.utils import to_unicode, to_bytes, to_str
+
+class cbf_wrapper(pycbf.cbf_handle_struct):
+    """Wrapper class that provides convenience functions for working with cbflib.
+       It ensures that string arguments are passed to parent class as bytes,
+       while bytes returned from the parent class are converted to strings."""
+
+    def add_category(self, name, columns):
+        """Create a new category and populate it with column names"""
+        self.new_category(to_bytes(name))
+        for column in columns:
+            self.new_column(to_bytes(column))
+
+    def add_row(self, data):
+        """Add a row to the current category.  If data contains more entries than
+        there are columns in this category, then the remainder is truncated
+        Use '.' for an empty value in a row."""
+
+        self.new_row()
+        self.rewind_column()
+        for item in data:
+            self.set_value(to_bytes(item))
+            if item == ".":
+                self.set_typeofvalue(b"null")
+            try:
+                self.next_column()
+            except Exception:
+                break
+
+    def has_sections(self):
+        """True if the cbf has the array_structure_list_section table, which
+        changes how its data is stored in the binary sections
+        """
+        try:
+            self.find_category("array_structure_list_section")
+            return True
+        except Exception as e:
+            if "CBF_NOTFOUND" in str(e):
+                return False
+            raise e
+
+    def read_widefile(self, imagefile, flags=pycbf.MSG_DIGEST):
+        return super(cbf_wrapper, self).read_widefile(to_bytes(imagefile), flags)
+
+    def new_datablock(self, arg):
+        return to_str(super(cbf_wrapper, self).new_datablock(to_bytes(arg)))
+
+    def find_category(self, arg):
+        return to_str(super(cbf_wrapper, self).find_category(to_bytes(arg)))
+
+    def find_column(self, arg):
+        return to_str(super(cbf_wrapper, self).find_column(to_bytes(arg)))
+
+    def set_realarray_wdims_fs(self,
+                                pycbf_const,
+                                binary_id,
+                                data,
+                                elsize,
+                                elements,
+                                byteorder,
+                                dimfast,
+                                dimmid,
+                                dimslow,
+                                padding):
+        return super(cbf_wrapper, self).set_realarray_wdims_fs(pycbf_const,
+                                                              binary_id,
+                                                              data,
+                                                              elsize,
+                                                              elements,
+                                                              to_bytes(byteorder),
+                                                              dimfast,
+                                                              dimmid,
+                                                              dimslow,
+                                                              padding)
+
+    def find_row(self, arg):
+        return to_str(super(cbf_wrapper, self).find_row(to_bytes(arg)))
+
+    def set_datablockname(self, arg):
+        return super(cbf_wrapper, self).set_datablockname(to_bytes(arg))
+
+    def column_name(self):
+        return to_str(super(cbf_wrapper, self).column_name())
+
+    def get_value(self):
+        return to_str(super(cbf_wrapper, self).get_value())
+
+    def set_value(self, val):
+        super(cbf_wrapper, self).set_value(to_bytes(val))
+
+    def category_name(self):
+        return to_str(super(cbf_wrapper, self).category_name())
+
+    def get_typeofvalue(self):
+        return to_str(super(cbf_wrapper, self).get_typeofvalue())
+
+    def get_axis_type(self, axis_id):
+        return to_str(super(cbf_wrapper, self).get_axis_type(to_bytes(axis_id)))
+
+    def get_axis_offset(self, axis_id):
+        return super(cbf_wrapper, self).get_axis_offset(to_bytes(axis_id))  
+
+    def get_axis_vector(self, axis_id):
+        return super(cbf_wrapper, self).get_axis_vector(to_bytes(axis_id))
+
+    def get_axis_setting(self, axis_id):
+        return super(cbf_wrapper, self).get_axis_setting(to_bytes(axis_id))
+
+    def get_axis_depends_on(self, axis_id):
+        return to_str(super(cbf_wrapper, self).get_axis_depends_on(to_bytes(axis_id)))
+
+    def get_axis_equipment_component(self, axis_id):
+        return to_str(super(cbf_wrapper, self).get_axis_equipment_component(to_bytes(axis_id)))
+
+    def set_axis_setting(self, axis_id, start, increment):
+        super(cbf_wrapper, self).set_axis_setting(to_bytes(axis_id), start, increment)
+
+    def construct_detector(self, element_number):
+        return cbf_detector_wrapper(super(cbf_wrapper, self).construct_detector(element_number))
+
+class cbf_detector_wrapper(object):
+    def __init__(self, cbf_detector):
+        self._cbf_detector = cbf_detector
+
+    def __getattr__(self, name):
+        return getattr(self._cbf_detector, name)
+
+    def __setattr__(self, name, value):
+        if name == '_cbf_detector':
+            super(cbf_detector_wrapper, self).__setattr__(name, value)    
+        else:
+            setattr(self._cbf_detector, name, value)
+
+    def get_detector_surface_axes(self, index):
+        return to_str(self._cbf_detector.get_detector_surface_axes(index))
+

--- a/format/cbf_wrapper.py
+++ b/format/cbf_wrapper.py
@@ -146,3 +146,8 @@ class cbf_detector_wrapper(object):
     def get_detector_surface_axes(self, index):
         return to_str(self._cbf_detector.get_detector_surface_axes(index))
 
+    def __swig_destroy__(self, cbf_detector):
+        try:
+            self._cbf_detector.__swig_destroy__(cbf_detector)
+        except TypeError:
+            self._cbf_detector.__swig_destroy__(cbf_detector._cbf_detector)

--- a/format/cbf_wrapper.py
+++ b/format/cbf_wrapper.py
@@ -42,6 +42,9 @@ class cbf_wrapper(pycbf.cbf_handle_struct):
                 return False
             raise e
 
+    def read_file(self, imagefile, flags=pycbf.MSG_DIGEST):
+        return super(cbf_wrapper, self).read_file(to_bytes(imagefile), flags)
+
     def read_widefile(self, imagefile, flags=pycbf.MSG_DIGEST):
         return super(cbf_wrapper, self).read_widefile(to_bytes(imagefile), flags)
 

--- a/format/cbf_wrapper.py
+++ b/format/cbf_wrapper.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 import pycbf
-from libtbx.utils import to_unicode, to_bytes, to_str
+from libtbx.utils import to_bytes, to_str
+
 
 class cbf_wrapper(pycbf.cbf_handle_struct):
     """Wrapper class that provides convenience functions for working with cbflib.
@@ -53,27 +54,31 @@ class cbf_wrapper(pycbf.cbf_handle_struct):
     def find_column(self, arg):
         return to_str(super(cbf_wrapper, self).find_column(to_bytes(arg)))
 
-    def set_realarray_wdims_fs(self,
-                                pycbf_const,
-                                binary_id,
-                                data,
-                                elsize,
-                                elements,
-                                byteorder,
-                                dimfast,
-                                dimmid,
-                                dimslow,
-                                padding):
-        return super(cbf_wrapper, self).set_realarray_wdims_fs(pycbf_const,
-                                                              binary_id,
-                                                              data,
-                                                              elsize,
-                                                              elements,
-                                                              to_bytes(byteorder),
-                                                              dimfast,
-                                                              dimmid,
-                                                              dimslow,
-                                                              padding)
+    def set_realarray_wdims_fs(
+        self,
+        pycbf_const,
+        binary_id,
+        data,
+        elsize,
+        elements,
+        byteorder,
+        dimfast,
+        dimmid,
+        dimslow,
+        padding,
+    ):
+        return super(cbf_wrapper, self).set_realarray_wdims_fs(
+            pycbf_const,
+            binary_id,
+            data,
+            elsize,
+            elements,
+            to_bytes(byteorder),
+            dimfast,
+            dimmid,
+            dimslow,
+            padding,
+        )
 
     def find_row(self, arg):
         return to_str(super(cbf_wrapper, self).find_row(to_bytes(arg)))
@@ -100,7 +105,7 @@ class cbf_wrapper(pycbf.cbf_handle_struct):
         return to_str(super(cbf_wrapper, self).get_axis_type(to_bytes(axis_id)))
 
     def get_axis_offset(self, axis_id):
-        return super(cbf_wrapper, self).get_axis_offset(to_bytes(axis_id))  
+        return super(cbf_wrapper, self).get_axis_offset(to_bytes(axis_id))
 
     def get_axis_vector(self, axis_id):
         return super(cbf_wrapper, self).get_axis_vector(to_bytes(axis_id))
@@ -112,13 +117,18 @@ class cbf_wrapper(pycbf.cbf_handle_struct):
         return to_str(super(cbf_wrapper, self).get_axis_depends_on(to_bytes(axis_id)))
 
     def get_axis_equipment_component(self, axis_id):
-        return to_str(super(cbf_wrapper, self).get_axis_equipment_component(to_bytes(axis_id)))
+        return to_str(
+            super(cbf_wrapper, self).get_axis_equipment_component(to_bytes(axis_id))
+        )
 
     def set_axis_setting(self, axis_id, start, increment):
         super(cbf_wrapper, self).set_axis_setting(to_bytes(axis_id), start, increment)
 
     def construct_detector(self, element_number):
-        return cbf_detector_wrapper(super(cbf_wrapper, self).construct_detector(element_number))
+        return cbf_detector_wrapper(
+            super(cbf_wrapper, self).construct_detector(element_number)
+        )
+
 
 class cbf_detector_wrapper(object):
     def __init__(self, cbf_detector):
@@ -128,8 +138,8 @@ class cbf_detector_wrapper(object):
         return getattr(self._cbf_detector, name)
 
     def __setattr__(self, name, value):
-        if name == '_cbf_detector':
-            super(cbf_detector_wrapper, self).__setattr__(name, value)    
+        if name == "_cbf_detector":
+            super(cbf_detector_wrapper, self).__setattr__(name, value)
         else:
             setattr(self._cbf_detector, name, value)
 

--- a/model/beam.py
+++ b/model/beam.py
@@ -5,7 +5,7 @@ from builtins import object, range
 
 import libtbx.phil
 
-import pycbf
+from dxtbx.format.cbf_wrapper import cbf_wrapper
 from dxtbx_model_ext import Beam
 
 beam_phil_scope = libtbx.phil.parse(
@@ -226,8 +226,8 @@ class BeamFactory(object):
         in this - it is the angle between the polarization plane and the
         +Y laboratory frame vector."""
 
-        cbf_handle = pycbf.cbf_handle_struct()
-        cbf_handle.read_widefile(cif_file.encode(), pycbf.MSG_DIGEST)
+        cbf_handle = cbf_wrapper()
+        cbf_handle.read_widefile(cif_file)
 
         result = BeamFactory.imgCIF_H(cbf_handle)
 
@@ -243,19 +243,19 @@ class BeamFactory(object):
 
         d2r = math.pi / 180.0
 
-        cbf_handle.find_category(b"axis")
+        cbf_handle.find_category("axis")
 
         # find record with equipment = source
 
         try:
-            cbf_handle.find_column(b"equipment")
-            cbf_handle.find_row(b"source")
+            cbf_handle.find_column("equipment")
+            cbf_handle.find_row("source")
 
             # then get the vector and offset from this
             direction = []
 
             for j in range(3):
-                cbf_handle.find_column(b"vector[%d]" % (j + 1))
+                cbf_handle.find_column("vector[%d]" % (j + 1))
                 direction.append(cbf_handle.get_doublevalue())
         except Exception as e:
             if str(e).split()[-1] != "CBF_NOTFOUND":

--- a/model/detector.py
+++ b/model/detector.py
@@ -8,7 +8,7 @@ from cctbx.eltbx import attenuation_coefficient
 from libtbx.utils import Sorry
 from scitbx import matrix
 
-import pycbf
+from dxtbx.format.cbf_wrapper import cbf_wrapper
 from dxtbx.model.detector_helpers import (
     detector_helper_sensors,
     find_undefined_value,
@@ -711,8 +711,8 @@ class DetectorFactory(object):
     def imgCIF(cif_file, sensor):
         """Initialize a detector model from an imgCIF file."""
 
-        cbf_handle = pycbf.cbf_handle_struct()
-        cbf_handle.read_file(cif_file.encode(), pycbf.MSG_DIGEST)
+        cbf_handle = cbf_wrapper()
+        cbf_handle.read_file(cif_file)
 
         return DetectorFactory.imgCIF_H(cbf_handle, sensor)
 

--- a/model/scan.py
+++ b/model/scan.py
@@ -6,7 +6,7 @@ from builtins import object, range
 import libtbx.phil
 from scitbx.array_family import flex
 
-import pycbf
+from dxtbx.format.cbf_wrapper import cbf_wrapper
 from dxtbx.model.scan_helpers import scan_helper_image_files, scan_helper_image_formats
 from dxtbx_model_ext import Scan
 
@@ -166,8 +166,8 @@ class ScanFactory(object):
     def imgCIF(cif_file):
         """Initialize a scan model from an imgCIF file."""
 
-        cbf_handle = pycbf.cbf_handle_struct()
-        cbf_handle.read_file(cif_file, pycbf.MSG_DIGEST)
+        cbf_handle = cbf_wrapper()
+        cbf_handle.read_file(cif_file)
 
         return ScanFactory.imgCIF_H(cif_file, cbf_handle)
 


### PR DESCRIPTION
As part of the psana1/psana2/python3 work, we have now reached the point where we need to convert the cbf writing in cctbx.xfel to python 3.  It became clear that it makes sense to move all the string handling into a centralized class in dxtbx, `cbf_wrapper`, that wraps the pycbf swig code.  We are using the py2/py3 aware to_str and to_bytes functions @bkpoon made in libtbx to do the conversion in the wrapping class.  What's nice is all the `b"` tags now can go away in the FormatCBFFull classes.

A subsequent pull request in cctbx_project/xfel will be prepared to use these features.
