### PR TITLE
New "postrefined cell" member data

### DIFF
--- a/model/__init__.py
+++ b/model/__init__.py
@@ -279,6 +279,12 @@ class _(object):
             except RuntimeError:
                 pass
 
+        try:
+            postrefine_cell = self.get_unit_cell(postrefined=True)
+            xl_dict["postrefined_cell"] = postrefine_cell
+        except RuntimeError:
+            pass
+
         return xl_dict
 
     @staticmethod
@@ -336,6 +342,9 @@ class _(object):
             cov_B_at_scan_points.reshape(flex.grid(xl.num_scan_points, 9, 9))
             xl.set_B_covariance_at_scan_points(cov_B_at_scan_points)
 
+        postrefined_cell = d.get("postrefined_cell")
+        if postrefined_cell is not None:
+            xl.set_unit_cell(postrefined_cell, postrefined=True)
         return xl
 
 

--- a/model/boost_python/crystal.cc
+++ b/model/boost_python/crystal.cc
@@ -284,14 +284,15 @@ namespace dxtbx { namespace model { namespace boost_python {
   }
 
   inline void CrystalBase_set_unit_cell(CrystalBase &self,
-                                        cctbx::uctbx::unit_cell &unit_cell) {
-    self.set_unit_cell(unit_cell);
+                                        cctbx::uctbx::unit_cell &unit_cell,
+                                        bool postrefined=false) {
+    self.set_unit_cell(unit_cell, postrefined);
   }
 
   void export_crystal() {
     class_<CrystalBase, boost::noncopyable>("CrystalBase", no_init)
       .def("set_unit_cell", CrystalBase_set_unit_cell_real_space_vectors)
-      .def("set_unit_cell", CrystalBase_set_unit_cell)
+      .def("set_unit_cell", CrystalBase_set_unit_cell,(arg("unit_cell"), arg("postrefined") = false))
       .def("update_B", &CrystalBase::update_B)
       .def("set_U", &CrystalBase::set_U)
       .def("get_U", &CrystalBase::get_U)
@@ -299,7 +300,7 @@ namespace dxtbx { namespace model { namespace boost_python {
       .def("get_B", &CrystalBase::get_B)
       .def("set_A", &CrystalBase::set_A)
       .def("get_A", &CrystalBase::get_A)
-      .def("get_unit_cell", &CrystalBase::get_unit_cell)
+      .def("get_unit_cell", &CrystalBase::get_unit_cell,(arg("postrefined") = false))
       .def("get_real_space_vectors", &CrystalBase::get_real_space_vectors)
       .def("set_space_group", &CrystalBase::set_space_group)
       .def("get_space_group", &CrystalBase::get_space_group)

--- a/model/crystal.h
+++ b/model/crystal.h
@@ -153,7 +153,8 @@ namespace dxtbx { namespace model {
                                const vec3<double> &real_space_b,
                                const vec3<double> &real_space_c) = 0;
     // Set the unit cell parameters
-    virtual void set_unit_cell(const cctbx::uctbx::unit_cell &unit_cell) = 0;
+    virtual void set_unit_cell(const cctbx::uctbx::unit_cell &unit_cell,
+                               bool postrefined = false) = 0;
     // Update the B matrix
     virtual void update_B() = 0;
     // Set the U matrix
@@ -169,7 +170,7 @@ namespace dxtbx { namespace model {
     // @returns the A matrix
     virtual mat3<double> get_A() const = 0;
     // @returns the unit_cell
-    virtual cctbx::uctbx::unit_cell get_unit_cell() const = 0;
+    virtual cctbx::uctbx::unit_cell get_unit_cell(bool postrefined = false) const = 0;
     // @returns the real space vectors
     virtual scitbx::af::shared<vec3<double> > get_real_space_vectors() const = 0;
     // Set the space group
@@ -383,9 +384,13 @@ namespace dxtbx { namespace model {
      *
      * @param unit_cell The updated unit cell
      */
-    void set_unit_cell(const cctbx::uctbx::unit_cell &unit_cell) {
-      unit_cell_ = unit_cell;
-      update_B();
+    void set_unit_cell(const cctbx::uctbx::unit_cell &unit_cell, bool postrefined=false) {
+      if (postrefined){
+        postrefined_cell_ = unit_cell;
+      } else {
+        unit_cell_ = unit_cell;
+        update_B();
+      }
     }
 
     /**
@@ -461,8 +466,12 @@ namespace dxtbx { namespace model {
     /**
      * @returns the unit_cell
      */
-    cctbx::uctbx::unit_cell get_unit_cell() const {
-      return unit_cell_;
+    cctbx::uctbx::unit_cell get_unit_cell(bool postrefined=false) const {
+      if (postrefined){
+        return postrefined_cell_;
+      } else {
+        return unit_cell_;
+      }
     }
 
     /**
@@ -1028,6 +1037,7 @@ namespace dxtbx { namespace model {
   protected:
     cctbx::sgtbx::space_group space_group_;
     cctbx::uctbx::unit_cell unit_cell_;
+    cctbx::uctbx::unit_cell postrefined_cell_;
     mat3<double> U_;
     mat3<double> B_;
     scitbx::af::shared<mat3<double> > A_at_scan_points_;

--- a/model/crystal.h
+++ b/model/crystal.h
@@ -154,7 +154,7 @@ namespace dxtbx { namespace model {
                                const vec3<double> &real_space_c) = 0;
     // Set the unit cell parameters
     virtual void set_unit_cell(const cctbx::uctbx::unit_cell &unit_cell,
-                               bool postrefined = false) = 0;
+                               const bool postrefined = false) = 0;
     // Update the B matrix
     virtual void update_B() = 0;
     // Set the U matrix
@@ -384,8 +384,10 @@ namespace dxtbx { namespace model {
      *
      * @param unit_cell The updated unit cell
      */
-    void set_unit_cell(const cctbx::uctbx::unit_cell &unit_cell, bool postrefined=false) {
+    void set_unit_cell(const cctbx::uctbx::unit_cell &unit_cell,
+                       const bool postrefined=false) {
       if (postrefined){
+        postrefined_cell_is_set_ = true;
         postrefined_cell_ = unit_cell;
       } else {
         unit_cell_ = unit_cell;
@@ -468,6 +470,7 @@ namespace dxtbx { namespace model {
      */
     cctbx::uctbx::unit_cell get_unit_cell(bool postrefined=false) const {
       if (postrefined){
+        DXTBX_ASSERT(postrefined_cell_is_set_);
         return postrefined_cell_;
       } else {
         return unit_cell_;
@@ -1038,6 +1041,7 @@ namespace dxtbx { namespace model {
     cctbx::sgtbx::space_group space_group_;
     cctbx::uctbx::unit_cell unit_cell_;
     cctbx::uctbx::unit_cell postrefined_cell_;
+    bool postrefined_cell_is_set_ = false;
     mat3<double> U_;
     mat3<double> B_;
     scitbx::af::shared<mat3<double> > A_at_scan_points_;

--- a/model/crystal.h
+++ b/model/crystal.h
@@ -712,6 +712,15 @@ namespace dxtbx { namespace model {
       if (!uc_a.is_similar_to(uc_b, uc_rel_length_tolerance, uc_abs_angle_tolerance)) {
         return false;
       }
+      if (postrefined_cell_is_set_) {
+        bool postrefined = true;
+        cctbx::uctbx::unit_cell uc_a = get_unit_cell(postrefined);
+        cctbx::uctbx::unit_cell uc_b = other.get_unit_cell(postrefined);
+        if (!uc_a.is_similar_to(uc_b, uc_rel_length_tolerance, uc_abs_angle_tolerance)) {
+          return false;
+        }
+      }
+
 
       // scan varying tests
       if (get_num_scan_points() != other.get_num_scan_points()) {

--- a/tests/model/test_crystal_model.py
+++ b/tests/model/test_crystal_model.py
@@ -596,3 +596,25 @@ def test_set_scan_varying_B_covariance(crystal_class):
         assert cov_B_at_scan_point == cov_B_2d
         cell_sd_at_scan_point = xl.get_cell_parameter_sd_at_scan_point(i)
         assert cell_sd_at_scan_point == pytest.approx(cell_sd)
+
+
+def test_postrefined_cell():
+    xl = Crystal(
+        real_space_a=(10, 0, 0),
+        real_space_b=(0, 11, 0),
+        real_space_c=(0, 0, 12),
+        space_group_symbol="P 1",
+    )
+
+    # This should fail: cannot access postrefined cell before it is set
+    with pytest.raises(RuntimeError):
+        xl.get_unit_cell(postrefined=True)
+        pytest.fail("Postrefined cell not set yet")
+
+    uc1 = xl.get_unit_cell()
+    xl.set_unit_cell(uc1, postrefined=True)
+
+    # Now it is possible to get the cell
+    uc2 = xl.get_unit_cell(postrefined=True)
+
+    assert uc1.is_similar_to(uc2)

--- a/tests/serialize/test_crystal_model_serialize.py
+++ b/tests/serialize/test_crystal_model_serialize.py
@@ -75,3 +75,17 @@ def test_crystal_with_scan_points(example_crystal):
             assert abs(e1 - e2) <= eps
 
     assert c1 == c2
+
+
+def test_crystal_with_postrefined_cell(example_crystal):
+    c1 = Crystal(**example_crystal)
+    uc = c1.get_unit_cell()
+    c1.set_unit_cell(uc, postrefined=True)
+
+    d = c1.to_dict()
+    c2 = CrystalFactory.from_dict(d)
+
+    assert c1.get_unit_cell(postrefined=True).is_similar_to(
+        c2.get_unit_cell(postrefined=True)
+    )
+    assert c1 == c2


### PR DESCRIPTION
Extends `Crystal` to include a separate cell that can be accessed by passing `postrefined=True` into `get_unit_cell` and `set_unit_cell`. This is preparatory work for dials/dials#670 and fixes #142