### PR TITLE
Add goniometer.axis parameter.

### DIFF
--- a/model/goniometer.py
+++ b/model/goniometer.py
@@ -246,6 +246,8 @@ class GoniometerFactory(object):
         else:
             if params.goniometer.axis is None and params.goniometer.axes is None:
                 return None
+            if params.goniometer.axis and params.goniometer.axes:
+                raise ValueError("Only one of axis or axes should be set")
             if params.goniometer.axes and len(params.goniometer.axes) > 3:
                 goniometer = GoniometerFactory.multi_axis_goniometer_from_phil(params)
             else:

--- a/model/goniometer.py
+++ b/model/goniometer.py
@@ -24,6 +24,12 @@ goniometer_phil_scope = libtbx.phil.parse(
     .short_caption = "Goniometer overrides"
   {
 
+    axis = None
+      .type = floats(size=3)
+      .help = "Override the axis for a single axis goniometer. Equivalent to"
+              "providing a single 3D vector to 'axes'."
+      .short_caption="Goniometer axis"
+
     axes = None
       .type = floats
       .help = "Override the goniometer axes. Axes must be provided in the"
@@ -82,9 +88,11 @@ class GoniometerFactory(object):
 
         """
 
-        # Check the axes parameter
-        if params.goniometer.axes is not None and len(params.goniometer.axes) != 3:
-            raise RuntimeError("Single axis goniometer requires 3 axes parameters")
+        # Check the axis parameter and copy from axes if required
+        if params.goniometer.axis is None:
+            params.goniometer.axis = params.goniometer.axes
+        if params.goniometer.axis is not None and len(params.goniometer.axis) != 3:
+            raise RuntimeError("Single axis goniometer requires 3 axis values")
 
         # Check the angles parameter
         if params.goniometer.angles is not None:
@@ -101,8 +109,8 @@ class GoniometerFactory(object):
             goniometer = reference
 
         # Set the parameters
-        if params.goniometer.axes is not None:
-            goniometer.set_rotation_axis_datum(params.goniometer.axes)
+        if params.goniometer.axis is not None:
+            goniometer.set_rotation_axis_datum(params.goniometer.axis)
         if params.goniometer.fixed_rotation is not None:
             goniometer.set_fixed_rotation(params.goniometer.fixed_rotation)
         if params.goniometer.setting_rotation is not None:
@@ -223,7 +231,7 @@ class GoniometerFactory(object):
     @staticmethod
     def from_phil(params, reference=None):
         """
-        Convert the phil parameters into a beam model
+        Convert the phil parameters into a goniometer model
 
         """
         if reference is not None:
@@ -236,9 +244,9 @@ class GoniometerFactory(object):
                     params, reference
                 )
         else:
-            if params.goniometer.axes is None:
+            if params.goniometer.axis is None and params.goniometer.axes is None:
                 return None
-            if len(params.goniometer.axes) > 3:
+            if params.goniometer.axes and len(params.goniometer.axes) > 3:
                 goniometer = GoniometerFactory.multi_axis_goniometer_from_phil(params)
             else:
                 goniometer = GoniometerFactory.single_axis_goniometer_from_phil(params)

--- a/model/goniometer.py
+++ b/model/goniometer.py
@@ -234,18 +234,26 @@ class GoniometerFactory(object):
         Convert the phil parameters into a goniometer model
 
         """
+        if params.goniometer.axis and params.goniometer.axes:
+            raise ValueError("Only one of axis or axes should be set")
         if reference is not None:
             if isinstance(reference, MultiAxisGoniometer):
+                if params.goniometer.axis:
+                    raise ValueError(
+                        "Cannot set 'axis' with a multi-axis reference goniometer"
+                    )
                 goniometer = GoniometerFactory.multi_axis_goniometer_from_phil(
                     params, reference
                 )
             else:
+                if params.goniometer.axes:
+                    raise ValueError(
+                        "Cannot set 'axes' with a single-axis reference goniometer"
+                    )
                 goniometer = GoniometerFactory.single_axis_goniometer_from_phil(
                     params, reference
                 )
         else:
-            if params.goniometer.axis and params.goniometer.axes:
-                raise ValueError("Only one of axis or axes should be set")
             if params.goniometer.axes and len(params.goniometer.axes) > 3:
                 goniometer = GoniometerFactory.multi_axis_goniometer_from_phil(params)
             elif params.goniometer.axis or params.goniometer.axes:

--- a/model/goniometer.py
+++ b/model/goniometer.py
@@ -244,14 +244,14 @@ class GoniometerFactory(object):
                     params, reference
                 )
         else:
-            if params.goniometer.axis is None and params.goniometer.axes is None:
-                return None
             if params.goniometer.axis and params.goniometer.axes:
                 raise ValueError("Only one of axis or axes should be set")
             if params.goniometer.axes and len(params.goniometer.axes) > 3:
                 goniometer = GoniometerFactory.multi_axis_goniometer_from_phil(params)
-            else:
+            elif params.goniometer.axis or params.goniometer.axes:
                 goniometer = GoniometerFactory.single_axis_goniometer_from_phil(params)
+            else:
+                return None
         return goniometer
 
     @staticmethod

--- a/tests/test_goniometer.py
+++ b/tests/test_goniometer.py
@@ -200,7 +200,7 @@ def test_multi_axis_goniometer():
     assert single_axis.get_rotation_axis() == (1, 0, 0)
 
 
-def test_goniometer_from_phil():
+def test_single_axis_goniometer_from_phil():
     params = goniometer_phil_scope.fetch(
         parse(
             """
@@ -214,6 +214,53 @@ def test_goniometer_from_phil():
     g1 = GoniometerFactory.from_phil(params)
 
     assert g1.get_rotation_axis() == (1, 0, 0)
+
+
+def test_single_axis_goniometer_using_axes_from_phil():
+    params = goniometer_phil_scope.fetch(
+        parse(
+            """
+    goniometer {
+      axes = (1, 0, 0)
+    }
+  """
+        )
+    ).extract()
+
+    g1 = GoniometerFactory.from_phil(params)
+
+    assert g1.get_rotation_axis() == (1, 0, 0)
+
+
+def test_single_axis_goniometer_using_axis_and_axes_from_phil():
+
+    params = goniometer_phil_scope.fetch(
+        parse(
+            """
+    goniometer {
+      axis = (1, 0, 0)
+      axes = (1, 0, 0)
+    }
+    """
+        )
+    ).extract()
+
+    with pytest.raises(ValueError):
+        GoniometerFactory.from_phil(params)
+
+
+def test_single_axis_goniometer_with_fixed_rotation_and_reference_from_phil():
+    params = goniometer_phil_scope.fetch(
+        parse(
+            """
+    goniometer {
+      axes = (1, 0, 0)
+    }
+  """
+        )
+    ).extract()
+
+    g1 = GoniometerFactory.from_phil(params)
 
     params = goniometer_phil_scope.fetch(
         parse(
@@ -231,6 +278,8 @@ def test_goniometer_from_phil():
     assert g2.get_rotation_axis() == (0, 1, 0)
     assert g2.get_fixed_rotation() == (0, 1, 0, 1, 0, 0, 0, 0, 1)
 
+
+def test_multi_axis_goniometer_from_phil():
     params = goniometer_phil_scope.fetch(
         parse(
             """
@@ -242,10 +291,11 @@ def test_goniometer_from_phil():
         )
     ).extract()
 
-    g3 = GoniometerFactory.from_phil(params)
-    assert tuple(g3.get_axes()) == ((1, 0, 0), (0, 1, 0), (0, 0, 1))
-    assert g3.get_scan_axis() == 2
+    g1 = GoniometerFactory.from_phil(params)
+    assert tuple(g1.get_axes()) == ((1, 0, 0), (0, 1, 0), (0, 0, 1))
+    assert g1.get_scan_axis() == 2
 
+    # Test using a reference
     params = goniometer_phil_scope.fetch(
         parse(
             """
@@ -256,26 +306,9 @@ def test_goniometer_from_phil():
         )
     ).extract()
 
-    g4 = GoniometerFactory.from_phil(params, reference=g3)
+    g2 = GoniometerFactory.from_phil(params, reference=g1)
 
-    assert tuple(g4.get_axes()) == ((0, 1, 0), (1, 0, 0), (0, 0, 1))
-
-
-def test_axis_and_axes_from_phil():
-
-    params = goniometer_phil_scope.fetch(
-        parse(
-            """
-    goniometer {
-      axis = (1, 0, 0)
-      axes = (1, 0, 0)
-    }
-    """
-        )
-    ).extract()
-
-    with pytest.raises(ValueError):
-        GoniometerFactory.from_phil(params)
+    assert tuple(g2.get_axes()) == ((0, 1, 0), (1, 0, 0), (0, 0, 1))
 
 
 def test_scan_varying():

--- a/tests/test_goniometer.py
+++ b/tests/test_goniometer.py
@@ -4,8 +4,6 @@ import math
 import os
 from builtins import range
 
-import pytest
-
 import libtbx.load_env
 from libtbx import easy_pickle
 from libtbx.phil import parse
@@ -13,6 +11,7 @@ from libtbx.test_utils import Exception_expected, approx_equal
 from scitbx import matrix
 from scitbx.array_family import flex
 
+import pytest
 from dxtbx.model.goniometer import (
     Goniometer,
     GoniometerFactory,
@@ -206,7 +205,7 @@ def test_goniometer_from_phil():
         parse(
             """
     goniometer {
-      axes = (1, 0, 0)
+      axis = (1, 0, 0)
     }
   """
         )
@@ -220,7 +219,7 @@ def test_goniometer_from_phil():
         parse(
             """
     goniometer {
-      axes = (0, 1, 0)
+      axis = (0, 1, 0)
       fixed_rotation = (0, 1, 0, 1, 0, 0, 0, 0, 1)
     }
   """

--- a/tests/test_goniometer.py
+++ b/tests/test_goniometer.py
@@ -233,6 +233,8 @@ def test_single_axis_goniometer_using_axes_from_phil():
 
 
 def test_single_axis_goniometer_using_axis_and_axes_from_phil_raises_error():
+    """Supplying both the 'axis' and 'axes' parameters is ambiguous, so it should
+    be mutually exclusive. This test ensures that is the case."""
 
     params = goniometer_phil_scope.fetch(
         parse(
@@ -312,6 +314,9 @@ def test_multi_axis_goniometer_from_phil():
 
 
 def test_single_axis_goniometer_with_multi_axis_reference_from_phil_raises_error():
+    """Attempting to set up a single-axis goniometer while using a multi-axis
+    goniometer as reference is explicitly unsupported. Ensure this raises an error"""
+
     params = goniometer_phil_scope.fetch(
         parse(
             """
@@ -340,6 +345,8 @@ def test_single_axis_goniometer_with_multi_axis_reference_from_phil_raises_error
 
 
 def test_multi_axis_goniometer_with_single_axis_reference_from_phil_raises_error():
+    """Attempting to set up a mulyi-axis goniometer while using a single-axis
+    goniometer as reference is explicitly unsupported. Ensure this raises an error"""
 
     params = goniometer_phil_scope.fetch(
         parse(

--- a/tests/test_goniometer.py
+++ b/tests/test_goniometer.py
@@ -311,6 +311,63 @@ def test_multi_axis_goniometer_from_phil():
     assert tuple(g2.get_axes()) == ((0, 1, 0), (1, 0, 0), (0, 0, 1))
 
 
+def test_single_axis_goniometer_with_multi_axis_reference_from_phil():
+    params = goniometer_phil_scope.fetch(
+        parse(
+            """
+    goniometer {
+      axes = (1, 0, 0, 0, 1, 0, 0, 0, 1)
+      scan_axis = 2
+    }
+  """
+        )
+    ).extract()
+
+    g1 = GoniometerFactory.from_phil(params)
+
+    params = goniometer_phil_scope.fetch(
+        parse(
+            """
+    goniometer {
+      axis = (0, 1, 0)
+    }
+  """
+        )
+    ).extract()
+
+    with pytest.raises(ValueError):
+        GoniometerFactory.from_phil(params, reference=g1)
+
+
+def test_multi_axis_goniometer_with_single_axis_reference_from_phil():
+
+    params = goniometer_phil_scope.fetch(
+        parse(
+            """
+    goniometer {
+      axis = (0, 1, 0)
+    }
+  """
+        )
+    ).extract()
+
+    g1 = GoniometerFactory.from_phil(params)
+
+    params = goniometer_phil_scope.fetch(
+        parse(
+            """
+    goniometer {
+      axes = (1, 0, 0, 0, 1, 0, 0, 0, 1)
+      scan_axis = 2
+    }
+  """
+        )
+    ).extract()
+
+    with pytest.raises(ValueError):
+        GoniometerFactory.from_phil(params, reference=g1)
+
+
 def test_scan_varying():
     axis = (1, 0, 0)
     g = Goniometer(axis)

--- a/tests/test_goniometer.py
+++ b/tests/test_goniometer.py
@@ -261,6 +261,23 @@ def test_goniometer_from_phil():
     assert tuple(g4.get_axes()) == ((0, 1, 0), (1, 0, 0), (0, 0, 1))
 
 
+def test_axis_and_axes_from_phil():
+
+    params = goniometer_phil_scope.fetch(
+        parse(
+            """
+    goniometer {
+      axis = (1, 0, 0)
+      axes = (1, 0, 0)
+    }
+    """
+        )
+    ).extract()
+
+    with pytest.raises(ValueError):
+        GoniometerFactory.from_phil(params)
+
+
 def test_scan_varying():
     axis = (1, 0, 0)
     g = Goniometer(axis)

--- a/tests/test_goniometer.py
+++ b/tests/test_goniometer.py
@@ -339,7 +339,7 @@ def test_single_axis_goniometer_with_multi_axis_reference_from_phil():
         GoniometerFactory.from_phil(params, reference=g1)
 
 
-def test_multi_axis_goniometer_with_single_axis_reference_from_phil():
+def test_multi_axis_goniometer_with_single_axis_reference_from_phil_raises_error():
 
     params = goniometer_phil_scope.fetch(
         parse(

--- a/tests/test_goniometer.py
+++ b/tests/test_goniometer.py
@@ -311,7 +311,7 @@ def test_multi_axis_goniometer_from_phil():
     assert tuple(g2.get_axes()) == ((0, 1, 0), (1, 0, 0), (0, 0, 1))
 
 
-def test_single_axis_goniometer_with_multi_axis_reference_from_phil():
+def test_single_axis_goniometer_with_multi_axis_reference_from_phil_raises_error():
     params = goniometer_phil_scope.fetch(
         parse(
             """

--- a/tests/test_goniometer.py
+++ b/tests/test_goniometer.py
@@ -232,7 +232,7 @@ def test_single_axis_goniometer_using_axes_from_phil():
     assert g1.get_rotation_axis() == (1, 0, 0)
 
 
-def test_single_axis_goniometer_using_axis_and_axes_from_phil():
+def test_single_axis_goniometer_using_axis_and_axes_from_phil_raises_error():
 
     params = goniometer_phil_scope.fetch(
         parse(


### PR DESCRIPTION
Previously overriding single-axis goniometer orientation in
dials.import only be done by using the geometry.goniometer.axes
parameter, but providing a single 3D axis. This commit adds an
'axis' parameter to give a more natural interface in that case.