### PR TITLE
Add SpectrumBeam as derived class from Beam object

### DIFF
--- a/model/__init__.py
+++ b/model/__init__.py
@@ -26,6 +26,7 @@ from dxtbx.model.scan import ScanFactory
 from dxtbx_model_ext import (
     Beam,
     BeamBase,
+    SpectrumBeam,
     Crystal,
     CrystalBase,
     Detector,
@@ -60,6 +61,7 @@ from dxtbx_model_ext import (
 __all__ = (
     "Beam",
     "BeamBase",
+    "SpectrumBeam",
     "BeamFactory",
     "Crystal",
     "CrystalBase",

--- a/model/__init__.py
+++ b/model/__init__.py
@@ -130,6 +130,37 @@ class _(object):
                 queue.extend(node)
 
 
+@boost.python.inject_into(SpectrumBeam)
+class _(object):
+    def to_dict(self):
+        """Convert the SpectrumBeam model to a dictionary
+
+        Returns:
+            A dictionary of the parameters
+        """
+
+        d = super(SpectrumBeam, self).to_dict()
+        d["spectrum_energies"] = tuple(self.get_spectrum_energies())
+        d["spectrum_weights"] = tuple(self.get_spectrum_weights())
+        return d
+
+    def from_dict(d):
+        """Convert the dictionary to a SpectrumBeam model
+
+        Params:
+            d The dictionary of parameters
+
+        Returns:
+            The SpectrumBeam model
+        """
+        beam = SpectrumBeam(Beam.from_dict(d))
+        if "spectrum_energies" in d:
+            beam.set_spectrum(
+                flex.double(d["spectrum_energies"]), flex.double(d["spectrum_weights"])
+            )
+        return beam
+
+
 @boost.python.inject_into(Crystal)
 class _(object):
     def show(self, show_scan_varying=False, out=None):

--- a/model/beam.h
+++ b/model/beam.h
@@ -579,6 +579,7 @@ namespace dxtbx { namespace model {
                                                           polarization_fraction_tolerance))
         return false;
       const SpectrumBeam* other = dynamic_cast<const SpectrumBeam* >(&rhs);
+      if (!other) return true;
       return (std::abs(get_weighted_wavelength() - other->get_weighted_wavelength()) <=
               spectrum_weighted_wavelength_tolerance);
     }

--- a/model/beam.py
+++ b/model/beam.py
@@ -6,7 +6,7 @@ from builtins import object, range
 import libtbx.phil
 
 import pycbf
-from dxtbx_model_ext import Beam
+from dxtbx_model_ext import Beam, SpectrumBeam
 
 beam_phil_scope = libtbx.phil.parse(
     """
@@ -90,7 +90,10 @@ class BeamFactory(object):
         joint.update(d)
 
         # Create the model from the joint dictionary
-        return Beam.from_dict(joint)
+        if "spectrum_energies" in joint:
+            return SpectrumBeam.from_dict(joint)
+        else:
+            return Beam.from_dict(joint)
 
     @staticmethod
     def make_beam(

--- a/model/boost_python/beam.cc
+++ b/model/boost_python/beam.cc
@@ -329,22 +329,6 @@ namespace dxtbx { namespace model { namespace boost_python {
     return b;
   }
 
-  template <>
-  boost::python::dict to_dict<SpectrumBeam>(const SpectrumBeam &obj) {
-    boost::python::dict result = to_dict<Beam>(obj);
-    result["spectrum_energies"] = obj.get_spectrum_energies();
-    result["spectrum_weights"] = obj.get_spectrum_weights();
-    return result;
-  }
-
-  template <>
-  SpectrumBeam* from_dict<SpectrumBeam>(boost::python::dict obj) {
-    SpectrumBeam* b = new SpectrumBeam(*from_dict<Beam>(obj));
-    b->set_spectrum(boost::python::extract< scitbx::af::shared<double> >(obj.get("spectrum_energies", scitbx::af::shared<double>())),
-                    boost::python::extract< scitbx::af::shared<double> >(obj.get("spectrum_weights",  scitbx::af::shared<double>())));
-    return b;
-  }
-
   void export_beam() {
     // Export BeamBase
     class_<BeamBase, boost::noncopyable>("BeamBase", no_init)
@@ -487,10 +471,6 @@ namespace dxtbx { namespace model { namespace boost_python {
             arg("polarization_fraction_tolerance") = 1e-6,
             arg("spectrum_weighted_wavelength_tolerance") = 1e-6))
       .def("__str__", &spectrumbeam_to_string)
-      .def("to_dict", &to_dict<SpectrumBeam>)
-      .def("from_dict", &from_dict<SpectrumBeam>,
-        return_value_policy<manage_new_object>())
-      .staticmethod("from_dict")
       .def_pickle(SpectrumBeamPickleSuite());
 
     scitbx::af::boost_python::flex_wrapper<Beam>::plain("flex_Beam");

--- a/tests/model/test_beam.py
+++ b/tests/model/test_beam.py
@@ -192,3 +192,9 @@ def test_spectrum_beam():
     assert b1.is_similar_to(b2)
     b2.set_spectrum(spectrum_energies + 50, spectrum_weights)
     assert not b1.is_similar_to(b2)
+
+    b3 = Beam()
+    b1.set_wavelength(1.2)
+    b3.set_wavelength(1.2)
+    assert b1.is_similar_to(b3)
+    assert b3.is_similar_to(b1)

--- a/tests/model/test_beam.py
+++ b/tests/model/test_beam.py
@@ -7,8 +7,9 @@ import pytest
 from libtbx.phil import parse
 from scitbx import matrix
 
-from dxtbx.model import Beam
+from dxtbx.model import Beam, SpectrumBeam
 from dxtbx.model.beam import BeamFactory, beam_phil_scope
+from dials.array_family import flex
 
 
 def test_setting_direction_and_wavelength():
@@ -178,3 +179,16 @@ def test_beam_object_comparison():
 def test_beam_self_serialization():
     beam = Beam()
     assert beam == BeamFactory.from_dict(beam.to_dict())
+
+
+def test_spectrum_beam():
+    spectrum_energies = flex.double(range(9450, 9550))
+    spectrum_weights = flex.double(range(len(spectrum_energies)))
+    b1 = SpectrumBeam()
+    b2 = SpectrumBeam()
+    b1.set_spectrum(spectrum_energies, spectrum_weights)
+    b2.set_spectrum(spectrum_energies, spectrum_weights)
+    assert b1.get_weighted_wavelength() == pytest.approx(1.3028567060142213)
+    assert b1.is_similar_to(b2)
+    b2.set_spectrum(spectrum_energies + 50, spectrum_weights)
+    assert not b1.is_similar_to(b2)

--- a/tests/serialize/test_serialize.py
+++ b/tests/serialize/test_serialize.py
@@ -7,6 +7,7 @@ from scitbx.array_family import flex
 
 from dxtbx.model import (
     Beam,
+    SpectrumBeam,
     BeamFactory,
     Goniometer,
     GoniometerFactory,
@@ -17,6 +18,30 @@ from dxtbx.model import (
 
 def test_beam():
     b1 = Beam((1, 0, 0), 2, 0.1, 0.1)
+    d = b1.to_dict()
+    b2 = BeamFactory.from_dict(d)
+    assert d["direction"] == (1, 0, 0)
+    assert d["wavelength"] == 2
+    assert d["divergence"] == pytest.approx(0.1)
+    assert d["sigma_divergence"] == pytest.approx(0.1)
+    assert b1 == b2
+    assert "s0_at_scan_points" not in d
+
+    # Test with a template and partial dictionary
+    d2 = {"direction": (0, 1, 0), "divergence": 0.2}
+    b3 = BeamFactory.from_dict(d2, d)
+    assert b3.get_sample_to_source_direction() == (0, 1, 0)
+    assert b3.get_wavelength() == 2
+    assert b3.get_divergence() == pytest.approx(0.2)
+    assert b3.get_sigma_divergence() == pytest.approx(0.1)
+    assert b2 != b3
+
+
+def test_spectrum_beam():
+    b1 = SpectrumBeam((1, 0, 0), 2, 0.1, 0.1)
+    spectrum_energies = flex.double(range(9450, 9550))
+    spectrum_weights = flex.double(range(len(spectrum_energies)))
+    b1.set_spectrum(spectrum_energies, spectrum_weights)
     d = b1.to_dict()
     b2 = BeamFactory.from_dict(d)
     assert d["direction"] == (1, 0, 0)


### PR DESCRIPTION
SpectrumBeam has these methods:
set_spectrum(flex.double energies, flex.double weights)
get_spectrum_energies()
get_spectrum_weights()
get_weighted_wavelength()

Two flex arrays, energies (eV) and weights (dimensionless), represent the spectrum as a scatter plot.  This follows the conventions set up in nexusformat/definitions#717. The new function get_weighted_wavelength uses a simple weighted mean to determine a wavelength.

It is ok if the SpectrumBeam has a wavelength != get_weighted_wavelength.  This represents a calibrated wavelength determined from processing the spectrum.

is_similar_to tests get_weighted_wavelength between the two beams.

Includes tests.

Marking as a draft until #151 is merged, then will rebase on master and mark as ready for review. This is ready for review now though.