### PR TITLE
Recalculated cell

### DIFF
--- a/model/__init__.py
+++ b/model/__init__.py
@@ -369,12 +369,6 @@ class _(object):
 
         return xl
 
-    def get_recalc_unit_cell(self):
-        if self._has_recalc_unit_cell():
-            return self._get_recalc_unit_cell()
-        else:
-            return None
-
 
 @boost.python.inject_into(MosaicCrystalKabsch2010)
 class _(object):

--- a/model/__init__.py
+++ b/model/__init__.py
@@ -298,9 +298,13 @@ class _(object):
 
         recalculated_unit_cell = self.get_recalculated_unit_cell()
         if recalculated_unit_cell is not None:
-            recalculated_cell_parameter_sd = self.get_recalculated_cell_parameter_sd()
             xl_dict["recalculated_unit_cell"] = recalculated_unit_cell.parameters()
-            xl_dict["recalculated_cell_parameter_sd"] = recalculated_cell_parameter_sd
+            xl_dict[
+                "recalculated_cell_parameter_sd"
+            ] = self.get_recalculated_cell_parameter_sd()
+            xl_dict[
+                "recalculated_cell_volume_sd"
+            ] = self.get_recalculated_cell_volume_sd()
 
         return xl_dict
 
@@ -366,6 +370,10 @@ class _(object):
         recalculated_cell_parameter_sd = d.get("recalculated_cell_parameter_sd")
         if recalculated_cell_parameter_sd is not None:
             xl.set_recalculated_cell_parameter_sd(recalculated_cell_parameter_sd)
+
+        recalculated_cell_volume_sd = d.get("recalculated_cell_volume_sd")
+        if recalculated_cell_volume_sd is not None:
+            xl.set_recalculated_cell_volume_sd(recalculated_cell_volume_sd)
 
         return xl
 

--- a/model/__init__.py
+++ b/model/__init__.py
@@ -169,10 +169,10 @@ class _(object):
                 format_float_with_standard_uncertainty(v, e, minimum=1.0e-5)
                 for (v, e) in zip(uc, uc_sd)
             ]
-            msg.append("    Unit cell: (" + ", ".join(cell_str) + ")")
+            msg.append("    Unit cell: " + ", ".join(cell_str))
         else:
             msg.append(
-                "    Unit cell: " + "(%5.3f, %5.3f, %5.3f, %5.3f, %5.3f, %5.3f)" % uc
+                "    Unit cell: " + "%5.3f, %5.3f, %5.3f, %5.3f, %5.3f, %5.3f" % uc
             )
         msg.append("    Space group: " + sg)
         msg.append("    U matrix:  " + umat[0])
@@ -204,7 +204,7 @@ class _(object):
                     msg.append("  Scan point #%i:" % (i + 1))
                     msg.append(
                         "    Unit cell: "
-                        + "(%5.3f, %5.3f, %5.3f, %5.3f, %5.3f, %5.3f)" % uc
+                        + "%5.3f, %5.3f, %5.3f, %5.3f, %5.3f, %5.3f" % uc
                     )
                     msg.append("    U matrix:  " + umat[0])
                     msg.append("               " + umat[1])
@@ -225,7 +225,7 @@ class _(object):
                     format_float_with_standard_uncertainty(v, e, minimum=1.0e-5)
                     for (v, e) in zip(uc, uc_sd)
                 ]
