### PR TITLE
Add spectrum to beam object

### DIFF
--- a/model/__init__.py
+++ b/model/__init__.py
@@ -798,6 +798,8 @@ class _(object):
         from dxtbx.datablock import AutoEncoder
 
         for fname, obj in to_write:
+            beam_spectra_to_pickle(filename, obj)
+
             if compact:
                 separators = (",", ":")
                 indent = None
@@ -887,3 +889,46 @@ class _(object):
         for expt, cb_op in zip(return_expts, change_of_basis_ops):
             expt.crystal = expt.crystal.change_basis(cb_op)
         return return_expts
+
+def beam_spectra_to_pickle(filename, obj):
+    """
+    Helper function to take an experiment list dictionary and move the
+    spectra to a pickle file
+
+    Args:
+        filename: File name the experiment list will be saved to
+        obj: Experiment list dictionary
+    """
+    if "beam" not in obj:
+        return
+    all_energies = []
+    all_weights = []
+    test = None
+    all_eq = True
+    for beam in obj["beam"]:
+        if "spectrum_energies" not in beam:
+            continue
+        if test is None:
+            test = beam["spectrum_energies"]
+        else:
+            if (test == beam["spectrum_energies"]).count(False):
+                all_eq = False
+                break
+
+    for beam in obj["beam"]:
+        if "spectrum_energies" not in beam:
+            continue
+        if not all_eq or not all_energies:
+            all_energies.append(beam["spectrum_energies"])
+        all_weights.append(beam["spectrum_weights"])
+        del beam["spectrum_energies"]
+        del beam["spectrum_weights"]
+        beam["spectrum_index"] = len(all_weights) - 1
+    if not all_energies:
+        return
+    pickle_filename = os.path.splitext(filename)[0] + "_spectrum.pickle"
+    obj["spectra_pickle"] = pickle_filename
+    with open(str(pickle_filename), "wb") as outfile:
+        pickle.dump(
+            (all_energies, all_weights), outfile, protocol=pickle.HIGHEST_PROTOCOL
+        )

