### PR TITLE
Don't swallow FileNotFoundError in ExperimentList.from_file

### DIFF
--- a/model/experiment_list.py
+++ b/model/experiment_list.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, division, print_function
 
 import copy
+import errno
 import json
 import os
 from builtins import range
@@ -743,8 +744,11 @@ class ExperimentListFactory(object):
         # First try as a JSON file
         try:
             return ExperimentListFactory.from_json_file(filename, check_format)
-        except FileNotFoundError:
-            raise
+        except IOError as e:
+            # In an ideal Python 3 world this would be much more simply FileNotFoundError
+            if e.errno == errno.ENOENT:
+                raise
+            pass
         except Exception:
             pass
 

--- a/model/experiment_list.py
+++ b/model/experiment_list.py
@@ -743,6 +743,8 @@ class ExperimentListFactory(object):
         # First try as a JSON file
         try:
             return ExperimentListFactory.from_json_file(filename, check_format)
+        except FileNotFoundError:
+            raise
         except Exception:
             pass
 

--- a/model/experiment_list.py
+++ b/model/experiment_list.py
@@ -748,7 +748,6 @@ class ExperimentListFactory(object):
             # In an ideal Python 3 world this would be much more simply FileNotFoundError
             if e.errno == errno.ENOENT:
                 raise
-            pass
         except Exception:
             pass
 

--- a/tests/model/test_experiment_list.py
+++ b/tests/model/test_experiment_list.py
@@ -2,6 +2,7 @@
 
 from __future__ import absolute_import, division, print_function
 
+import errno
 import os
 from builtins import range
 from glob import glob
@@ -801,10 +802,11 @@ def compare_experiment(exp1, exp2):
 def test_experimentlist_from_file(dials_regression, tmpdir):
     # With the default check_format=True this file should fail to load with an
     # appropriate error as we can't find the images on disk
-    with pytest.raises(FileNotFoundError) as e:
+    with pytest.raises(IOError) as e:
         exp_list = ExperimentList.from_file(
             os.path.join(dials_regression, "experiment_test_data", "experiment_1.json")
         )
+    assert e.value.errno == errno.ENOENT
     assert "No such file or directory" in str(e.value)
     assert "centroid_0001.cbf" in str(e.value)
 

--- a/tests/model/test_experiment_list.py
+++ b/tests/model/test_experiment_list.py
@@ -799,7 +799,25 @@ def compare_experiment(exp1, exp2):
 
 
 def test_experimentlist_from_file(dials_regression, tmpdir):
-    # This allows expansion of environment variables in regression files
+    # With the default check_format=True this file should fail to load with an
+    # appropriate error as we can't find the images on disk
+    with pytest.raises(FileNotFoundError) as e:
+        exp_list = ExperimentList.from_file(
+            os.path.join(dials_regression, "experiment_test_data", "experiment_1.json")
+        )
+    assert "No such file or directory" in str(e.value)
+    assert "centroid_0001.cbf" in str(e.value)
+
+    # Setting check_format=False should allow the file to load
+    exp_list = ExperimentList.from_file(
+        os.path.join(dials_regression, "experiment_test_data", "experiment_1.json"),
+        check_format=False,
+    )
+    assert len(exp_list) == 1
+    assert exp_list[0].beam
+
+    # This allows expansion of environment variables in regression files, enabling the
+    # file to load with check_format=True
     os.environ["DIALS_REGRESSION"] = dials_regression
 
     exp_list = ExperimentList.from_file(


### PR DESCRIPTION
Otherwise this confusingly leads to an error under from_pickle_file.
Fixes #154