-                msg.append("    Recalculated unit cell: (" + ", ".join(cell_str) + ")")
+                msg.append("    Recalculated unit cell: " + ", ".join(cell_str))
             else:
                 msg.append(
                     "    Recalculated unit cell: "

--- a/model/__init__.py
+++ b/model/__init__.py
@@ -281,7 +281,9 @@ class _(object):
 
         if self.has_recalc_unit_cell():
             recalc_unit_cell = self.get_recalc_unit_cell()
+            recalc_cell_parameter_sd = self.get_recalc_cell_parameter_sd()
             xl_dict["recalc_unit_cell"] = recalc_unit_cell
+            xl_dict["recalc_cell_parameter_sd"] = recalc_cell_parameter_sd
 
         return xl_dict
 
@@ -343,6 +345,10 @@ class _(object):
         recalc_unit_cell = d.get("recalc_unit_cell")
         if recalc_unit_cell is not None:
             xl.set_recalc_unit_cell(recalc_unit_cell)
+
+        recalc_cell_parameter_sd = d.get("recalc_cell_parameter_sd")
+        if recalc_cell_parameter_sd is not None:
+            xl.set_recalc_cell_parameter_sd(recalc_cell_parameter_sd)
 
         return xl
 

--- a/model/__init__.py
+++ b/model/__init__.py
@@ -10,6 +10,7 @@ import six.moves.cPickle as pickle
 
 import boost.python
 import cctbx.crystal
+import cctbx.uctbx
 from libtbx.containers import OrderedSet
 from libtbx.utils import format_float_with_standard_uncertainty
 from scitbx import matrix
@@ -214,6 +215,20 @@ class _(object):
                     msg.append("    A = UB:    " + amat[0])
                     msg.append("               " + amat[1])
                     msg.append("               " + amat[2])
+        if self.has_recalc_unit_cell():
+            uc = self.get_recalc_unit_cell().parameters()
+            uc_sd = self.get_recalc_cell_parameter_sd()
+            if len(uc_sd) != 0:
+                cell_str = [
+                    format_float_with_standard_uncertainty(v, e, minimum=1.0e-5)
+                    for (v, e) in zip(uc, uc_sd)
+                ]
+                msg.append("    Recalculated unit cell: (" + ", ".join(cell_str) + ")")
+            else:
+                msg.append(
+                    "    Recalculated unit cell: "
+                    + "(%5.3f, %5.3f, %5.3f, %5.3f, %5.3f, %5.3f)" % uc
+                )
         return "\n".join(msg)
 
     def __str__(self):
@@ -282,7 +297,7 @@ class _(object):
         if self.has_recalc_unit_cell():
             recalc_unit_cell = self.get_recalc_unit_cell()
             recalc_cell_parameter_sd = self.get_recalc_cell_parameter_sd()
-            xl_dict["recalc_unit_cell"] = recalc_unit_cell
+            xl_dict["recalc_unit_cell"] = recalc_unit_cell.parameters()
             xl_dict["recalc_cell_parameter_sd"] = recalc_cell_parameter_sd
 
         return xl_dict
@@ -344,7 +359,7 @@ class _(object):
 
         recalc_unit_cell = d.get("recalc_unit_cell")
         if recalc_unit_cell is not None:
-            xl.set_recalc_unit_cell(recalc_unit_cell)
+            xl.set_recalc_unit_cell(cctbx.uctbx.unit_cell(recalc_unit_cell))
 
         recalc_cell_parameter_sd = d.get("recalc_cell_parameter_sd")
         if recalc_cell_parameter_sd is not None:

--- a/model/__init__.py
+++ b/model/__init__.py
@@ -216,10 +216,10 @@ class _(object):
                     msg.append("               " + amat[1])
                     msg.append("               " + amat[2])
 
-        uc = self.get_recalc_unit_cell()
+        uc = self.get_recalculated_unit_cell()
         if uc is not None:
             uc = uc.parameters()
-            uc_sd = self.get_recalc_cell_parameter_sd()
+            uc_sd = self.get_recalculated_cell_parameter_sd()
             if len(uc_sd) != 0:
                 cell_str = [
                     format_float_with_standard_uncertainty(v, e, minimum=1.0e-5)
@@ -296,11 +296,11 @@ class _(object):
             except RuntimeError:
                 pass
 
-        recalc_unit_cell = self.get_recalc_unit_cell()
-        if recalc_unit_cell is not None:
-            recalc_cell_parameter_sd = self.get_recalc_cell_parameter_sd()
-            xl_dict["recalc_unit_cell"] = recalc_unit_cell.parameters()
-            xl_dict["recalc_cell_parameter_sd"] = recalc_cell_parameter_sd
+        recalculated_unit_cell = self.get_recalculated_unit_cell()
+        if recalculated_unit_cell is not None:
+            recalculated_cell_parameter_sd = self.get_recalculated_cell_parameter_sd()
+            xl_dict["recalculated_unit_cell"] = recalculated_unit_cell.parameters()
+            xl_dict["recalculated_cell_parameter_sd"] = recalculated_cell_parameter_sd
 
         return xl_dict
 
@@ -359,13 +359,13 @@ class _(object):
             cov_B_at_scan_points.reshape(flex.grid(xl.num_scan_points, 9, 9))
             xl.set_B_covariance_at_scan_points(cov_B_at_scan_points)
 
-        recalc_unit_cell = d.get("recalc_unit_cell")
-        if recalc_unit_cell is not None:
-            xl.set_recalc_unit_cell(cctbx.uctbx.unit_cell(recalc_unit_cell))
+        recalculated_unit_cell = d.get("recalculated_unit_cell")
+        if recalculated_unit_cell is not None:
+            xl.set_recalculated_unit_cell(cctbx.uctbx.unit_cell(recalculated_unit_cell))
 
-        recalc_cell_parameter_sd = d.get("recalc_cell_parameter_sd")
-        if recalc_cell_parameter_sd is not None:
-            xl.set_recalc_cell_parameter_sd(recalc_cell_parameter_sd)
+        recalculated_cell_parameter_sd = d.get("recalculated_cell_parameter_sd")
+        if recalculated_cell_parameter_sd is not None:
+            xl.set_recalculated_cell_parameter_sd(recalculated_cell_parameter_sd)
 
         return xl
 

--- a/model/__init__.py
+++ b/model/__init__.py
@@ -279,6 +279,10 @@ class _(object):
             except RuntimeError:
                 pass
 
+        if self.has_recalc_unit_cell():
+            recalc_unit_cell = self.get_recalc_unit_cell()
+            xl_dict["recalc_unit_cell"] = recalc_unit_cell
+
         return xl_dict
 
     @staticmethod
@@ -335,6 +339,10 @@ class _(object):
             cov_B_at_scan_points = flex.double(cov_B_at_scan_points).as_1d()
             cov_B_at_scan_points.reshape(flex.grid(xl.num_scan_points, 9, 9))
             xl.set_B_covariance_at_scan_points(cov_B_at_scan_points)
+
+        recalc_unit_cell = d.get("recalc_unit_cell")
+        if recalc_unit_cell is not None:
+            xl.set_recalc_unit_cell(recalc_unit_cell)
 
         return xl
 

--- a/model/__init__.py
+++ b/model/__init__.py
@@ -215,8 +215,10 @@ class _(object):
                     msg.append("    A = UB:    " + amat[0])
                     msg.append("               " + amat[1])
                     msg.append("               " + amat[2])
-        if self.has_recalc_unit_cell():
-            uc = self.get_recalc_unit_cell().parameters()
+
+        uc = self.get_recalc_unit_cell()
+        if uc is not None:
+            uc = uc.parameters()
             uc_sd = self.get_recalc_cell_parameter_sd()
             if len(uc_sd) != 0:
                 cell_str = [
@@ -294,8 +296,8 @@ class _(object):
             except RuntimeError:
                 pass
 
-        if self.has_recalc_unit_cell():
-            recalc_unit_cell = self.get_recalc_unit_cell()
+        recalc_unit_cell = self.get_recalc_unit_cell()
+        if recalc_unit_cell is not None:
             recalc_cell_parameter_sd = self.get_recalc_cell_parameter_sd()
             xl_dict["recalc_unit_cell"] = recalc_unit_cell.parameters()
             xl_dict["recalc_cell_parameter_sd"] = recalc_cell_parameter_sd
@@ -366,6 +368,12 @@ class _(object):
             xl.set_recalc_cell_parameter_sd(recalc_cell_parameter_sd)
 
         return xl
+
+    def get_recalc_unit_cell(self):
+        if self._has_recalc_unit_cell():
+            return self._get_recalc_unit_cell()
+        else:
+            return None
 
 
 @boost.python.inject_into(MosaicCrystalKabsch2010)

--- a/model/boost_python/crystal.cc
+++ b/model/boost_python/crystal.cc
@@ -288,6 +288,16 @@ namespace dxtbx { namespace model { namespace boost_python {
     self.set_unit_cell(unit_cell);
   }
 
+  inline void CrystalBase_set_recalc_unit_cell(CrystalBase &self,
+                                        cctbx::uctbx::unit_cell &unit_cell) {
+    self.set_recalc_unit_cell(unit_cell);
+  }
+
+  inline void CrystalBase_set_recalc_cell_parameter_sd(CrystalBase &self,
+      const scitbx::af::small<double, 6> &unit_cell_sd) {
+    self.set_recalc_cell_parameter_sd(unit_cell_sd);
+  }
+
   void export_crystal() {
     class_<CrystalBase, boost::noncopyable>("CrystalBase", no_init)
       .def("set_unit_cell", CrystalBase_set_unit_cell_real_space_vectors)
@@ -338,6 +348,11 @@ namespace dxtbx { namespace model { namespace boost_python {
       .def("get_cell_parameter_sd_at_scan_point",
            &CrystalBase::get_cell_parameter_sd_at_scan_point)
       .def("reset_unit_cell_errors", &CrystalBase::reset_unit_cell_errors)
+      .def("set_recalc_unit_cell", &CrystalBase_set_recalc_unit_cell)
+      .def("get_recalc_unit_cell", &CrystalBase::get_recalc_unit_cell)
+      .def("set_recalc_cell_parameter_sd", &CrystalBase_set_recalc_cell_parameter_sd)
+      .def("get_recalc_cell_parameter_sd", &CrystalBase::get_recalc_cell_parameter_sd)
+      .def("has_recalc_unit_cell", &CrystalBase::has_recalc_unit_cell)
       .def("__eq__", &CrystalBase::operator==)
       .def("__ne__", &CrystalBase::operator!=);
 

--- a/model/boost_python/crystal.cc
+++ b/model/boost_python/crystal.cc
@@ -155,12 +155,14 @@ namespace dxtbx { namespace model { namespace boost_python {
       return boost::python::make_tuple(obj.attr("__dict__"),
                                        crystal.get_A_at_scan_points(),
                                        crystal.get_B_covariance(),
-                                       crystal.get_B_covariance_at_scan_points());
+                                       crystal.get_B_covariance_at_scan_points(),
+                                       crystal.get_recalculated_unit_cell(),
+                                       crystal.get_recalculated_cell_parameter_sd());
     }
 
     static void setstate(boost::python::object obj, boost::python::tuple state) {
       Crystal &crystal = boost::python::extract<Crystal &>(obj)();
-      DXTBX_ASSERT(boost::python::len(state) == 4);
+      DXTBX_ASSERT(boost::python::len(state) == 6);
 
       // restore the object's __dict__
       boost::python::dict d =
@@ -176,9 +178,17 @@ namespace dxtbx { namespace model { namespace boost_python {
       scitbx::af::const_ref<double, scitbx::af::c_grid<3> > cov_B_scanpoints =
         boost::python::extract<scitbx::af::const_ref<double, scitbx::af::c_grid<3> > >(
           state[3]);
+      boost::optional<cctbx::uctbx::unit_cell> recalculated_unit_cell =
+        boost::python::extract<boost::optional<cctbx::uctbx::unit_cell> >(state[4]);
+      scitbx::af::small<double, 6> recalculated_cell_parameter_sd =
+        boost::python::extract<scitbx::af::small<double, 6> >(state[5]);
       crystal.set_A_at_scan_points(A_scanpoints);
       crystal.set_B_covariance(cov_B);
       crystal.set_B_covariance_at_scan_points(cov_B_scanpoints);
+      if (recalculated_unit_cell) {
+          crystal.set_recalculated_unit_cell(*recalculated_unit_cell);
+      }
+      crystal.set_recalculated_cell_parameter_sd(recalculated_cell_parameter_sd);
     }
 
     static bool getstate_manages_dict() {
@@ -200,13 +210,15 @@ namespace dxtbx { namespace model { namespace boost_python {
                                        crystal.get_A_at_scan_points(),
                                        crystal.get_B_covariance(),
                                        crystal.get_B_covariance_at_scan_points(),
+                                       crystal.get_recalculated_unit_cell(),
+                                       crystal.get_recalculated_cell_parameter_sd(),
                                        crystal.get_mosaicity());
     }
 
     static void setstate(boost::python::object obj, boost::python::tuple state) {
       MosaicCrystalKabsch2010 &crystal =
         boost::python::extract<MosaicCrystalKabsch2010 &>(obj)();
-      DXTBX_ASSERT(boost::python::len(state) == 5);
+      DXTBX_ASSERT(boost::python::len(state) == 7);
 
       // restore the object's __dict__
       boost::python::dict d =
@@ -222,10 +234,18 @@ namespace dxtbx { namespace model { namespace boost_python {
       scitbx::af::const_ref<double, scitbx::af::c_grid<3> > cov_B_scanpoints =
         boost::python::extract<scitbx::af::const_ref<double, scitbx::af::c_grid<3> > >(
           state[3]);
-      double mosaicity = boost::python::extract<double>(state[4]);
+      boost::optional<cctbx::uctbx::unit_cell> recalculated_unit_cell =
+        boost::python::extract<boost::optional<cctbx::uctbx::unit_cell> >(state[4]);
+      scitbx::af::small<double, 6> recalculated_cell_parameter_sd =
+        boost::python::extract<scitbx::af::small<double, 6> >(state[5]);
+      double mosaicity = boost::python::extract<double>(state[6]);
       crystal.set_A_at_scan_points(A_scanpoints);
       crystal.set_B_covariance(cov_B);
       crystal.set_B_covariance_at_scan_points(cov_B_scanpoints);
+      if (recalculated_unit_cell) {
+          crystal.set_recalculated_unit_cell(*recalculated_unit_cell);
+      }
+      crystal.set_recalculated_cell_parameter_sd(recalculated_cell_parameter_sd);
       crystal.set_mosaicity(mosaicity);
     }
   };
@@ -244,6 +264,8 @@ namespace dxtbx { namespace model { namespace boost_python {
                                        crystal.get_A_at_scan_points(),
                                        crystal.get_B_covariance(),
                                        crystal.get_B_covariance_at_scan_points(),
+                                       crystal.get_recalculated_unit_cell(),
+                                       crystal.get_recalculated_cell_parameter_sd(),
                                        crystal.get_half_mosaicity_deg(),
                                        crystal.get_domain_size_ang());
     }
@@ -251,7 +273,7 @@ namespace dxtbx { namespace model { namespace boost_python {
     static void setstate(boost::python::object obj, boost::python::tuple state) {
       MosaicCrystalSauter2014 &crystal =
         boost::python::extract<MosaicCrystalSauter2014 &>(obj)();
-      DXTBX_ASSERT(boost::python::len(state) == 6);
+      DXTBX_ASSERT(boost::python::len(state) == 8);
 
       // restore the object's __dict__
       boost::python::dict d =
@@ -267,11 +289,19 @@ namespace dxtbx { namespace model { namespace boost_python {
       scitbx::af::const_ref<double, scitbx::af::c_grid<3> > cov_B_scanpoints =
         boost::python::extract<scitbx::af::const_ref<double, scitbx::af::c_grid<3> > >(
           state[3]);
-      double half_mosaicity_deg = boost::python::extract<double>(state[4]);
-      double domain_size_ang = boost::python::extract<double>(state[5]);
+      boost::optional<cctbx::uctbx::unit_cell> recalculated_unit_cell =
+        boost::python::extract<boost::optional<cctbx::uctbx::unit_cell> >(state[4]);
+      scitbx::af::small<double, 6> recalculated_cell_parameter_sd =
+        boost::python::extract<scitbx::af::small<double, 6> >(state[5]);
+      double half_mosaicity_deg = boost::python::extract<double>(state[6]);
+      double domain_size_ang = boost::python::extract<double>(state[7]);
       crystal.set_A_at_scan_points(A_scanpoints);
       crystal.set_B_covariance(cov_B);
       crystal.set_B_covariance_at_scan_points(cov_B_scanpoints);
+      if (recalculated_unit_cell) {
+          crystal.set_recalculated_unit_cell(*recalculated_unit_cell);
+      }
+      crystal.set_recalculated_cell_parameter_sd(recalculated_cell_parameter_sd);
       crystal.set_half_mosaicity_deg(half_mosaicity_deg);
       crystal.set_domain_size_ang(domain_size_ang);
     }

--- a/model/boost_python/crystal.cc
+++ b/model/boost_python/crystal.cc
@@ -157,12 +157,13 @@ namespace dxtbx { namespace model { namespace boost_python {
                                        crystal.get_B_covariance(),
                                        crystal.get_B_covariance_at_scan_points(),
                                        crystal.get_recalculated_unit_cell(),
-                                       crystal.get_recalculated_cell_parameter_sd());
+                                       crystal.get_recalculated_cell_parameter_sd(),
+                                       crystal.get_recalculated_cell_volume_sd());
     }
 
     static void setstate(boost::python::object obj, boost::python::tuple state) {
       Crystal &crystal = boost::python::extract<Crystal &>(obj)();
-      DXTBX_ASSERT(boost::python::len(state) == 6);
+      DXTBX_ASSERT(boost::python::len(state) == 7);
 
       // restore the object's __dict__
       boost::python::dict d =
@@ -182,6 +183,8 @@ namespace dxtbx { namespace model { namespace boost_python {
         boost::python::extract<boost::optional<cctbx::uctbx::unit_cell> >(state[4]);
       scitbx::af::small<double, 6> recalculated_cell_parameter_sd =
         boost::python::extract<scitbx::af::small<double, 6> >(state[5]);
+      double recalculated_cell_volume_sd =
+        boost::python::extract<double>(state[6]);
       crystal.set_A_at_scan_points(A_scanpoints);
       crystal.set_B_covariance(cov_B);
       crystal.set_B_covariance_at_scan_points(cov_B_scanpoints);
@@ -189,6 +192,7 @@ namespace dxtbx { namespace model { namespace boost_python {
           crystal.set_recalculated_unit_cell(*recalculated_unit_cell);
       }
       crystal.set_recalculated_cell_parameter_sd(recalculated_cell_parameter_sd);
+      crystal.set_recalculated_cell_volume_sd(recalculated_cell_volume_sd);
     }
 
     static bool getstate_manages_dict() {
@@ -212,67 +216,13 @@ namespace dxtbx { namespace model { namespace boost_python {
                                        crystal.get_B_covariance_at_scan_points(),
                                        crystal.get_recalculated_unit_cell(),
                                        crystal.get_recalculated_cell_parameter_sd(),
+                                       crystal.get_recalculated_cell_volume_sd(),
                                        crystal.get_mosaicity());
     }
 
     static void setstate(boost::python::object obj, boost::python::tuple state) {
       MosaicCrystalKabsch2010 &crystal =
         boost::python::extract<MosaicCrystalKabsch2010 &>(obj)();
-      DXTBX_ASSERT(boost::python::len(state) == 7);
-
-      // restore the object's __dict__
-      boost::python::dict d =
-        boost::python::extract<boost::python::dict>(obj.attr("__dict__"))();
-      d.update(state[0]);
-
-      // restore the internal state of the C++ object
-      scitbx::af::const_ref<mat3<double> > A_scanpoints =
-        boost::python::extract<scitbx::af::const_ref<mat3<double> > >(state[1]);
-      scitbx::af::const_ref<double, scitbx::af::c_grid<2> > cov_B =
-        boost::python::extract<scitbx::af::const_ref<double, scitbx::af::c_grid<2> > >(
-          state[2]);
-      scitbx::af::const_ref<double, scitbx::af::c_grid<3> > cov_B_scanpoints =
-        boost::python::extract<scitbx::af::const_ref<double, scitbx::af::c_grid<3> > >(
-          state[3]);
-      boost::optional<cctbx::uctbx::unit_cell> recalculated_unit_cell =
-        boost::python::extract<boost::optional<cctbx::uctbx::unit_cell> >(state[4]);
-      scitbx::af::small<double, 6> recalculated_cell_parameter_sd =
-        boost::python::extract<scitbx::af::small<double, 6> >(state[5]);
-      double mosaicity = boost::python::extract<double>(state[6]);
-      crystal.set_A_at_scan_points(A_scanpoints);
-      crystal.set_B_covariance(cov_B);
-      crystal.set_B_covariance_at_scan_points(cov_B_scanpoints);
-      if (recalculated_unit_cell) {
-          crystal.set_recalculated_unit_cell(*recalculated_unit_cell);
-      }
-      crystal.set_recalculated_cell_parameter_sd(recalculated_cell_parameter_sd);
-      crystal.set_mosaicity(mosaicity);
-    }
-  };
-
-  struct MosaicCrystalSauter2014PickleSuite : CrystalPickleSuite {
-    static boost::python::tuple getinitargs(const MosaicCrystalSauter2014 &obj) {
-      scitbx::af::shared<vec3<double> > real_space_v = obj.get_real_space_vectors();
-      return boost::python::make_tuple(
-        real_space_v[0], real_space_v[1], real_space_v[2], obj.get_space_group());
-    }
-
-    static boost::python::tuple getstate(boost::python::object obj) {
-      const MosaicCrystalSauter2014 &crystal =
-        boost::python::extract<const MosaicCrystalSauter2014 &>(obj)();
-      return boost::python::make_tuple(obj.attr("__dict__"),
-                                       crystal.get_A_at_scan_points(),
-                                       crystal.get_B_covariance(),
-                                       crystal.get_B_covariance_at_scan_points(),
-                                       crystal.get_recalculated_unit_cell(),
-                                       crystal.get_recalculated_cell_parameter_sd(),
-                                       crystal.get_half_mosaicity_deg(),
-                                       crystal.get_domain_size_ang());
-    }
-
-    static void setstate(boost::python::object obj, boost::python::tuple state) {
-      MosaicCrystalSauter2014 &crystal =
-        boost::python::extract<MosaicCrystalSauter2014 &>(obj)();
       DXTBX_ASSERT(boost::python::len(state) == 8);
 
       // restore the object's __dict__
@@ -293,8 +243,9 @@ namespace dxtbx { namespace model { namespace boost_python {
         boost::python::extract<boost::optional<cctbx::uctbx::unit_cell> >(state[4]);
       scitbx::af::small<double, 6> recalculated_cell_parameter_sd =
         boost::python::extract<scitbx::af::small<double, 6> >(state[5]);
-      double half_mosaicity_deg = boost::python::extract<double>(state[6]);
-      double domain_size_ang = boost::python::extract<double>(state[7]);
+      double recalculated_cell_volume_sd =
+        boost::python::extract<double>(state[6]);
+      double mosaicity = boost::python::extract<double>(state[7]);
       crystal.set_A_at_scan_points(A_scanpoints);
       crystal.set_B_covariance(cov_B);
       crystal.set_B_covariance_at_scan_points(cov_B_scanpoints);
@@ -302,6 +253,67 @@ namespace dxtbx { namespace model { namespace boost_python {
           crystal.set_recalculated_unit_cell(*recalculated_unit_cell);
       }
       crystal.set_recalculated_cell_parameter_sd(recalculated_cell_parameter_sd);
+      crystal.set_recalculated_cell_volume_sd(recalculated_cell_volume_sd);
+      crystal.set_mosaicity(mosaicity);
+    }
+  };
+
+  struct MosaicCrystalSauter2014PickleSuite : CrystalPickleSuite {
+    static boost::python::tuple getinitargs(const MosaicCrystalSauter2014 &obj) {
+      scitbx::af::shared<vec3<double> > real_space_v = obj.get_real_space_vectors();
+      return boost::python::make_tuple(
+        real_space_v[0], real_space_v[1], real_space_v[2], obj.get_space_group());
+    }
+
+    static boost::python::tuple getstate(boost::python::object obj) {
+      const MosaicCrystalSauter2014 &crystal =
+        boost::python::extract<const MosaicCrystalSauter2014 &>(obj)();
+      return boost::python::make_tuple(obj.attr("__dict__"),
+                                       crystal.get_A_at_scan_points(),
+                                       crystal.get_B_covariance(),
+                                       crystal.get_B_covariance_at_scan_points(),
+                                       crystal.get_recalculated_unit_cell(),
+                                       crystal.get_recalculated_cell_parameter_sd(),
+                                       crystal.get_recalculated_cell_volume_sd(),
+                                       crystal.get_half_mosaicity_deg(),
+                                       crystal.get_domain_size_ang());
+    }
+
+    static void setstate(boost::python::object obj, boost::python::tuple state) {
+      MosaicCrystalSauter2014 &crystal =
+        boost::python::extract<MosaicCrystalSauter2014 &>(obj)();
+      DXTBX_ASSERT(boost::python::len(state) == 9);
+
+      // restore the object's __dict__
+      boost::python::dict d =
+        boost::python::extract<boost::python::dict>(obj.attr("__dict__"))();
+      d.update(state[0]);
+
+      // restore the internal state of the C++ object
+      scitbx::af::const_ref<mat3<double> > A_scanpoints =
+        boost::python::extract<scitbx::af::const_ref<mat3<double> > >(state[1]);
+      scitbx::af::const_ref<double, scitbx::af::c_grid<2> > cov_B =
+        boost::python::extract<scitbx::af::const_ref<double, scitbx::af::c_grid<2> > >(
+          state[2]);
+      scitbx::af::const_ref<double, scitbx::af::c_grid<3> > cov_B_scanpoints =
+        boost::python::extract<scitbx::af::const_ref<double, scitbx::af::c_grid<3> > >(
+          state[3]);
+      boost::optional<cctbx::uctbx::unit_cell> recalculated_unit_cell =
+        boost::python::extract<boost::optional<cctbx::uctbx::unit_cell> >(state[4]);
+      scitbx::af::small<double, 6> recalculated_cell_parameter_sd =
+        boost::python::extract<scitbx::af::small<double, 6> >(state[5]);
+      double recalculated_cell_volume_sd =
+        boost::python::extract<double>(state[6]);
+      double half_mosaicity_deg = boost::python::extract<double>(state[7]);
+      double domain_size_ang = boost::python::extract<double>(state[8]);
+      crystal.set_A_at_scan_points(A_scanpoints);
+      crystal.set_B_covariance(cov_B);
+      crystal.set_B_covariance_at_scan_points(cov_B_scanpoints);
+      if (recalculated_unit_cell) {
+          crystal.set_recalculated_unit_cell(*recalculated_unit_cell);
+      }
+      crystal.set_recalculated_cell_parameter_sd(recalculated_cell_parameter_sd);
+      crystal.set_recalculated_cell_volume_sd(recalculated_cell_volume_sd);
       crystal.set_half_mosaicity_deg(half_mosaicity_deg);
       crystal.set_domain_size_ang(domain_size_ang);
     }
@@ -381,6 +393,8 @@ namespace dxtbx { namespace model { namespace boost_python {
            &CrystalBase::get_B_covariance_at_scan_points)
       .def("get_cell_parameter_sd", &CrystalBase::get_cell_parameter_sd)
       .def("get_cell_volume_sd", &CrystalBase::get_cell_volume_sd)
+      .def("get_recalculated_cell_volume_sd", &CrystalBase::get_recalculated_cell_volume_sd)
+      .def("set_recalculated_cell_volume_sd", &CrystalBase::set_recalculated_cell_volume_sd)
       .def("get_cell_parameter_sd_at_scan_point",
            &CrystalBase::get_cell_parameter_sd_at_scan_point)
       .def("reset_unit_cell_errors", &CrystalBase::reset_unit_cell_errors)

--- a/model/boost_python/crystal.cc
+++ b/model/boost_python/crystal.cc
@@ -10,6 +10,7 @@
  */
 #include <boost/python.hpp>
 #include <boost/python/def.hpp>
+#include <boost_adaptbx/optional_conversions.h>
 #include <string>
 #include <sstream>
 #include <dxtbx/model/crystal.h>
@@ -17,6 +18,7 @@
 namespace dxtbx { namespace model { namespace boost_python {
 
   using namespace boost::python;
+  using boost_adaptbx::optional_conversions::to_and_from_python;
 
   static Crystal *make_crystal_default(const vec3<double> &real_space_a,
                                        const vec3<double> &real_space_b,
@@ -299,6 +301,9 @@ namespace dxtbx { namespace model { namespace boost_python {
   }
 
   void export_crystal() {
+    // Expose the optional values
+    to_and_from_python<boost::optional<cctbx::uctbx::unit_cell > >();
+
     class_<CrystalBase, boost::noncopyable>("CrystalBase", no_init)
       .def("set_unit_cell", CrystalBase_set_unit_cell_real_space_vectors)
       .def("set_unit_cell", CrystalBase_set_unit_cell)
@@ -349,10 +354,9 @@ namespace dxtbx { namespace model { namespace boost_python {
            &CrystalBase::get_cell_parameter_sd_at_scan_point)
       .def("reset_unit_cell_errors", &CrystalBase::reset_unit_cell_errors)
       .def("set_recalc_unit_cell", &CrystalBase_set_recalc_unit_cell)
-      .def("_get_recalc_unit_cell", &CrystalBase::get_recalc_unit_cell)
+      .def("get_recalc_unit_cell", &CrystalBase::get_recalc_unit_cell)
       .def("set_recalc_cell_parameter_sd", &CrystalBase_set_recalc_cell_parameter_sd)
       .def("get_recalc_cell_parameter_sd", &CrystalBase::get_recalc_cell_parameter_sd)
-      .def("_has_recalc_unit_cell", &CrystalBase::has_recalc_unit_cell)
       .def("__eq__", &CrystalBase::operator==)
       .def("__ne__", &CrystalBase::operator!=);
 

--- a/model/boost_python/crystal.cc
+++ b/model/boost_python/crystal.cc
@@ -183,13 +183,12 @@ namespace dxtbx { namespace model { namespace boost_python {
         boost::python::extract<boost::optional<cctbx::uctbx::unit_cell> >(state[4]);
       scitbx::af::small<double, 6> recalculated_cell_parameter_sd =
         boost::python::extract<scitbx::af::small<double, 6> >(state[5]);
-      double recalculated_cell_volume_sd =
-        boost::python::extract<double>(state[6]);
+      double recalculated_cell_volume_sd = boost::python::extract<double>(state[6]);
       crystal.set_A_at_scan_points(A_scanpoints);
       crystal.set_B_covariance(cov_B);
       crystal.set_B_covariance_at_scan_points(cov_B_scanpoints);
       if (recalculated_unit_cell) {
-          crystal.set_recalculated_unit_cell(*recalculated_unit_cell);
+        crystal.set_recalculated_unit_cell(*recalculated_unit_cell);
       }
       crystal.set_recalculated_cell_parameter_sd(recalculated_cell_parameter_sd);
       crystal.set_recalculated_cell_volume_sd(recalculated_cell_volume_sd);
@@ -243,14 +242,13 @@ namespace dxtbx { namespace model { namespace boost_python {
         boost::python::extract<boost::optional<cctbx::uctbx::unit_cell> >(state[4]);
       scitbx::af::small<double, 6> recalculated_cell_parameter_sd =
         boost::python::extract<scitbx::af::small<double, 6> >(state[5]);
-      double recalculated_cell_volume_sd =
-        boost::python::extract<double>(state[6]);
+      double recalculated_cell_volume_sd = boost::python::extract<double>(state[6]);
       double mosaicity = boost::python::extract<double>(state[7]);
       crystal.set_A_at_scan_points(A_scanpoints);
       crystal.set_B_covariance(cov_B);
       crystal.set_B_covariance_at_scan_points(cov_B_scanpoints);
       if (recalculated_unit_cell) {
-          crystal.set_recalculated_unit_cell(*recalculated_unit_cell);
+        crystal.set_recalculated_unit_cell(*recalculated_unit_cell);
       }
       crystal.set_recalculated_cell_parameter_sd(recalculated_cell_parameter_sd);
       crystal.set_recalculated_cell_volume_sd(recalculated_cell_volume_sd);
@@ -302,15 +300,14 @@ namespace dxtbx { namespace model { namespace boost_python {
         boost::python::extract<boost::optional<cctbx::uctbx::unit_cell> >(state[4]);
       scitbx::af::small<double, 6> recalculated_cell_parameter_sd =
         boost::python::extract<scitbx::af::small<double, 6> >(state[5]);
-      double recalculated_cell_volume_sd =
-        boost::python::extract<double>(state[6]);
+      double recalculated_cell_volume_sd = boost::python::extract<double>(state[6]);
       double half_mosaicity_deg = boost::python::extract<double>(state[7]);
       double domain_size_ang = boost::python::extract<double>(state[8]);
       crystal.set_A_at_scan_points(A_scanpoints);
       crystal.set_B_covariance(cov_B);
       crystal.set_B_covariance_at_scan_points(cov_B_scanpoints);
       if (recalculated_unit_cell) {
-          crystal.set_recalculated_unit_cell(*recalculated_unit_cell);
+        crystal.set_recalculated_unit_cell(*recalculated_unit_cell);
       }
       crystal.set_recalculated_cell_parameter_sd(recalculated_cell_parameter_sd);
       crystal.set_recalculated_cell_volume_sd(recalculated_cell_volume_sd);
@@ -332,8 +329,9 @@ namespace dxtbx { namespace model { namespace boost_python {
     self.set_unit_cell(unit_cell);
   }
 
-  inline void CrystalBase_set_recalculated_unit_cell(CrystalBase &self,
-                                               cctbx::uctbx::unit_cell &unit_cell) {
+  inline void CrystalBase_set_recalculated_unit_cell(
+    CrystalBase &self,
+    cctbx::uctbx::unit_cell &unit_cell) {
     self.set_recalculated_unit_cell(unit_cell);
   }
 
@@ -393,15 +391,19 @@ namespace dxtbx { namespace model { namespace boost_python {
            &CrystalBase::get_B_covariance_at_scan_points)
       .def("get_cell_parameter_sd", &CrystalBase::get_cell_parameter_sd)
       .def("get_cell_volume_sd", &CrystalBase::get_cell_volume_sd)
-      .def("get_recalculated_cell_volume_sd", &CrystalBase::get_recalculated_cell_volume_sd)
-      .def("set_recalculated_cell_volume_sd", &CrystalBase::set_recalculated_cell_volume_sd)
+      .def("get_recalculated_cell_volume_sd",
+           &CrystalBase::get_recalculated_cell_volume_sd)
+      .def("set_recalculated_cell_volume_sd",
+           &CrystalBase::set_recalculated_cell_volume_sd)
       .def("get_cell_parameter_sd_at_scan_point",
            &CrystalBase::get_cell_parameter_sd_at_scan_point)
       .def("reset_unit_cell_errors", &CrystalBase::reset_unit_cell_errors)
       .def("set_recalculated_unit_cell", &CrystalBase_set_recalculated_unit_cell)
       .def("get_recalculated_unit_cell", &CrystalBase::get_recalculated_unit_cell)
-      .def("set_recalculated_cell_parameter_sd", &CrystalBase_set_recalculated_cell_parameter_sd)
-      .def("get_recalculated_cell_parameter_sd", &CrystalBase::get_recalculated_cell_parameter_sd)
+      .def("set_recalculated_cell_parameter_sd",
+           &CrystalBase_set_recalculated_cell_parameter_sd)
+      .def("get_recalculated_cell_parameter_sd",
+           &CrystalBase::get_recalculated_cell_parameter_sd)
       .def("__eq__", &CrystalBase::operator==)
       .def("__ne__", &CrystalBase::operator!=);
 

--- a/model/boost_python/crystal.cc
+++ b/model/boost_python/crystal.cc
@@ -349,10 +349,10 @@ namespace dxtbx { namespace model { namespace boost_python {
            &CrystalBase::get_cell_parameter_sd_at_scan_point)
       .def("reset_unit_cell_errors", &CrystalBase::reset_unit_cell_errors)
       .def("set_recalc_unit_cell", &CrystalBase_set_recalc_unit_cell)
-      .def("get_recalc_unit_cell", &CrystalBase::get_recalc_unit_cell)
+      .def("_get_recalc_unit_cell", &CrystalBase::get_recalc_unit_cell)
       .def("set_recalc_cell_parameter_sd", &CrystalBase_set_recalc_cell_parameter_sd)
       .def("get_recalc_cell_parameter_sd", &CrystalBase::get_recalc_cell_parameter_sd)
-      .def("has_recalc_unit_cell", &CrystalBase::has_recalc_unit_cell)
+      .def("_has_recalc_unit_cell", &CrystalBase::has_recalc_unit_cell)
       .def("__eq__", &CrystalBase::operator==)
       .def("__ne__", &CrystalBase::operator!=);
 

--- a/model/boost_python/crystal.cc
+++ b/model/boost_python/crystal.cc
@@ -290,15 +290,15 @@ namespace dxtbx { namespace model { namespace boost_python {
     self.set_unit_cell(unit_cell);
   }
 
-  inline void CrystalBase_set_recalc_unit_cell(CrystalBase &self,
+  inline void CrystalBase_set_recalculated_unit_cell(CrystalBase &self,
                                                cctbx::uctbx::unit_cell &unit_cell) {
-    self.set_recalc_unit_cell(unit_cell);
+    self.set_recalculated_unit_cell(unit_cell);
   }
 
-  inline void CrystalBase_set_recalc_cell_parameter_sd(
+  inline void CrystalBase_set_recalculated_cell_parameter_sd(
     CrystalBase &self,
     const scitbx::af::small<double, 6> &unit_cell_sd) {
-    self.set_recalc_cell_parameter_sd(unit_cell_sd);
+    self.set_recalculated_cell_parameter_sd(unit_cell_sd);
   }
 
   void export_crystal() {
@@ -354,10 +354,10 @@ namespace dxtbx { namespace model { namespace boost_python {
       .def("get_cell_parameter_sd_at_scan_point",
            &CrystalBase::get_cell_parameter_sd_at_scan_point)
       .def("reset_unit_cell_errors", &CrystalBase::reset_unit_cell_errors)
-      .def("set_recalc_unit_cell", &CrystalBase_set_recalc_unit_cell)
-      .def("get_recalc_unit_cell", &CrystalBase::get_recalc_unit_cell)
-      .def("set_recalc_cell_parameter_sd", &CrystalBase_set_recalc_cell_parameter_sd)
-      .def("get_recalc_cell_parameter_sd", &CrystalBase::get_recalc_cell_parameter_sd)
+      .def("set_recalculated_unit_cell", &CrystalBase_set_recalculated_unit_cell)
+      .def("get_recalculated_unit_cell", &CrystalBase::get_recalculated_unit_cell)
+      .def("set_recalculated_cell_parameter_sd", &CrystalBase_set_recalculated_cell_parameter_sd)
+      .def("get_recalculated_cell_parameter_sd", &CrystalBase::get_recalculated_cell_parameter_sd)
       .def("__eq__", &CrystalBase::operator==)
       .def("__ne__", &CrystalBase::operator!=);
 

--- a/model/boost_python/crystal.cc
+++ b/model/boost_python/crystal.cc
@@ -291,18 +291,19 @@ namespace dxtbx { namespace model { namespace boost_python {
   }
 
   inline void CrystalBase_set_recalc_unit_cell(CrystalBase &self,
-                                        cctbx::uctbx::unit_cell &unit_cell) {
+                                               cctbx::uctbx::unit_cell &unit_cell) {
     self.set_recalc_unit_cell(unit_cell);
   }
 
-  inline void CrystalBase_set_recalc_cell_parameter_sd(CrystalBase &self,
-      const scitbx::af::small<double, 6> &unit_cell_sd) {
+  inline void CrystalBase_set_recalc_cell_parameter_sd(
+    CrystalBase &self,
+    const scitbx::af::small<double, 6> &unit_cell_sd) {
     self.set_recalc_cell_parameter_sd(unit_cell_sd);
   }
 
   void export_crystal() {
     // Expose the optional values
-    to_and_from_python<boost::optional<cctbx::uctbx::unit_cell > >();
+    to_and_from_python<boost::optional<cctbx::uctbx::unit_cell> >();
 
     class_<CrystalBase, boost::noncopyable>("CrystalBase", no_init)
       .def("set_unit_cell", CrystalBase_set_unit_cell_real_space_vectors)

--- a/model/crystal.h
+++ b/model/crystal.h
@@ -277,7 +277,8 @@ namespace dxtbx { namespace model {
                             other.A_at_scan_points_.end()),
           cov_B_(other.cov_B_.accessor()),
           cell_sd_(other.cell_sd_),
-          cell_volume_sd_(other.cell_volume_sd_) {
+          cell_volume_sd_(other.cell_volume_sd_),
+          recalculated_unit_cell_(other.recalculated_unit_cell_) {
       std::copy(other.cov_B_.begin(), other.cov_B_.end(), cov_B_.begin());
     }
 

--- a/model/crystal.h
+++ b/model/crystal.h
@@ -271,15 +271,15 @@ namespace dxtbx { namespace model {
     Crystal(const Crystal &other)
         : space_group_(other.space_group_),
           unit_cell_(other.unit_cell_),
+          recalculated_unit_cell_(other.recalculated_unit_cell_),
           U_(other.U_),
           B_(other.B_),
           A_at_scan_points_(other.A_at_scan_points_.begin(),
                             other.A_at_scan_points_.end()),
           cov_B_(other.cov_B_.accessor()),
           cell_sd_(other.cell_sd_),
-          cell_volume_sd_(other.cell_volume_sd_),
-          recalculated_unit_cell_(other.recalculated_unit_cell_),
-          recalculated_cell_sd_(other.recalculated_cell_sd_){
+          recalculated_cell_sd_(other.recalculated_cell_sd_),
+          cell_volume_sd_(other.cell_volume_sd_){
       std::copy(other.cov_B_.begin(), other.cov_B_.end(), cov_B_.begin());
     }
 

--- a/model/crystal.h
+++ b/model/crystal.h
@@ -238,7 +238,16 @@ namespace dxtbx { namespace model {
     virtual void calc_cell_parameter_sd() = 0;
     // Reset unit cell errors
     virtual void reset_unit_cell_errors() = 0;
+    // Access recalculated unit cell, set e.g. by postrefinement
+    virtual void set_recalc_unit_cell(const cctbx::uctbx::unit_cell &unit_cell) = 0;
+    virtual cctbx::uctbx::unit_cell get_recalc_unit_cell() const = 0;
+    virtual void set_recalc_cell_parameter_sd(
+      const scitbx::af::small<double, 6> &unit_cell_sd
+    ) = 0;
+    virtual scitbx::af::small<double, 6> get_recalc_cell_parameter_sd() = 0;
+    virtual bool has_recalc_unit_cell() const = 0;
   };
+
 
   /**
    * Simple model for the crystal lattice geometry and symmetry
@@ -1025,15 +1034,40 @@ namespace dxtbx { namespace model {
       cell_volume_sd_ = 0;
     }
 
+    void set_recalc_unit_cell(const cctbx::uctbx::unit_cell &unit_cell) {
+      recalc_unit_cell_ = unit_cell;
+    }
+
+    cctbx::uctbx::unit_cell get_recalc_unit_cell() const {
+      return recalc_unit_cell_;
+    }
+
+    void set_recalc_cell_parameter_sd(const scitbx::af::small<double, 6> &unit_cell_sd)
+    {
+      recalc_cell_sd_ = unit_cell_sd;
+    }
+
+    scitbx::af::small<double, 6> get_recalc_cell_parameter_sd() {
+      return recalc_cell_sd_;
+    }
+
+    bool has_recalc_unit_cell() const {
+      return has_recalc_cell_;
+    }
+
+
   protected:
     cctbx::sgtbx::space_group space_group_;
     cctbx::uctbx::unit_cell unit_cell_;
+    cctbx::uctbx::unit_cell recalc_unit_cell_;
     mat3<double> U_;
     mat3<double> B_;
     scitbx::af::shared<mat3<double> > A_at_scan_points_;
     scitbx::af::versa<double, scitbx::af::c_grid<2> > cov_B_;
     scitbx::af::versa<double, scitbx::af::c_grid<3> > cov_B_at_scan_points_;
     scitbx::af::small<double, 6> cell_sd_;
+    scitbx::af::small<double, 6> recalc_cell_sd_;
+    bool has_recalc_cell_ = false;
     double cell_volume_sd_;
   };
 

--- a/model/crystal.h
+++ b/model/crystal.h
@@ -278,7 +278,8 @@ namespace dxtbx { namespace model {
           cov_B_(other.cov_B_.accessor()),
           cell_sd_(other.cell_sd_),
           cell_volume_sd_(other.cell_volume_sd_),
-          recalculated_unit_cell_(other.recalculated_unit_cell_) {
+          recalculated_unit_cell_(other.recalculated_unit_cell_),
+          recalculated_cell_sd_(other.recalculated_cell_sd_){
       std::copy(other.cov_B_.begin(), other.cov_B_.end(), cov_B_.begin());
     }
 

--- a/model/crystal.h
+++ b/model/crystal.h
@@ -241,12 +241,11 @@ namespace dxtbx { namespace model {
     // Access recalculated unit cell, intended for use by post-integration
     // refinement algorithms, such as that of dials.two_theta_refine
     virtual void set_recalc_unit_cell(const cctbx::uctbx::unit_cell &unit_cell) = 0;
-    virtual cctbx::uctbx::unit_cell get_recalc_unit_cell() const = 0;
+    virtual boost::optional<cctbx::uctbx::unit_cell> get_recalc_unit_cell() const = 0;
     virtual void set_recalc_cell_parameter_sd(
       const scitbx::af::small<double, 6> &unit_cell_sd
     ) = 0;
     virtual scitbx::af::small<double, 6> get_recalc_cell_parameter_sd() = 0;
-    virtual bool has_recalc_unit_cell() const = 0;
   };
 
 
@@ -712,10 +711,10 @@ namespace dxtbx { namespace model {
       }
 
       // recalculated unit cell test, if both exist
-      if (has_recalc_cell_ && other.has_recalc_unit_cell()) {
-        cctbx::uctbx::unit_cell uc_a = get_recalc_unit_cell();
-        cctbx::uctbx::unit_cell uc_b = other.get_recalc_unit_cell();
-        if (!uc_a.is_similar_to(uc_b, uc_rel_length_tolerance, uc_abs_angle_tolerance)) {
+      boost::optional<cctbx::uctbx::unit_cell> recalc_uc_a = get_recalc_unit_cell();
+      boost::optional<cctbx::uctbx::unit_cell> recalc_uc_b = other.get_recalc_unit_cell();
+      if (recalc_uc_a && recalc_uc_b) {
+        if (!recalc_uc_a->is_similar_to(*recalc_uc_b, uc_rel_length_tolerance, uc_abs_angle_tolerance)) {
           return false;
         }
       }
@@ -1045,11 +1044,10 @@ namespace dxtbx { namespace model {
     }
 
     void set_recalc_unit_cell(const cctbx::uctbx::unit_cell &unit_cell) {
-      has_recalc_cell_ = true;
       recalc_unit_cell_ = unit_cell;
     }
 
-    cctbx::uctbx::unit_cell get_recalc_unit_cell() const {
+    boost::optional<cctbx::uctbx::unit_cell> get_recalc_unit_cell() const {
       return recalc_unit_cell_;
     }
 
@@ -1062,15 +1060,11 @@ namespace dxtbx { namespace model {
       return recalc_cell_sd_;
     }
 
-    bool has_recalc_unit_cell() const {
-      return has_recalc_cell_;
-    }
-
 
   protected:
     cctbx::sgtbx::space_group space_group_;
     cctbx::uctbx::unit_cell unit_cell_;
-    cctbx::uctbx::unit_cell recalc_unit_cell_;
+    boost::optional<cctbx::uctbx::unit_cell> recalc_unit_cell_ = boost::none;
     mat3<double> U_;
     mat3<double> B_;
     scitbx::af::shared<mat3<double> > A_at_scan_points_;
@@ -1078,7 +1072,6 @@ namespace dxtbx { namespace model {
     scitbx::af::versa<double, scitbx::af::c_grid<3> > cov_B_at_scan_points_;
     scitbx::af::small<double, 6> cell_sd_;
     scitbx::af::small<double, 6> recalc_cell_sd_ = scitbx::af::small<double, 6>();
-    bool has_recalc_cell_ = false;
     double cell_volume_sd_;
   };
 

--- a/model/crystal.h
+++ b/model/crystal.h
@@ -1076,7 +1076,7 @@ namespace dxtbx { namespace model {
     scitbx::af::versa<double, scitbx::af::c_grid<2> > cov_B_;
     scitbx::af::versa<double, scitbx::af::c_grid<3> > cov_B_at_scan_points_;
     scitbx::af::small<double, 6> cell_sd_;
-    scitbx::af::small<double, 6> recalc_cell_sd_;
+    scitbx::af::small<double, 6> recalc_cell_sd_ = scitbx::af::small<double, 6>();
     bool has_recalc_cell_ = false;
     double cell_volume_sd_;
   };

--- a/model/crystal.h
+++ b/model/crystal.h
@@ -243,11 +243,9 @@ namespace dxtbx { namespace model {
     virtual void set_recalc_unit_cell(const cctbx::uctbx::unit_cell &unit_cell) = 0;
     virtual boost::optional<cctbx::uctbx::unit_cell> get_recalc_unit_cell() const = 0;
     virtual void set_recalc_cell_parameter_sd(
-      const scitbx::af::small<double, 6> &unit_cell_sd
-    ) = 0;
+      const scitbx::af::small<double, 6> &unit_cell_sd) = 0;
     virtual scitbx::af::small<double, 6> get_recalc_cell_parameter_sd() = 0;
   };
-
 
   /**
    * Simple model for the crystal lattice geometry and symmetry
@@ -712,9 +710,11 @@ namespace dxtbx { namespace model {
 
       // recalculated unit cell test, if both exist
       boost::optional<cctbx::uctbx::unit_cell> recalc_uc_a = get_recalc_unit_cell();
-      boost::optional<cctbx::uctbx::unit_cell> recalc_uc_b = other.get_recalc_unit_cell();
+      boost::optional<cctbx::uctbx::unit_cell> recalc_uc_b =
+        other.get_recalc_unit_cell();
       if (recalc_uc_a && recalc_uc_b) {
-        if (!recalc_uc_a->is_similar_to(*recalc_uc_b, uc_rel_length_tolerance, uc_abs_angle_tolerance)) {
+        if (!recalc_uc_a->is_similar_to(
+              *recalc_uc_b, uc_rel_length_tolerance, uc_abs_angle_tolerance)) {
           return false;
         }
       }
@@ -1051,15 +1051,14 @@ namespace dxtbx { namespace model {
       return recalc_unit_cell_;
     }
 
-    void set_recalc_cell_parameter_sd(const scitbx::af::small<double, 6> &unit_cell_sd)
-    {
+    void set_recalc_cell_parameter_sd(
+      const scitbx::af::small<double, 6> &unit_cell_sd) {
       recalc_cell_sd_ = unit_cell_sd;
     }
 
     scitbx::af::small<double, 6> get_recalc_cell_parameter_sd() {
       return recalc_cell_sd_;
     }
-
 
   protected:
     cctbx::sgtbx::space_group space_group_;

--- a/model/crystal.h
+++ b/model/crystal.h
@@ -240,11 +240,11 @@ namespace dxtbx { namespace model {
     virtual void reset_unit_cell_errors() = 0;
     // Access recalculated unit cell, intended for use by post-integration
     // refinement algorithms, such as that of dials.two_theta_refine
-    virtual void set_recalc_unit_cell(const cctbx::uctbx::unit_cell &unit_cell) = 0;
-    virtual boost::optional<cctbx::uctbx::unit_cell> get_recalc_unit_cell() const = 0;
-    virtual void set_recalc_cell_parameter_sd(
+    virtual void set_recalculated_unit_cell(const cctbx::uctbx::unit_cell &unit_cell) = 0;
+    virtual boost::optional<cctbx::uctbx::unit_cell> get_recalculated_unit_cell() const = 0;
+    virtual void set_recalculated_cell_parameter_sd(
       const scitbx::af::small<double, 6> &unit_cell_sd) = 0;
-    virtual scitbx::af::small<double, 6> get_recalc_cell_parameter_sd() = 0;
+    virtual scitbx::af::small<double, 6> get_recalculated_cell_parameter_sd() = 0;
   };
 
   /**
@@ -709,12 +709,12 @@ namespace dxtbx { namespace model {
       }
 
       // recalculated unit cell test, if both exist
-      boost::optional<cctbx::uctbx::unit_cell> recalc_uc_a = get_recalc_unit_cell();
-      boost::optional<cctbx::uctbx::unit_cell> recalc_uc_b =
-        other.get_recalc_unit_cell();
-      if (recalc_uc_a && recalc_uc_b) {
-        if (!recalc_uc_a->is_similar_to(
-              *recalc_uc_b, uc_rel_length_tolerance, uc_abs_angle_tolerance)) {
+      boost::optional<cctbx::uctbx::unit_cell> recalculated_uc_a = get_recalculated_unit_cell();
+      boost::optional<cctbx::uctbx::unit_cell> recalculated_uc_b =
+        other.get_recalculated_unit_cell();
+      if (recalculated_uc_a && recalculated_uc_b) {
+        if (!recalculated_uc_a->is_similar_to(
+              *recalculated_uc_b, uc_rel_length_tolerance, uc_abs_angle_tolerance)) {
           return false;
         }
       }
@@ -1043,34 +1043,34 @@ namespace dxtbx { namespace model {
       cell_volume_sd_ = 0;
     }
 
-    void set_recalc_unit_cell(const cctbx::uctbx::unit_cell &unit_cell) {
-      recalc_unit_cell_ = unit_cell;
+    void set_recalculated_unit_cell(const cctbx::uctbx::unit_cell &unit_cell) {
+      recalculated_unit_cell_ = unit_cell;
     }
 
-    boost::optional<cctbx::uctbx::unit_cell> get_recalc_unit_cell() const {
-      return recalc_unit_cell_;
+    boost::optional<cctbx::uctbx::unit_cell> get_recalculated_unit_cell() const {
+      return recalculated_unit_cell_;
     }
 
-    void set_recalc_cell_parameter_sd(
+    void set_recalculated_cell_parameter_sd(
       const scitbx::af::small<double, 6> &unit_cell_sd) {
-      recalc_cell_sd_ = unit_cell_sd;
+      recalculated_cell_sd_ = unit_cell_sd;
     }
 
-    scitbx::af::small<double, 6> get_recalc_cell_parameter_sd() {
-      return recalc_cell_sd_;
+    scitbx::af::small<double, 6> get_recalculated_cell_parameter_sd() {
+      return recalculated_cell_sd_;
     }
 
   protected:
     cctbx::sgtbx::space_group space_group_;
     cctbx::uctbx::unit_cell unit_cell_;
-    boost::optional<cctbx::uctbx::unit_cell> recalc_unit_cell_ = boost::none;
+    boost::optional<cctbx::uctbx::unit_cell> recalculated_unit_cell_ = boost::none;
     mat3<double> U_;
     mat3<double> B_;
     scitbx::af::shared<mat3<double> > A_at_scan_points_;
     scitbx::af::versa<double, scitbx::af::c_grid<2> > cov_B_;
     scitbx::af::versa<double, scitbx::af::c_grid<3> > cov_B_at_scan_points_;
     scitbx::af::small<double, 6> cell_sd_;
-    scitbx::af::small<double, 6> recalc_cell_sd_ = scitbx::af::small<double, 6>();
+    scitbx::af::small<double, 6> recalculated_cell_sd_ = scitbx::af::small<double, 6>();
     double cell_volume_sd_;
   };
 

--- a/model/crystal.h
+++ b/model/crystal.h
@@ -238,7 +238,8 @@ namespace dxtbx { namespace model {
     virtual void calc_cell_parameter_sd() = 0;
     // Reset unit cell errors
     virtual void reset_unit_cell_errors() = 0;
-    // Access recalculated unit cell, set e.g. by postrefinement
+    // Access recalculated unit cell, intended for use by post-integration
+    // refinement algorithms, such as that of dials.two_theta_refine
     virtual void set_recalc_unit_cell(const cctbx::uctbx::unit_cell &unit_cell) = 0;
     virtual cctbx::uctbx::unit_cell get_recalc_unit_cell() const = 0;
     virtual void set_recalc_cell_parameter_sd(

--- a/model/crystal.h
+++ b/model/crystal.h
@@ -710,6 +710,15 @@ namespace dxtbx { namespace model {
         return false;
       }
 
+      // recalculated unit cell test, if both exist
+      if (has_recalc_cell_ && other.has_recalc_unit_cell()) {
+        cctbx::uctbx::unit_cell uc_a = get_recalc_unit_cell();
+        cctbx::uctbx::unit_cell uc_b = other.get_recalc_unit_cell();
+        if (!uc_a.is_similar_to(uc_b, uc_rel_length_tolerance, uc_abs_angle_tolerance)) {
+          return false;
+        }
+      }
+
       // scan varying tests
       if (get_num_scan_points() != other.get_num_scan_points()) {
         return false;
@@ -1035,6 +1044,7 @@ namespace dxtbx { namespace model {
     }
 
     void set_recalc_unit_cell(const cctbx::uctbx::unit_cell &unit_cell) {
+      has_recalc_cell_ = true;
       recalc_unit_cell_ = unit_cell;
     }
 

--- a/model/crystal.h
+++ b/model/crystal.h
@@ -238,7 +238,8 @@ namespace dxtbx { namespace model {
     // Get the recalculated cell volume standard deviation
     virtual double get_recalculated_cell_volume_sd() const = 0;
     // Set the recalculated cell volume standard deviation
-    virtual void set_recalculated_cell_volume_sd(double recalculated_cell_volume_sd) = 0;
+    virtual void set_recalculated_cell_volume_sd(
+      double recalculated_cell_volume_sd) = 0;
     virtual void calc_cell_parameter_sd() = 0;
     // Reset unit cell errors
     virtual void reset_unit_cell_errors() = 0;
@@ -302,7 +303,9 @@ namespace dxtbx { namespace model {
             const vec3<double> &real_space_b,
             const vec3<double> &real_space_c,
             const cctbx::sgtbx::space_group &space_group)
-        : space_group_(space_group), cell_volume_sd_(0), recalculated_cell_volume_sd_(0) {
+        : space_group_(space_group),
+          cell_volume_sd_(0),
+          recalculated_cell_volume_sd_(0) {
       // Setting matrix at initialisation
       mat3<double> A = mat3<double>(real_space_a[0],
                                     real_space_a[1],
@@ -346,7 +349,9 @@ namespace dxtbx { namespace model {
     Crystal(const mat3<double> &A,
             const cctbx::sgtbx::space_group &space_group,
             const bool &reciprocal = true)
-        : space_group_(space_group), cell_volume_sd_(0), recalculated_cell_volume_sd_(0) {
+        : space_group_(space_group),
+          cell_volume_sd_(0),
+          recalculated_cell_volume_sd_(0) {
       if (reciprocal) {
         set_A(A);
       } else {

--- a/model/crystal.h
+++ b/model/crystal.h
@@ -629,6 +629,10 @@ namespace dxtbx { namespace model {
         }
         other->set_A_at_scan_points(new_A_at_scan_points.const_ref());
       }
+      if (recalculated_unit_cell_) {
+        other->set_recalculated_unit_cell(
+          recalculated_unit_cell_->change_basis(change_of_basis_op));
+      }
       return other;
     }
 

--- a/model/crystal.h
+++ b/model/crystal.h
@@ -1079,6 +1079,8 @@ namespace dxtbx { namespace model {
 
     void set_recalculated_unit_cell(const cctbx::uctbx::unit_cell &unit_cell) {
       recalculated_unit_cell_ = unit_cell;
+      recalculated_cell_sd_ = scitbx::af::small<double, 6>();
+      recalculated_cell_volume_sd_ = 0;
     }
 
     boost::optional<cctbx::uctbx::unit_cell> get_recalculated_unit_cell() const {

--- a/newsfragments/142.feature
+++ b/newsfragments/142.feature
@@ -1,0 +1,1 @@
+A new recalculated unit cell attribute is added to the Crystal model, for use by post-integration cell refinement methods, such as that of dials.two_theta_refine.

--- a/tests/model/test_crystal_model.py
+++ b/tests/model/test_crystal_model.py
@@ -636,3 +636,8 @@ def test_recalculated_cell(crystal_class):
     ).get_recalculated_unit_cell().parameters() == pytest.approx(
         (11.0, 10.0, 10.0, 90.0, 90.0, 90.0)
     )
+
+    # Verify that set_recalculated_unit_cell() resets the cell parameter sd's
+    xl.set_recalculated_unit_cell(uctbx.unit_cell((11, 12, 13, 90, 90, 90)))
+    assert xl.get_recalculated_cell_parameter_sd() == ()
+    assert xl.get_recalculated_cell_volume_sd() == 0

--- a/tests/model/test_crystal_model.py
+++ b/tests/model/test_crystal_model.py
@@ -609,12 +609,18 @@ def test_recalculated_cell():
     assert not xl.has_recalc_unit_cell()
 
     uc1 = xl.get_unit_cell()
-    xl.set_recalc_unit_cell(uc1)
+    uc2 = uctbx.unit_cell((10, 11, 10, 90, 90, 90))
+    xl.set_recalc_unit_cell(uc2)
     assert xl.has_recalc_unit_cell()
 
-    uc2 = xl.get_recalc_unit_cell()
-    assert uc1.is_similar_to(uc2)
+    uc3 = xl.get_recalc_unit_cell()
+    assert not uc1.is_similar_to(uc2)
+    assert uc2.is_similar_to(uc3)
 
     xl.set_recalc_cell_parameter_sd((0.1,) * 6)
-
     assert xl.get_recalc_cell_parameter_sd() == (0.1, 0.1, 0.1, 0.1, 0.1, 0.1)
+
+    assert str(xl).splitlines()[-1] == (
+        "    Recalculated unit cell: (10.00(10)"
+        ", 11.00(10), 10.00(10), 90.00(10), 90.00(10), 90.00(10))"
+    )

--- a/tests/model/test_crystal_model.py
+++ b/tests/model/test_crystal_model.py
@@ -610,6 +610,7 @@ def test_recalculated_cell(crystal_class):
     )
 
     assert xl.get_recalculated_unit_cell() is None
+    assert xl.get_recalculated_cell_volume_sd() == 0
 
     uc1 = xl.get_unit_cell()
     uc2 = uctbx.unit_cell((10, 11, 10, 90, 90, 90))
@@ -620,7 +621,9 @@ def test_recalculated_cell(crystal_class):
     assert uc2.is_similar_to(uc3)
 
     xl.set_recalculated_cell_parameter_sd((0.1,) * 6)
+    xl.set_recalculated_cell_volume_sd(0.001)
     assert xl.get_recalculated_cell_parameter_sd() == (0.1, 0.1, 0.1, 0.1, 0.1, 0.1)
+    assert xl.get_recalculated_cell_volume_sd() == 0.001
     assert (
         "    Recalculated unit cell: 10.00(10)"
         ", 11.00(10), 10.00(10), 90.00(10), 90.00(10), 90.00(10)"

--- a/tests/model/test_crystal_model.py
+++ b/tests/model/test_crystal_model.py
@@ -152,7 +152,7 @@ def test_crystal_model():
         str(model).replace("-0.0000", " 0.0000")
         == """\
 Crystal:
-    Unit cell: (10.000, 11.000, 12.000, 90.000, 90.000, 90.000)
+    Unit cell: 10.000, 11.000, 12.000, 90.000, 90.000, 90.000
     Space group: P 1
     U matrix:  {{ 0.4330, -0.7500,  0.5000},
                 { 0.7891,  0.0474, -0.6124},
@@ -332,7 +332,7 @@ def test_MosaicCrystalKabsch2010():
         str(mosaic_model).replace("-0.0000", " 0.0000")
         == """\
 Crystal:
-    Unit cell: (10.000, 11.000, 12.000, 90.000, 90.000, 90.000)
+    Unit cell: 10.000, 11.000, 12.000, 90.000, 90.000, 90.000
     Space group: P 1
     U matrix:  {{ 1.0000,  0.0000,  0.0000},
                 { 0.0000,  1.0000,  0.0000},
@@ -378,7 +378,7 @@ def test_MosaicCrystalSauter2014():
         str(mosaic_model).replace("-0.0000", " 0.0000")
         == """\
 Crystal:
-    Unit cell: (10.000, 11.000, 12.000, 90.000, 90.000, 90.000)
+    Unit cell: 10.000, 11.000, 12.000, 90.000, 90.000, 90.000
     Space group: P 1
     U matrix:  {{ 1.0000,  0.0000,  0.0000},
                 { 0.0000,  1.0000,  0.0000},
@@ -620,6 +620,6 @@ def test_recalculated_cell():
     assert xl.get_recalc_cell_parameter_sd() == (0.1, 0.1, 0.1, 0.1, 0.1, 0.1)
 
     assert str(xl).splitlines()[-1] == (
-        "    Recalculated unit cell: (10.00(10)"
-        ", 11.00(10), 10.00(10), 90.00(10), 90.00(10), 90.00(10))"
+        "    Recalculated unit cell: 10.00(10)"
+        ", 11.00(10), 10.00(10), 90.00(10), 90.00(10), 90.00(10)"
     )

--- a/tests/model/test_crystal_model.py
+++ b/tests/model/test_crystal_model.py
@@ -617,5 +617,4 @@ def test_recalculated_cell():
 
     xl.set_recalc_cell_parameter_sd((0.1,) * 6)
 
-    for val in xl.get_recalc_cell_parameter_sd():
-        assert val == 0.1
+    assert xl.get_recalc_cell_parameter_sd() == (0.1, 0.1, 0.1, 0.1, 0.1, 0.1)

--- a/tests/model/test_crystal_model.py
+++ b/tests/model/test_crystal_model.py
@@ -606,15 +606,13 @@ def test_recalculated_cell():
         space_group_symbol="P 1",
     )
 
-    assert not xl._has_recalc_unit_cell()
     assert xl.get_recalc_unit_cell() is None
 
     uc1 = xl.get_unit_cell()
     uc2 = uctbx.unit_cell((10, 11, 10, 90, 90, 90))
     xl.set_recalc_unit_cell(uc2)
-    assert xl._has_recalc_unit_cell()
-
     uc3 = xl.get_recalc_unit_cell()
+    assert uc3 is not None
     assert not uc1.is_similar_to(uc2)
     assert uc2.is_similar_to(uc3)
 

--- a/tests/model/test_crystal_model.py
+++ b/tests/model/test_crystal_model.py
@@ -606,18 +606,18 @@ def test_recalculated_cell():
         space_group_symbol="P 1",
     )
 
-    assert xl.get_recalc_unit_cell() is None
+    assert xl.get_recalculated_unit_cell() is None
 
     uc1 = xl.get_unit_cell()
     uc2 = uctbx.unit_cell((10, 11, 10, 90, 90, 90))
-    xl.set_recalc_unit_cell(uc2)
-    uc3 = xl.get_recalc_unit_cell()
+    xl.set_recalculated_unit_cell(uc2)
+    uc3 = xl.get_recalculated_unit_cell()
     assert uc3 is not None
     assert not uc1.is_similar_to(uc2)
     assert uc2.is_similar_to(uc3)
 
-    xl.set_recalc_cell_parameter_sd((0.1,) * 6)
-    assert xl.get_recalc_cell_parameter_sd() == (0.1, 0.1, 0.1, 0.1, 0.1, 0.1)
+    xl.set_recalculated_cell_parameter_sd((0.1,) * 6)
+    assert xl.get_recalculated_cell_parameter_sd() == (0.1, 0.1, 0.1, 0.1, 0.1, 0.1)
 
     assert str(xl).splitlines()[-1] == (
         "    Recalculated unit cell: 10.00(10)"

--- a/tests/model/test_crystal_model.py
+++ b/tests/model/test_crystal_model.py
@@ -596,3 +596,26 @@ def test_set_scan_varying_B_covariance(crystal_class):
         assert cov_B_at_scan_point == cov_B_2d
         cell_sd_at_scan_point = xl.get_cell_parameter_sd_at_scan_point(i)
         assert cell_sd_at_scan_point == pytest.approx(cell_sd)
+
+
+def test_recalculated_cell():
+    xl = Crystal(
+        real_space_a=(10, 0, 0),
+        real_space_b=(0, 11, 0),
+        real_space_c=(0, 0, 12),
+        space_group_symbol="P 1",
+    )
+
+    assert not xl.has_recalc_unit_cell()
+
+    uc1 = xl.get_unit_cell()
+    xl.set_recalc_unit_cell(uc1)
+    assert xl.has_recalc_unit_cell()
+
+    uc2 = xl.get_recalc_unit_cell()
+    assert uc1.is_similar_to(uc2)
+
+    xl.set_recalc_cell_parameter_sd((0.1,) * 6)
+
+    for val in xl.get_recalc_cell_parameter_sd():
+        assert val == 0.1

--- a/tests/model/test_crystal_model.py
+++ b/tests/model/test_crystal_model.py
@@ -629,3 +629,10 @@ def test_recalculated_cell(crystal_class):
         ", 11.00(10), 10.00(10), 90.00(10), 90.00(10), 90.00(10)"
         in str(xl).splitlines()
     )
+
+    cb_op = sgtbx.change_of_basis_op("b,c,a")
+    assert xl.change_basis(
+        cb_op
+    ).get_recalculated_unit_cell().parameters() == pytest.approx(
+        (11.0, 10.0, 10.0, 90.0, 90.0, 90.0)
+    )

--- a/tests/model/test_crystal_model.py
+++ b/tests/model/test_crystal_model.py
@@ -598,8 +598,11 @@ def test_set_scan_varying_B_covariance(crystal_class):
         assert cell_sd_at_scan_point == pytest.approx(cell_sd)
 
 
-def test_recalculated_cell():
-    xl = Crystal(
+@pytest.mark.parametrize(
+    "crystal_class", [Crystal, MosaicCrystalKabsch2010, MosaicCrystalSauter2014]
+)
+def test_recalculated_cell(crystal_class):
+    xl = crystal_class(
         real_space_a=(10, 0, 0),
         real_space_b=(0, 11, 0),
         real_space_c=(0, 0, 12),
@@ -618,8 +621,8 @@ def test_recalculated_cell():
 
     xl.set_recalculated_cell_parameter_sd((0.1,) * 6)
     assert xl.get_recalculated_cell_parameter_sd() == (0.1, 0.1, 0.1, 0.1, 0.1, 0.1)
-
-    assert str(xl).splitlines()[-1] == (
+    assert (
         "    Recalculated unit cell: 10.00(10)"
         ", 11.00(10), 10.00(10), 90.00(10), 90.00(10), 90.00(10)"
+        in str(xl).splitlines()
     )

--- a/tests/model/test_crystal_model.py
+++ b/tests/model/test_crystal_model.py
@@ -606,12 +606,13 @@ def test_recalculated_cell():
         space_group_symbol="P 1",
     )
 
-    assert not xl.has_recalc_unit_cell()
+    assert not xl._has_recalc_unit_cell()
+    assert xl.get_recalc_unit_cell() is None
 
     uc1 = xl.get_unit_cell()
     uc2 = uctbx.unit_cell((10, 11, 10, 90, 90, 90))
     xl.set_recalc_unit_cell(uc2)
-    assert xl.has_recalc_unit_cell()
+    assert xl._has_recalc_unit_cell()
 
     uc3 = xl.get_recalc_unit_cell()
     assert not uc1.is_similar_to(uc2)

--- a/tests/serialize/test_crystal_model_serialize.py
+++ b/tests/serialize/test_crystal_model_serialize.py
@@ -75,3 +75,15 @@ def test_crystal_with_scan_points(example_crystal):
             assert abs(e1 - e2) <= eps
 
     assert c1 == c2
+
+
+def test_crystal_with_recalculated_cell(example_crystal):
+    c1 = Crystal(**example_crystal)
+    uc = c1.get_unit_cell()
+    c1.set_recalc_unit_cell(uc)
+
+    d = c1.to_dict()
+    c2 = CrystalFactory.from_dict(d)
+
+    assert c1.get_recalc_unit_cell().is_similar_to(c2.get_recalc_unit_cell())
+    assert c1 == c2

--- a/tests/serialize/test_crystal_model_serialize.py
+++ b/tests/serialize/test_crystal_model_serialize.py
@@ -81,9 +81,13 @@ def test_crystal_with_recalculated_cell(example_crystal):
     c1 = Crystal(**example_crystal)
     uc = c1.get_unit_cell()
     c1.set_recalc_unit_cell(uc)
+    c1.set_recalc_cell_parameter_sd((0.1,) * 6)
 
     d = c1.to_dict()
     c2 = CrystalFactory.from_dict(d)
 
     assert c1.get_recalc_unit_cell().is_similar_to(c2.get_recalc_unit_cell())
     assert c1 == c2
+
+    for val in c2.get_recalc_cell_parameter_sd():
+        assert val == 0.1

--- a/tests/serialize/test_crystal_model_serialize.py
+++ b/tests/serialize/test_crystal_model_serialize.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function
 from builtins import range
 
 import pytest
+import six.moves.cPickle as pickle
 
 from scitbx import matrix
 from scitbx.array_family import flex
@@ -93,11 +94,12 @@ def test_crystal_with_recalculated_cell(crystal_class, example_crystal):
 
     d = c1.to_dict()
     c2 = CrystalFactory.from_dict(d)
+    c3 = pickle.loads(pickle.dumps(c1))
 
-    assert c2.get_recalculated_unit_cell() is not None
-    assert c1.get_recalculated_unit_cell().is_similar_to(
-        c2.get_recalculated_unit_cell()
-    )
-    assert c1 == c2
-
-    assert c2.get_recalculated_cell_parameter_sd() == (0.1, 0.1, 0.1, 0.1, 0.1, 0.1)
+    for c in (c2, c3):
+        assert c.get_recalculated_unit_cell() is not None
+        assert c1.get_recalculated_unit_cell().is_similar_to(
+            c.get_recalculated_unit_cell()
+        )
+        assert c1 == c
+        assert c.get_recalculated_cell_parameter_sd() == (0.1, 0.1, 0.1, 0.1, 0.1, 0.1)

--- a/tests/serialize/test_crystal_model_serialize.py
+++ b/tests/serialize/test_crystal_model_serialize.py
@@ -89,5 +89,4 @@ def test_crystal_with_recalculated_cell(example_crystal):
     assert c1.get_recalc_unit_cell().is_similar_to(c2.get_recalc_unit_cell())
     assert c1 == c2
 
-    for val in c2.get_recalc_cell_parameter_sd():
-        assert val == 0.1
+    assert c2.get_recalc_cell_parameter_sd() == (0.1, 0.1, 0.1, 0.1, 0.1, 0.1)

--- a/tests/serialize/test_crystal_model_serialize.py
+++ b/tests/serialize/test_crystal_model_serialize.py
@@ -91,6 +91,7 @@ def test_crystal_with_recalculated_cell(crystal_class, example_crystal):
     uc = c1.get_unit_cell()
     c1.set_recalculated_unit_cell(uc)
     c1.set_recalculated_cell_parameter_sd((0.1,) * 6)
+    c1.set_recalculated_cell_volume_sd(0.001)
 
     d = c1.to_dict()
     c2 = CrystalFactory.from_dict(d)
@@ -103,3 +104,4 @@ def test_crystal_with_recalculated_cell(crystal_class, example_crystal):
         )
         assert c1 == c
         assert c.get_recalculated_cell_parameter_sd() == (0.1, 0.1, 0.1, 0.1, 0.1, 0.1)
+        assert c.get_recalculated_cell_volume_sd() == 0.001

--- a/tests/serialize/test_crystal_model_serialize.py
+++ b/tests/serialize/test_crystal_model_serialize.py
@@ -7,7 +7,12 @@ import pytest
 from scitbx import matrix
 from scitbx.array_family import flex
 
-from dxtbx.model import Crystal, CrystalFactory, MosaicCrystalKabsch2010
+from dxtbx.model import (
+    Crystal,
+    CrystalFactory,
+    MosaicCrystalKabsch2010,
+    MosaicCrystalSauter2014,
+)
 
 
 @pytest.fixture()
@@ -77,8 +82,11 @@ def test_crystal_with_scan_points(example_crystal):
     assert c1 == c2
 
 
-def test_crystal_with_recalculated_cell(example_crystal):
-    c1 = Crystal(**example_crystal)
+@pytest.mark.parametrize(
+    "crystal_class", [Crystal, MosaicCrystalKabsch2010, MosaicCrystalSauter2014]
+)
+def test_crystal_with_recalculated_cell(crystal_class, example_crystal):
+    c1 = crystal_class(**example_crystal)
     uc = c1.get_unit_cell()
     c1.set_recalculated_unit_cell(uc)
     c1.set_recalculated_cell_parameter_sd((0.1,) * 6)
@@ -86,6 +94,7 @@ def test_crystal_with_recalculated_cell(example_crystal):
     d = c1.to_dict()
     c2 = CrystalFactory.from_dict(d)
 
+    assert c2.get_recalculated_unit_cell() is not None
     assert c1.get_recalculated_unit_cell().is_similar_to(
         c2.get_recalculated_unit_cell()
     )

--- a/tests/serialize/test_crystal_model_serialize.py
+++ b/tests/serialize/test_crystal_model_serialize.py
@@ -80,13 +80,15 @@ def test_crystal_with_scan_points(example_crystal):
 def test_crystal_with_recalculated_cell(example_crystal):
     c1 = Crystal(**example_crystal)
     uc = c1.get_unit_cell()
-    c1.set_recalc_unit_cell(uc)
-    c1.set_recalc_cell_parameter_sd((0.1,) * 6)
+    c1.set_recalculated_unit_cell(uc)
+    c1.set_recalculated_cell_parameter_sd((0.1,) * 6)
 
     d = c1.to_dict()
     c2 = CrystalFactory.from_dict(d)
 
-    assert c1.get_recalc_unit_cell().is_similar_to(c2.get_recalc_unit_cell())
+    assert c1.get_recalculated_unit_cell().is_similar_to(
+        c2.get_recalculated_unit_cell()
+    )
     assert c1 == c2
 
-    assert c2.get_recalc_cell_parameter_sd() == (0.1, 0.1, 0.1, 0.1, 0.1, 0.1)
+    assert c2.get_recalculated_cell_parameter_sd() == (0.1, 0.1, 0.1, 0.1, 0.1, 0.1)


### PR DESCRIPTION
Following discussion in #150, here is an alternative fix for #142.

The `Crystal` model is furnished with a new "recalculated cell" data member and associated errors. This is entirely independent of the existing static cell. The intention is to set this after some form of postrefinement. We don't want to wipe out the original static cell for this, because that cell was used for prediction, whereas this may not. The `recalc` cell plays a part in the `is_similar_to` iff both crystals have this cell set.