### PR TITLE
Update nexus readers to find beam in both sample and instrument groups

### DIFF
--- a/format/FormatHDF5EigerNearlyNexus.py
+++ b/format/FormatHDF5EigerNearlyNexus.py
@@ -343,6 +343,7 @@ class FormatHDF5EigerNearlyNexus(FormatHDF5):
         ), "Currently only supports 1 NXdetector_module"
         assert (
             len(reader.entries[0].samples[0].beams) == 1
+            or len(reader.entries[0].instruments[0].beams) == 1
         ), "Currently only supports 1 NXbeam"
 
         # Get the NXmx model objects
@@ -350,7 +351,7 @@ class FormatHDF5EigerNearlyNexus(FormatHDF5):
         self.instrument = instrument = entry.instruments[0]
         detector = instrument.detectors[0]
         sample = entry.samples[0]
-        beam = sample.beams[0]
+        beam = sample.beams[0] if sample.beams else instrument.beams[0]
 
         # Use data from original master file
         data = NXdata(fixer.handle_orig[entry.data[0].handle.name])

--- a/format/FormatNexus.py
+++ b/format/FormatNexus.py
@@ -43,6 +43,7 @@ class FormatNexus(FormatHDF5):
         assert len(reader.entries[0].samples) == 1, "Currently only supports 1 NXsample"
         assert (
             len(reader.entries[0].samples[0].beams) == 1
+            or len(reader.entries[0].instruments[0].beams) == 1
         ), "Currently only supports 1 NXbeam"
 
         # Get the NXmx model objects
@@ -50,7 +51,7 @@ class FormatNexus(FormatHDF5):
         self.instrument = instrument = entry.instruments[0]
         detector = instrument.detectors[0]
         sample = entry.samples[0]
-        beam = sample.beams[0]
+        beam = sample.beams[0] if sample.beams else instrument.beams[0]
         data = entry.data[0]
 
         # Construct the models

--- a/format/FormatNexusJungfrauHack.py
+++ b/format/FormatNexusJungfrauHack.py
@@ -51,6 +51,7 @@ class FormatNexusJungfrauHack(FormatNexus):
         assert len(reader.entries[0].samples) == 1, "Currently only supports 1 NXsample"
         assert (
             len(reader.entries[0].samples[0].beams) == 1
+            or len(reader.entries[0].instruments[0].beams) == 1
         ), "Currently only supports 1 NXbeam"
 
         # Get the NXmx model objects
@@ -58,7 +59,7 @@ class FormatNexusJungfrauHack(FormatNexus):
         self.instrument = instrument = entry.instruments[0]
         detector = instrument.detectors[0]
         sample = entry.samples[0]
-        beam = sample.beams[0]
+        beam = sample.beams[0] if sample.beams else instrument.beams[0]
         data = entry.data[0]
 
         # Construct the models

--- a/format/nexus.py
+++ b/format/nexus.py
@@ -400,6 +400,11 @@ class NXinstrument(object):
         for entry in find_class(self.handle, "NXdetector_group"):
             self.detector_groups.append(NXdetector_group(entry))
 
+        # Find the NXbeam
+        self.beams = []
+        for entry in find_class(self.handle, "NXbeam"):
+            self.beams.append(NXbeam(entry))
+
 
 class NXbeam(object):
     """
@@ -418,14 +423,10 @@ class NXsample(object):
     def __init__(self, handle):
         self.handle = handle
 
-        # Find the NXsource
+        # Find the NXbeam
         self.beams = []
         for entry in find_class(self.handle, "NXbeam"):
             self.beams.append(NXbeam(entry))
-
-        # Check we've got stuff
-        if not self.beams:
-            raise NXValidationError("No NXbeam in %s" % self.handle.name)
 
 
 class NXdata(object):
@@ -501,8 +502,10 @@ class NXmxReader(object):
             instruments = entry.instruments
             samples = entry.samples
             print("  > %s" % handle.name)
+            beams = []
             for instrument in instruments:
                 handle = instrument.handle
+                beams += instrument.beams
                 detectors = instrument.detectors
                 print("   > %s" % handle.name)
                 for detector in detectors:
@@ -514,11 +517,11 @@ class NXmxReader(object):
                         print("     > %s" % handle.name)
             for sample in samples:
                 handle = sample.handle
-                beams = sample.beams
+                beams += sample.beams
                 print("   > %s" % handle.name)
-                for beam in beams:
-                    handle = beam.handle
-                    print("    > %s" % handle.name)
+            for beam in beams:
+                handle = beam.handle
+                print("    > %s" % handle.name)
 
 
 def is_nexus_file(filename):


### PR DESCRIPTION
While NXmx (currently) specifies NXbeam is required on the NXsample group, the NeXus base class NXinstrument also allows NXbeam.  A PR to modifiy NXmx to note beam can be on instrument instead is under preparation.

With this change the revised NeXus master file in https://zenodo.org/record/3526738#.XrNAABNKipr works.