### PR TITLE
Fix sls eiger 168

### DIFF
--- a/format/nexus.py
+++ b/format/nexus.py
@@ -666,7 +666,7 @@ def get_depends_on_chain_using_equipment_components(transformation):
     by grouping them using equipment_component, then the dependency chain will
     skip the intermediate dependencies, listing only the first at each level.
     """
-    chain = []
+    chain = [transformation]
     current = transformation
 
     while True:

--- a/newsfragments/168.bugfix
+++ b/newsfragments/168.bugfix
@@ -1,0 +1,1 @@
+New Eiger FileWriter produces NeXus compliant files, which exposed a bug in finding axis sample depends on, now fixed.

--- a/newsfragments/168.bugfix
+++ b/newsfragments/168.bugfix
@@ -1,1 +1,1 @@
-New Eiger FileWriter produces NeXus compliant files, which exposed a bug in finding axis sample depends on, now fixed.
+New Eiger FileWriter (20.1.16.56035) produces NeXus compliant files, which exposed a bug in finding axis sample depends on, now fixed.


### PR DESCRIPTION
Include head in dependency tree - fixes #168

Previously we were skipping the first thing that the sample depends on for FormatNeXus - not a problem before because sample depended on sample_x etc.