### PR TITLE
Support Formats from "scheme://" URL identifiers

### DIFF
--- a/format/Format.py
+++ b/format/Format.py
@@ -56,9 +56,10 @@ try:
 except ImportError:
     gzip = None
 
-
-# import access to all of the factories that we will be needing
-
+try:
+    from typing import List
+except ImportError:
+    pass
 
 _cache_controller = dxtbx.filecache_controller.simple_controller()
 
@@ -99,7 +100,20 @@ class Format(object):
     image formats, from which all classes for reading the header should be
     inherited. This includes: autoregistration of implementation classes,
     stubs which need to be overridden and links to static factory methods
-    which will prove to be useful in other implementations."""
+    which will prove to be useful in other implementations.
+
+    Attributes:
+        schemes: List of schemes this Format class supports.
+            An empty string ("") is treated as non-URL filenames, where
+            "file" is treated as explicit file:// support. Format classes
+            that do not support the listed schema will _not_ be called
+            to understand() with the locator - note that this means if a
+            class does not declare "file", it will not get called to
+            understand "file://" URIs passed to it. An empty `schemes` will
+            not ever get called in Format registry searches.
+    """
+
+    schemes = [""]  # type: List[str]
 
     @staticmethod
     def understand(image_file):

--- a/format/Format.py
+++ b/format/Format.py
@@ -17,8 +17,6 @@ standard_library.install_aliases()
 
 import functools
 import sys
-import urllib.parse
-import urllib.request
 from builtins import range
 from os.path import abspath
 
@@ -515,25 +513,12 @@ class Format(object):
     #                                                                  #
     ####################################################################
 
-    @staticmethod
-    def is_url(path):
-        """See if the file is a URL."""
-
-        # Windows file paths can get caught up in this - check that the
-        # first letter is one character (which I think should be safe: all
-        # URL types are longer than this right?)
-        scheme = urllib.parse.urlparse(path).scheme
-        return scheme and len(scheme) != 1
-
     @classmethod
-    def open_file(cls, filename, mode="rb", url=False):
+    def open_file(cls, filename, mode="rb"):
         """Open file for reading, decompressing silently if necessary,
         caching transparently if possible."""
 
-        if url and Format.is_url(filename):
-            fh_func = functools.partial(urllib.request.urlopen, filename)
-
-        elif filename.endswith(".bz2"):
+        if filename.endswith(".bz2"):
             if not bz2:
                 raise RuntimeError("bz2 file provided without bz2 module")
             fh_func = functools.partial(bz2.BZ2File, filename, mode=mode)

--- a/newsfragments/173.feature
+++ b/newsfragments/173.feature
@@ -1,0 +1,1 @@
+Allow creation of Format classes that accept URLs instead of files

--- a/tests/format/test_uri.py
+++ b/tests/format/test_uri.py
@@ -1,0 +1,96 @@
+"""
+Testing URI-passing in the Format class hierarchy
+"""
+
+from typing import Type
+
+import pytest
+
+import dxtbx
+import dxtbx.format.Registry as Registry
+from dxtbx.format.Format import Format
+
+
+@pytest.fixture
+def registry(monkeypatch):
+    """Temporarily register a format class"""
+    _temporary_formats = {}
+    _original_get_format_class_for = Registry.get_format_class_for
+
+    def _get_format_class_for(format_class_name: str) -> Type[Format]:
+        """Intercept fetching format classes"""
+        if format_class_name in _temporary_formats:
+            return _temporary_formats[format_class_name]
+        else:
+            return _original_get_format_class_for(format_class_name)
+
+    monkeypatch.setattr(Registry, "get_format_class_for", _get_format_class_for)
+
+    class _registry:
+        @staticmethod
+        def register(format_class: Format) -> None:
+            name = format_class.__name__
+            _temporary_formats[name] = format_class
+            monkeypatch.setitem(Registry._format_dag, name, [])
+            _format_entry = list(Registry._format_dag["Format"]) + [name]
+            monkeypatch.setitem(Registry._format_dag, "Format", _format_entry)
+            # Registry._format_dag["Format"].append(name)
+
+    return _registry
+
+
+def test_registry_inject(registry, tmp_path):
+    """meta-test of registry injection"""
+    _hit_understand = []
+
+    class TestClass(Format):
+        @classmethod
+        def understand(cls, filename):
+            _hit_understand.append(True)
+            return "TEST_FILE" in str(filename)
+
+    filename_notest = tmp_path / "A_FILE"
+    filename_notest.touch()
+    filename = tmp_path / "TEST_FILE"
+    filename.touch()
+    assert not Registry.get_format_class_for_file(str(filename_notest))
+    registry.register(TestClass)
+    assert Registry.get_format_class_for("TestClass") is TestClass
+    assert Registry.get_format_class_for_file(str(filename))
+    assert _hit_understand == [True]
+
+
+def test_custom_scheme_handler(registry):
+    class SchemeHandler(Format):
+        schemes = ["scheme"]
+
+        @classmethod
+        def understand(cls, endpoint):
+            assert endpoint.startswith("scheme://")
+            return True
+
+    assert not Registry.get_format_class_for_file("scheme://something")
+    registry.register(SchemeHandler)
+    assert Registry.get_format_class_for_file("scheme://something") is SchemeHandler
+    # Check dxtbx.load
+    instance = dxtbx.load("scheme://something")
+    assert isinstance(instance, SchemeHandler)
+
+
+def test_multiple_scheme_handler(registry, tmp_path):
+    _hits = []
+
+    class SchemeHandler(Format):
+        schemes = ["scheme", ""]
+
+        @classmethod
+        def understand(cls, endpoint):
+            _hits.append(endpoint)
+            return True
+
+    registry.register(SchemeHandler)
+    assert Registry.get_format_class_for_file("scheme://something") is SchemeHandler
+    filename = tmp_path / "TEST_FILE"
+    filename.touch()
+    assert Registry.get_format_class_for_file(str(filename)) is SchemeHandler
+    assert _hits == ["scheme://something", str(filename)]


### PR DESCRIPTION
This patch adds the ability to build `Format` classes such that `dxtbx.load("scheme://something")` will work - e.g. create a format class from a URL instead of a filename. This also works when passing things in through dials, e.g. `dials.import`. This works via checking for a scheme extracted via [urlparse](https://docs.python.org/3/library/urllib.parse.html#urllib.parse.urlparse) - if a scheme is present then various file-based handling (open-read cache, absolute expansion) is bypassed.

A `Format` class must have the schemes it supports explicitly defined via the `schemes` attribute:
```python
def FormatScheme(Format):
    schemes = ["scheme"]
```
where the default value for `schemes` is empty (`""`). If the format class does not declare support for a scheme, then it will not be called to `understand()` the endpoint - this means that no existing format classes should need to be changed, as they inherit the empty scheme from `Format`. Currently, this evaluation is done before `understand()` but _after_ importing the class, so will require the usual import safety checks - I don't think it's worth altering the entry_point registry to handle this as it's easy enough to handle.

Resolves #162