--- a/model/boost_python/beam.cc
+++ b/model/boost_python/beam.cc
@@ -215,14 +215,8 @@ namespace dxtbx { namespace model { namespace boost_python {
       result["s0_at_scan_points"] = l;
     }
     if (obj.get_spectrum_energies().size()) {
-      boost::python::list e;
-      boost::python::list w;
-      for (size_t i = 0; i < obj.get_spectrum_energies().size(); i++) {
-        e.append(obj.get_spectrum_energies()[i]);
-        w.append(obj.get_spectrum_weights()[i]);
-      }
-      result["spectrum_energies"] = e;
-      result["spectrum_weights"] = w;
+      result["spectrum_energies"] = obj.get_spectrum_energies();
+      result["spectrum_weights"] = obj.get_spectrum_weights();
     }
     return result;
   }
@@ -246,16 +240,8 @@ namespace dxtbx { namespace model { namespace boost_python {
     }
     if (obj.has_key("spectrum_energies")) {
       DXTBX_ASSERT(obj.has_key("spectrum_weights"));
-      boost::python::list e_list = boost::python::extract<boost::python::list>(obj["spectrum_energies"]);
-      boost::python::list w_list = boost::python::extract<boost::python::list>(obj["spectrum_weights"]);
-      DXTBX_ASSERT(boost::python::len(e_list) == boost::python::len(w_list));
-      scitbx::af::shared<double> e;
-      scitbx::af::shared<double> w;
-      for (size_t i = 0; i < boost::python::len(e_list); i++) {
-        e.push_back(boost::python::extract<double>(e_list[i]));
-        w.push_back(boost::python::extract<double>(w_list[i]));
-      }
-      b->set_spectrum(e, w);
+      b->set_spectrum(boost::python::extract<scitbx::af::shared<double> >(obj["spectrum_energies"]),
+                      boost::python::extract<scitbx::af::shared<double> >(obj["spectrum_energies"]));
     }
     return b;
   }

--- a/model/boost_python/beam.cc
+++ b/model/boost_python/beam.cc
@@ -99,7 +99,7 @@ namespace dxtbx { namespace model { namespace boost_python {
     return beam;
   }
 
-  static Beam *make_beam_w_all(vec3<double> sample_to_source,
+  static Beam *make_beam_w_most(vec3<double> sample_to_source,
                                double wavelength,
                                double divergence,
                                double sigma_divergence,
@@ -128,6 +128,23 @@ namespace dxtbx { namespace model { namespace boost_python {
                       flux,
                       transmission);
     }
+    return beam;
+  }
+
+  static Beam *make_beam_w_all(vec3<double> sample_to_source,
+                               double wavelength,
+                               double divergence,
+                               double sigma_divergence,
+                               vec3<double> polarization_normal,
+                               double polarization_fraction,
+                               double flux,
+                               double transmission,
+                               scitbx::af::shared<double> spectrum_energies,
+                               scitbx::af::shared<double> spectrum_weights,
+                               bool deg) {
+    Beam *beam = make_beam_w_most(sample_to_source, wavelength, divergence, sigma_divergence,
+                                  polarization_normal, polarization_fraction, flux, transmission, deg);
+    beam->set_spectrum(spectrum_energies, spectrum_weights);
     return beam;
   }
 
@@ -310,6 +327,18 @@ namespace dxtbx { namespace model { namespace boost_python {
           default_call_policies(),
           (arg("s0"), arg("divergence"), arg("sigma_divergence"), arg("deg") = true)))
       .def("__init__",
+           make_constructor(&make_beam_w_most,
+                            default_call_policies(),
+                            (arg("direction"),
+                             arg("wavelength"),
+                             arg("divergence"),
+                             arg("sigma_divergence"),
+                             arg("polarization_normal"),
+                             arg("polarization_fraction"),
+                             arg("flux"),
+                             arg("transmission"),
+                             arg("deg") = true)))
+       .def("__init__",
            make_constructor(&make_beam_w_all,
                             default_call_policies(),
                             (arg("direction"),
@@ -320,6 +349,8 @@ namespace dxtbx { namespace model { namespace boost_python {
                              arg("polarization_fraction"),
                              arg("flux"),
                              arg("transmission"),
+                             arg("spectrum_energies"),
+                             arg("spectrum_weights"),
                              arg("deg") = true)))
       .def("__str__", &beam_to_string)
       .def("get_spectrum_energies",

--- a/model/experiment_list.py
+++ b/model/experiment_list.py
@@ -371,8 +371,28 @@ class ExperimentListDict(object):
                 )
             )
 
+        # Read the beam spectra if available
+        self._read_spectra_pickle(el.beams())
+
         # Return the experiment list
         return el
+
+    def _read_spectra_pickle(self, beams):
+        """ Read the beam spectra if available """
+        if "spectra_pickle" not in self._obj:
+            return
+        with open(self._obj["spectra_pickle"], "rb") as infile:
+            all_energies, all_weights = pickle.load(infile)
+        assert len(all_energies) == 1 or len(all_energies) == len(all_weights)
+        for i, beam in enumerate(beams):
+            spectrum_index = self._obj["beam"][i].get("spectrum_index")
+            if spectrum_index is not None:
+                if len(all_energies) == 1:
+                    beam.set_spectrum(all_energies[0], all_weights[spectrum_index])
+                else:
+                    beam.set_spectrum(
+                        all_energies[spectrum_index], all_weights[spectrum_index]
+                    )
 
     def _make_mem_imageset(self, imageset):
         """Can't make a mem imageset from dict."""

--- a/model/experiment_list.py
+++ b/model/experiment_list.py
@@ -384,7 +384,7 @@ class ExperimentListDict(object):
 
         import h5py
 
-        f = h5py.File(self._obj["spectra_h5"], "r")
+        f = h5py.File(os.path.join(self._directory, self._obj["spectra_h5"]), "r")
         all_energies = f["all_energies"][()]
         all_weights = f["all_weights"][()]
 
@@ -395,11 +395,16 @@ class ExperimentListDict(object):
             spectrum_index = self._obj["beam"][i].get("spectrum_index")
             if spectrum_index is not None:
                 if len(all_energies.shape) == 1:
-                    beam.set_spectrum(all_energies, all_weights[spectrum_index])
+                    spectrum = all_energies
                 else:
-                    beam.set_spectrum(
-                        all_energies[spectrum_index], all_weights[spectrum_index]
-                    )
+                    spectrum = all_energies[spectrum_index]
+
+                if len(all_weights.shape) == 1:
+                    weights = all_weights
+                else:
+                    weights = all_weights[spectrum_index]
+
+                beam.set_spectrum(spectrum, weights)
 
     def _make_mem_imageset(self, imageset):
         """Can't make a mem imageset from dict."""

--- a/tests/model/test_beam.py
+++ b/tests/model/test_beam.py
@@ -6,10 +6,10 @@ import pytest
 
 from libtbx.phil import parse
 from scitbx import matrix
+from scitbx.array_family import flex
 
 from dxtbx.model import Beam
 from dxtbx.model.beam import BeamFactory, beam_phil_scope
-from dials.array_family import flex
 
 
 def test_setting_direction_and_wavelength():

--- a/tests/model/test_beam.py
+++ b/tests/model/test_beam.py
@@ -9,6 +9,7 @@ from scitbx import matrix
 
 from dxtbx.model import Beam
 from dxtbx.model.beam import BeamFactory, beam_phil_scope
+from dials.array_family import flex
 
 
 def test_setting_direction_and_wavelength():
@@ -178,3 +179,22 @@ def test_beam_object_comparison():
 def test_beam_self_serialization():
     beam = Beam()
     assert beam == BeamFactory.from_dict(beam.to_dict())
+
+
+def test_spectrum_beam():
+    spectrum_energies = flex.double(range(9450, 9550))
+    spectrum_weights = flex.double(range(len(spectrum_energies)))
+    b1 = Beam()
+    b2 = Beam()
+    b1.set_spectrum(spectrum_energies, spectrum_weights)
+    b2.set_spectrum(spectrum_energies, spectrum_weights)
+    assert b1.get_weighted_wavelength() == pytest.approx(1.3028567060142213)
+    assert b1.is_similar_to(b2)
+    b2.set_spectrum(spectrum_energies + 50, spectrum_weights)
+    assert not b1.is_similar_to(b2)
+
+    b3 = Beam()
+    b1.set_wavelength(1.2)
+    b3.set_wavelength(1.2)
+    assert not b1.is_similar_to(b3)
+    assert not b3.is_similar_to(b1)

--- a/tests/serialize/test_serialize.py
+++ b/tests/serialize/test_serialize.py
@@ -53,6 +53,30 @@ def test_beam_with_scan_points():
     assert b1 == b2
 
 
+def test_spectrum_beam():
+    b1 = Beam((1, 0, 0), 2, 0.1, 0.1)
+    spectrum_energies = flex.double(range(9450, 9550))
+    spectrum_weights = flex.double(range(len(spectrum_energies)))
+    b1.set_spectrum(spectrum_energies, spectrum_weights)
+    d = b1.to_dict()
+    b2 = BeamFactory.from_dict(d)
+    assert d["direction"] == (1, 0, 0)
+    assert d["wavelength"] == 2
+    assert d["divergence"] == pytest.approx(0.1)
+    assert d["sigma_divergence"] == pytest.approx(0.1)
+    assert b1 == b2
+    assert "s0_at_scan_points" not in d
+
+    # Test with a template and partial dictionary
+    d2 = {"direction": (0, 1, 0), "divergence": 0.2}
+    b3 = BeamFactory.from_dict(d2, d)
+    assert b3.get_sample_to_source_direction() == (0, 1, 0)
+    assert b3.get_wavelength() == 2
+    assert b3.get_divergence() == pytest.approx(0.2)
+    assert b3.get_sigma_divergence() == pytest.approx(0.1)
+    assert b2 != b3
+
+
 def test_goniometer():
     g1 = Goniometer((1, 0, 0), (1, 0, 0, 0, 1, 0, 0, 0, 1))
     d = g1.to_dict()


### PR DESCRIPTION
Adds these methods:
set_spectrum(flex.double energies, flex.double weights)
get_spectrum_energies()
get_spectrum_weights()
get_weighted_wavelength()

Two flex arrays, energies (eV) and weights (dimensionless), represent the spectrum as a scatter plot.  This follows the conventions set up in nexusformat/definitions#717. The new function get_weighted_wavelength uses a simple weighted mean to determine a wavelength.

It is ok if the beam has a wavelength != get_weighted_wavelength.  This represents a calibrated wavelength determined from processing the spectrum.

is_similar_to tests get_weighted_wavelength between the two beams, if a spectrum is present.

Includes tests.