### PR TITLE
Multi-wavelength NeXus

### DIFF
--- a/format/FormatHDF5EigerNearlyNexus.py
+++ b/format/FormatHDF5EigerNearlyNexus.py
@@ -377,8 +377,7 @@ class FormatHDF5EigerNearlyNexus(FormatHDF5):
         return self._detector_model
 
     def _beam(self, index=None):
-        self._beam_factory.load_model(index)
-        self._beam_model = self._beam_factory.model
+        self._beam_model = self._beam_factory.load_model(index)
         return self._beam_model
 
     def _scan(self):

--- a/format/FormatHDF5EigerNearlyNexus.py
+++ b/format/FormatHDF5EigerNearlyNexus.py
@@ -356,8 +356,9 @@ class FormatHDF5EigerNearlyNexus(FormatHDF5):
         data = NXdata(fixer.handle_orig[entry.data[0].handle.name])
 
         # Construct the models
-        self._beam_model = BeamFactory(beam).model
-        self._detector_model = DetectorFactory(detector, self._beam_model).model
+        self._beam_factory = BeamFactory(beam)
+        self._beam_factory.load_model(0)
+        self._detector_model = DetectorFactory(detector, self._beam_factory.model).model
         self._goniometer_model = GoniometerFactory(sample).model
         self._scan_model = ScanFactory(sample, detector).model
         self._raw_data = DataFactory(data, cached_information=fixer.data_factory_cache)
@@ -375,7 +376,9 @@ class FormatHDF5EigerNearlyNexus(FormatHDF5):
     def _detector(self):
         return self._detector_model
 
-    def _beam(self):
+    def _beam(self, index=None):
+        self._beam_factory.load_model(index)
+        self._beam_model = self._beam_factory.model
         return self._beam_model
 
     def _scan(self):
@@ -388,7 +391,7 @@ class FormatHDF5EigerNearlyNexus(FormatHDF5):
         return self._detector()
 
     def get_beam(self, index=None):
-        return self._beam()
+        return self._beam(index)
 
     def get_scan(self, index=None):
         if index is None:

--- a/format/FormatNexus.py
+++ b/format/FormatNexus.py
@@ -98,8 +98,7 @@ class FormatNexus(FormatHDF5):
         return self._detector_model
 
     def _beam(self, index=None):
-        self._beam_factory.load_model(index)
-        self._beam_model = self._beam_factory.model
+        self._beam_model = self._beam_factory.load_model(index)
         return self._beam_model
 
     def _scan(self):

--- a/format/FormatNexusJungfrauHack.py
+++ b/format/FormatNexusJungfrauHack.py
@@ -62,9 +62,10 @@ class FormatNexusJungfrauHack(FormatNexus):
         data = entry.data[0]
 
         # Construct the models
-        self._beam_model = BeamFactory(beam).model
+        self._beam_factory = BeamFactory(beam).model
+        self._beam_factory.load_model(0)
 
-        self._setup_detector(detector, self._beam_model)
+        self._setup_detector(detector, self._beam_factory.model)
         self._setup_gonio_and_scan(sample, detector)
 
         if self._scan_model:
@@ -222,14 +223,8 @@ class FormatNexusJungfrauHack(FormatNexus):
         return self._detector_model
 
     def _beam(self, index=None):
-        if index is None:
-            index = 0
-
-        entry = self._reader.entries[0]
-        sample = entry.samples[0]
-        beam = sample.beams[0]
-
-        self._beam_model = BeamFactory(beam, index).model
+        self._beam_factory.load_model(index)
+        self._beam_model = self._beam_factory.model
         return self._beam_model
 
     def _scan(self):
@@ -242,7 +237,7 @@ class FormatNexusJungfrauHack(FormatNexus):
         return self._detector()
 
     def get_beam(self, index=None):
-        return self._beam()
+        return self._beam(index)
 
     def get_scan(self, index=None):
         if index is None:

--- a/format/FormatNexusJungfrauHack.py
+++ b/format/FormatNexusJungfrauHack.py
@@ -62,7 +62,7 @@ class FormatNexusJungfrauHack(FormatNexus):
         data = entry.data[0]
 
         # Construct the models
-        self._beam_factory = BeamFactory(beam).model
+        self._beam_factory = BeamFactory(beam)
         self._beam_factory.load_model(0)
 
         self._setup_detector(detector, self._beam_factory.model)
@@ -223,8 +223,7 @@ class FormatNexusJungfrauHack(FormatNexus):
         return self._detector_model
 
     def _beam(self, index=None):
-        self._beam_factory.load_model(index)
-        self._beam_model = self._beam_factory.model
+        self._beam_model = self._beam_factory.load_model(index)
         return self._beam_model
 
     def _scan(self):

--- a/format/nexus.py
+++ b/format/nexus.py
@@ -543,7 +543,7 @@ class BeamFactory(object):
     def load_model(self, index=None):
         # Cached model
         if self.model is not None and index == self.index:
-            return
+            return self.model
 
         # Get the items from the NXbeam class
         wavelength = self.obj.handle["incident_wavelength"]
@@ -569,6 +569,7 @@ class BeamFactory(object):
         # Construct the beam model
         self.index = index
         self.model = Beam(direction=(0, 0, 1), wavelength=wavelength_value)
+        return self.model
 
 
 def get_change_of_basis(transformation):


### PR DESCRIPTION
As of nexusformat/definitions#717, NeXus can support multiple wavelength files.  This pull request does two steps of refactoring:
1. Implement get_beam in FormatNexus and derived classes such that it takes an index.
2. Refactor the nexus.py BeamFactory to add a get_model method which takes an index. That way the beam model can be loaded on request as opposed to only in `__init__`.

Documentation for NXBeam as part of NXmx: https://manual.nexusformat.org/classes/applications/NXmx.html. Note the several available use cases, including a per-shot spectrum. These use cases are stubbed out in this pull request, and will be implemented at a later date.

This is a draft pull request because it requires #147.  After that is merged, I'll make this ready, but this request can be reviewed now.