### PR TITLE
Fix issues reloading data with scheme:// format data sources

### DIFF
--- a/datablock.py
+++ b/datablock.py
@@ -13,6 +13,7 @@ from os.path import abspath, dirname, normpath, splitext
 
 import six
 import six.moves.cPickle as pickle
+from six.moves.urllib_parse import urlparse
 
 import libtbx
 from scitbx import matrix
@@ -897,7 +898,10 @@ def _create_imageset(records, format_class, format_kwargs=None):
     # Nothing here should have been assigned a template parameter
     assert all(x.template is None for x in records)
     # Extract the filenames from the records
-    filenames = [os.path.abspath(x.filename) for x in records]
+    filenames = [
+        os.path.abspath(x.filename) if not urlparse(x.filename).scheme else x.filename
+        for x in records
+    ]
     # Create the imageset
     imageset = dxtbx.imageset.ImageSetFactory.make_imageset(
         filenames, format_class, format_kwargs=format_kwargs, check_format=False

--- a/format/Format.py
+++ b/format/Format.py
@@ -17,8 +17,10 @@ standard_library.install_aliases()
 
 import functools
 import sys
+import os
 from builtins import range
-from os.path import abspath
+
+from six.moves.urllib_parse import urlparse
 
 import libtbx
 
@@ -296,7 +298,7 @@ class Format(object):
     @classmethod
     def get_imageset(
         Class,
-        filenames,
+        input_filenames,
         beam=None,
         detector=None,
         goniometer=None,
@@ -315,8 +317,10 @@ class Format(object):
         # Import here to avoid cyclic imports
         from dxtbx.imageset import ImageSet, ImageSetData, ImageSequence
 
-        # Get filename absolute paths
-        filenames = tuple(map(abspath, filenames))
+        # Get filename absolute paths, for entries that are filenames
+        filenames = [
+            os.path.abspath(x) if not urlparse(x).scheme else x for x in input_filenames
+        ]
 
         # Make it a dict
         if format_kwargs is None:

--- a/model/experiment_list.py
+++ b/model/experiment_list.py
@@ -9,6 +9,7 @@ from builtins import range
 import pkg_resources
 import six
 import six.moves.cPickle as pickle
+from six.moves.urllib_parse import urlparse
 
 from dxtbx.datablock import (
     BeamComparison,
@@ -381,7 +382,8 @@ class ExperimentListDict(object):
     def _make_stills(self, imageset, format_kwargs=None):
         """Make a still imageset."""
         filenames = [
-            resolve_path(p, directory=self._directory) for p in imageset["images"]
+            resolve_path(p, directory=self._directory) if not urlparse(p).scheme else p
+            for p in imageset["images"]
         ]
         indices = None
         if "single_file_indices" in imageset:

--- a/newsfragments/176.bugfix
+++ b/newsfragments/176.bugfix
@@ -1,0 +1,1 @@
+Prevent mangling of URL-based filenames via abspath

--- a/tests/test_regression_images.py
+++ b/tests/test_regression_images.py
@@ -13,14 +13,15 @@ import sys
 import py.path
 import pytest
 import six
+from six.moves.urllib_parse import urlparse
 
 import libtbx.load_env
 import scitbx.matrix
 from rstbx.slip_viewer.slip_viewer_image_factory import SlipViewerImageFactory
+from scitbx.array_family import flex
 
 import dxtbx.conftest
 import dxtbx.format.Registry
-from scitbx.array_family import flex
 
 if sys.version_info[:2] >= (3, 6):
     from pathlib import Path
@@ -251,9 +252,11 @@ def test_format_class_API_assumptions(test_image):
         known_format_class = None
         multiple_formats = False
         for subformat in dag.get(parentformat, []):
-            understood = dxtbx.format.Registry.get_format_class_for(
-                subformat
-            ).understand(filename)
+            format_class = dxtbx.format.Registry.get_format_class_for(subformat)
+            if not urlparse(filename).scheme in format_class.schemes:
+                print("Not matching ", filename, "to", format_class)
+                continue
+            understood = format_class.understand(filename)
             print("%s%s: %s" % ("  " * level, subformat, understood))
             if understood:
                 recursive_format_class, subtree_multiple = recurse(


### PR DESCRIPTION
Schema format support went in in e8282159908f0fa5254f204e75ed829a8ba86ac2.

There are a couple of issues with `datablock.json`, `Format.py` and `experiment_list.py` that got missed from that commit, that cause issues with reloading schema data from file e.g. several places that when loading, assume filenames and call `abspath`.

This adds tests and fixes those.

In addition, a problem where the duplicate-format test was not scheme-aware is fixed.