### PR TITLE
Bugfix for hierarchical detectors in NeXus

### DIFF
--- a/format/nexus.py
+++ b/format/nexus.py
@@ -835,6 +835,7 @@ class DetectorFactoryFromGroup(object):
                 # Set up the hierarchical detector by iteraing through the dependencies,
                 # starting at the root
                 chain = get_depends_on_chain_using_equipment_components(depends_on)
+                chain.pop(0)  # Do not want fast/slow pixel directions here
                 pg = None
                 for transform in reversed(chain):
                     name = str(os.path.basename(transform.name))


### PR DESCRIPTION
Account for #169, where the first element of the depends on chain is now the input element. Fine for gonio/scan but doesn't work for multipanel detectors.

@graeme-winter could you run dials.import on your sls eiger file with and without this change and let me know if there is a difference?

This change is critical for the JF16M so let me know.  I'd like this merged ASAP if it doesn't affect things on your end.  THANKS.