### PR TITLE
Do not use Sorry in a library environment

### DIFF
--- a/datablock.py
+++ b/datablock.py
@@ -11,14 +11,14 @@ import os.path
 from builtins import range
 from os.path import abspath, dirname, normpath, splitext
 
+import six
+import six.moves.cPickle as pickle
+
 import libtbx
-from libtbx.utils import Sorry
 from scitbx import matrix
 
 import dxtbx.imageset
 import dxtbx.model
-import six
-import six.moves.cPickle as pickle
 from dxtbx.format.Format import Format
 from dxtbx.format.FormatMultiImage import FormatMultiImage
 from dxtbx.format.image import ImageBool, ImageDouble
@@ -384,14 +384,14 @@ class DataBlockTemplateImporter(object):
 
             # Check if we've matched any filenames
             if len(paths) == 0:
-                raise Sorry('Template "%s" does not match any files' % template)
+                raise ValueError('Template "%s" does not match any files' % template)
 
             # Get the format from the first image
             fmt = FormatChecker().find_format(paths[0])
             if fmt is None:
-                raise Sorry("Image file %s format is unknown" % paths[0])
+                raise ValueError("Image file %s format is unknown" % paths[0])
             elif fmt.ignore():
-                raise Sorry("Image file %s format will be ignored" % paths[0])
+                raise ValueError("Image file %s format will be ignored" % paths[0])
             else:
                 imageset = self._create_imageset(fmt, template, paths, **kwargs)
                 append_to_datablocks(imageset)
@@ -408,7 +408,7 @@ class DataBlockTemplateImporter(object):
             all_numbers = {int(f[index]) for f in filenames}
             missing = set(range(first, last + 1)) - all_numbers
             if missing:
-                raise Sorry(
+                raise ValueError(
                     "Missing image{} {} from imageset ({}-{})".format(
                         "s" if len(missing) > 1 else "",
                         ", ".join(str(x) for x in sorted(missing)),

--- a/format/FormatBrukerPhotonII.py
+++ b/format/FormatBrukerPhotonII.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, division, print_function
 import sys
 
 from boost.python import streambuf
-from libtbx.utils import Sorry
 from scitbx import matrix
 from scitbx.array_family import flex
 
@@ -166,8 +165,8 @@ class FormatBrukerPhotonII(FormatBruker):
         # the understand method. Otherwise the user gets FormatBruker reading the
         # image improperly but without failing
         if self.header_dict["FORMAT"] != "100":
-            raise Sorry(
-                "Only FORMAT 100 images from the Photon II are currently " "supported"
+            raise ValueError(
+                "Only FORMAT 100 images from the Photon II are currently supported"
             )
 
         f = self.open_file(self._image_file, "rb")

--- a/format/FormatBrukerPhotonII.py
+++ b/format/FormatBrukerPhotonII.py
@@ -165,7 +165,7 @@ class FormatBrukerPhotonII(FormatBruker):
         # the understand method. Otherwise the user gets FormatBruker reading the
         # image improperly but without failing
         if self.header_dict["FORMAT"] != "100":
-            raise ValueError(
+            raise NotImplementedError(
                 "Only FORMAT 100 images from the Photon II are currently supported"
             )
 

--- a/model/detector.py
+++ b/model/detector.py
@@ -5,7 +5,6 @@ from builtins import object, range
 
 import libtbx.phil
 from cctbx.eltbx import attenuation_coefficient
-from libtbx.utils import Sorry
 from scitbx import matrix
 
 import pycbf
@@ -446,7 +445,9 @@ class DetectorFactory(object):
             if len(params.detector.slow_fast_beam_centre) > 2:
                 panel_id = params.detector.slow_fast_beam_centre[2]
             if panel_id >= len(detector):
-                raise Sorry("Detector does not have panel index {}".format(panel_id))
+                raise IndexError(
+                    "Detector does not have panel index {}".format(panel_id)
+                )
             px_size_f, px_size_s = detector[0].get_pixel_size()
             slow_fast_beam_centre_mm = (
                 params.detector.slow_fast_beam_centre[0] * px_size_s,

--- a/model/scan_helpers.py
+++ b/model/scan_helpers.py
@@ -9,8 +9,6 @@ import os
 import re
 from builtins import object
 
-from libtbx.utils import Sorry
-
 # These are reversed patterns...
 patterns = [
     r"([0-9]{2,12})\.(.*)",
@@ -49,7 +47,7 @@ def template_regex(filename):
         return template, int(digits)
 
     # What is supposed to happen otherwise?
-    raise Sorry("Could not determine filename template")
+    raise ValueError("Could not determine filename template")
 
 
 def _image2template(filename):


### PR DESCRIPTION
For dxtbx to be general for Python (not just cctbx) people use proper Python built-in exceptions e.g. IndexError, ValueError. 

With this branch leaves Sorry in one area of code I have no business in and `command_line` which is fine. 

```
Grey-Area dxtbx :( [not-sorry] $ find . -name '*py' | xargs grep Sorry 
./format/FormatCBFMultiTileHierarchy.py:from libtbx.utils import Sorry
./format/FormatCBFMultiTileHierarchy.py:            raise Sorry("Unrecognized vector type: %s" % axis_type)
./command_line/radial_average.py:from libtbx.utils import Sorry, Usage
./command_line/radial_average.py:                    raise Sorry(
./command_line/radial_average.py:                    raise Sorry("Unrecognized argument '%s'" % arg)
./command_line/plot_detector_models.py:from libtbx.utils import Sorry
./command_line/plot_detector_models.py:                raise Sorry("Unrecognized argument %s" % arg)
./command_line/image_average.py:from libtbx.utils import Sorry, Usage
./command_line/image_average.py:            raise Sorry("Could not read path {}".format(paths[0]))
./command_line/image_average.py:            raise Sorry("MPI not found")
./command_line/detector_superpose.py:from libtbx.utils import Sorry
./command_line/detector_superpose.py:            raise Sorry("Please ensure reference has only 1 detector model")
./command_line/detector_superpose.py:            raise Sorry("Please ensure moving has only 1 detector model")
```

