### PR TITLE
Handle slicing when images start from 0

### DIFF
--- a/imageset.py
+++ b/imageset.py
@@ -226,26 +226,27 @@ class _(object):
 
         """
         if isinstance(item, slice):
+            offset = self.get_scan().get_batch_offset()
             if item.step is not None:
                 raise IndexError("Sequences must be sequential")
 
             # nasty workaround for https://github.com/dials/dials/issues/1153
             # slices with -1 in them are meaningful :-/ so grab the original
-            # constructor arguments
-            if self.get_scan().get_batch_offset() < 0:
+            # constructor arguments of the slice object.
+            # item.start and item.stop may have been compromised at this point.
+            if offset < 0:
                 start, stop, step = item.__reduce__()[1]
                 if start is None:
                     start = 0
                 else:
-                    start -= self.get_scan().get_batch_offset()
+                    start -= offset
                 if stop is None:
                     stop = len(self)
                 else:
-                    stop -= self.get_scan().get_batch_offset()
+                    stop -= offset
                 return self.partial_set(start, stop)
             else:
                 start = item.start or 0
-                offset = self.get_scan().get_batch_offset()
                 stop = item.stop or (len(self) + offset)
                 return self.partial_set(start - offset, stop - offset)
         else:

--- a/imageset.py
+++ b/imageset.py
@@ -226,12 +226,28 @@ class _(object):
 
         """
         if isinstance(item, slice):
-            start = item.start or 0
-            offset = self.get_scan().get_batch_offset()
-            stop = item.stop or (len(self) + offset)
             if item.step is not None:
                 raise IndexError("Sequences must be sequential")
-            return self.partial_set(start - offset, stop - offset)
+
+            # nasty workaround for https://github.com/dials/dials/issues/1153
+            # slices with -1 in them are meaningful :-/ so grab the original
+            # constructor arguments
+            if self.get_scan().get_batch_offset() < 0:
+                start, stop, step = item.__reduce__()[1]
+                if start is None:
+                    start = 0
+                else:
+                    start -= self.get_scan().get_batch_offset()
+                if stop is None:
+                    stop = len(self)
+                else:
+                    stop -= self.get_scan().get_batch_offset()
+                return self.partial_set(start, stop)
+            else:
+                start = item.start or 0
+                offset = self.get_scan().get_batch_offset()
+                stop = item.stop or (len(self) + offset)
+                return self.partial_set(start - offset, stop - offset)
         else:
             return self.get_corrected_data(item)
 

--- a/newsfragments/141.bugfix
+++ b/newsfragments/141.bugfix
@@ -1,0 +1,1 @@
+Fixed imageset slicing for image sets starting from image 0


### PR DESCRIPTION
Because of the unique way we handle numbers (i.e. mishandle in most obfuscated way possible) images numbered 0 have index -1 which in turn makes for a lot of fun indexing `imageset[j:j+1]` since `imageset[-1:0]` _means_ something in Python; yay. Work around by grabbing the constructor arguments which were provided as input and correcting these; needs very substantial testing to ensure slicing to end of array or similar still works...