### PR TITLE
Use the gain for full cbf files 

### DIFF
--- a/command_line/image_average.py
+++ b/command_line/image_average.py
@@ -360,7 +360,7 @@ def run(argv=None):
 
     # Early exit if no statistics were accumulated.
     if command_line.options.verbose:
-        sys.stderr.write("Processed %d images (%d failed)\n" % (nmemb, nfail))
+        sys.stdout.write("Processed %d images (%d failed)\n" % (nmemb, nfail))
     if nmemb == 0:
         return 0
 

--- a/format/FormatCBFMultiTile.py
+++ b/format/FormatCBFMultiTile.py
@@ -135,6 +135,15 @@ class FormatCBFMultiTile(FormatCBFFull):
                     raise
                 trusted_range = (0.0, 0.0)
 
+            try:
+                cbf.find_column(b"gain")
+                cbf.select_row(i)
+                gain = cbf.get_doublevalue()
+            except Exception as e:
+                if "CBF_NOTFOUND" not in str(e):
+                    raise
+                gain = 1.0
+
             cbf_detector.__swig_destroy__(cbf_detector)
             del cbf_detector
 
@@ -143,6 +152,7 @@ class FormatCBFMultiTile(FormatCBFFull):
             p.set_pixel_size(tuple(map(float, pixel)))
             p.set_image_size(size)
             p.set_trusted_range(tuple(map(float, trusted_range)))
+            p.set_gain(gain)
             # p.set_px_mm_strategy(px_mm) FIXME
 
         return d

--- a/format/FormatCBFMultiTile.py
+++ b/format/FormatCBFMultiTile.py
@@ -126,10 +126,13 @@ class FormatCBFMultiTile(FormatCBFFull):
             try:
                 cbf.find_category(b"array_intensities")
                 cbf.find_column(b"undefined_value")
+                cbf.select_row(i)
                 underload = cbf.get_doublevalue()
-                overload = cbf.get_overload(0)
+                overload = cbf.get_overload(i)
                 trusted_range = (underload, overload)
-            except Exception:
+            except Exception as e:
+                if "CBF_NOTFOUND" not in str(e):
+                    raise
                 trusted_range = (0.0, 0.0)
 
             cbf_detector.__swig_destroy__(cbf_detector)

--- a/format/FormatCBFMultiTileHierarchy.py
+++ b/format/FormatCBFMultiTileHierarchy.py
@@ -299,9 +299,18 @@ class FormatCBFMultiTileHierarchy(FormatCBFMultiTile):
                     raise
                 trusted_range = (0.0, 0.0)
 
+            try:
+                cbf.find_column(b"gain")
+                gain = cbf.get_doublevalue()
+            except Exception as e:
+                if "CBF_NOTFOUND" not in str(e):
+                    raise
+                gain = 1.0
+
             p.set_pixel_size(tuple(map(float, pixel)))
             p.set_image_size(size)
             p.set_trusted_range(tuple(map(float, trusted_range)))
+            p.set_gain(gain)
             p.set_name(panel_name)
             # p.set_px_mm_strategy(px_mm) FIXME
 

--- a/format/cbf_writer.py
+++ b/format/cbf_writer.py
@@ -203,6 +203,7 @@ class FullCBFWriter(object):
                 [panel.get_trusted_range() for panel in detector],
                 diffrn_id,
                 False,
+                gain=[panel.get_gain() for panel in detector],
             )
 
         """Data items in the AXIS category record the information required

--- a/model/detector.py
+++ b/model/detector.py
@@ -11,6 +11,7 @@ import pycbf
 from dxtbx.model.detector_helpers import (
     detector_helper_sensors,
     find_undefined_value,
+    find_gain_value,
     set_detector_distance,
     set_mosflm_beam_centre,
     set_slow_fast_beam_centre_mm,
@@ -741,6 +742,8 @@ class DetectorFactory(object):
         except Exception:
             trusted_range = (0.0, 1.0e6)
 
+        gain = find_gain_value(cbf_handle)
+
         cbf_detector.__swig_destroy__(cbf_detector)
         del cbf_detector
 
@@ -752,6 +755,7 @@ class DetectorFactory(object):
             pixel,
             size,
             trusted_range,
+            gain=gain,
         )
 
     @staticmethod

--- a/model/detector_helpers.py
+++ b/model/detector_helpers.py
@@ -115,6 +115,18 @@ def find_undefined_value(cbf_handle):
     return cbf_handle.get_doublevalue()
 
 
+def find_gain_value(cbf_handle):
+    """Given a cbf handle, get the gain value."""
+    try:
+        cbf_handle.find_category(b"array_intensities")
+        cbf_handle.find_column(b"gain")
+    except Exception as e:
+        if "CBF_NOTFOUND" not in str(e):
+            raise
+        return 1.0
+    return cbf_handle.get_doublevalue()
+
+
 class detector_helper_sensors(object):
     """A helper class which allows enumeration of detector sensor technologies
     which should help in identifying specific detectors when needed. These are

--- a/tests/command_line/test_average.py
+++ b/tests/command_line/test_average.py
@@ -1,0 +1,27 @@
+from __future__ import absolute_import, division, print_function
+
+import procrunner
+import dxtbx
+import os
+
+
+def test_average(dials_regression, tmpdir):
+    data = os.path.join(
+        dials_regression,
+        "image_examples",
+        "SACLA_MPCCD_Cheetah",
+        "run266702-0-subset.h5",
+    )
+    result = procrunner.run(
+        ["dxtbx.image_average"]
+        + "-v -a avg.cbf -s stddev.cbf -m max.cbf".split()
+        + [data],
+        working_directory=tmpdir,
+    )
+    assert not result.returncode and not result.stderr
+
+    h5 = dxtbx.load(data).get_detector()
+    cbf = dxtbx.load(tmpdir.join("avg.cbf")).get_detector()
+
+    assert h5.is_similar_to(cbf)
+    assert h5[0].get_gain() == cbf[0].get_gain()


### PR DESCRIPTION
- Add a test for dxtbx.image_average that includes testing gain
- Modify full cbf format readers to read the gain
- Modify cbf_writer to use the gain

This does affect any processing that uses cbfs with a gain !=1.  See for example dials_regression/image_examples/SPring8_ADSC_SN916/Xtal17-2phi_3_015.cbf.  On master, dxtbx.print_header will report gain=1.  With this change, gain will be 1.84.