### PR TITLE
Trust data dimensions not image_size

### DIFF
--- a/format/FormatHDF5EigerNearlyNexus.py
+++ b/format/FormatHDF5EigerNearlyNexus.py
@@ -352,11 +352,14 @@ class FormatHDF5EigerNearlyNexus(FormatHDF5):
 
         # Use data from original master file
         data = NXdata(fixer.handle_orig[entry.data[0].handle.name])
+        self._raw_data = DataFactory(data, cached_information=fixer.data_factory_cache)
 
         # Construct the models
         self._beam_factory = BeamFactory(beam)
         self._beam_factory.load_model(0)
-        self._detector_model = DetectorFactory(detector, self._beam_factory.model).model
+        self._detector_model = DetectorFactory(
+            detector, self._beam_factory.model, shape=self._raw_data.shape()
+        ).model
 
         # Override the minimum trusted value - for Eiger should be -1
         for panel in self._detector_model:
@@ -365,7 +368,6 @@ class FormatHDF5EigerNearlyNexus(FormatHDF5):
 
         self._goniometer_model = GoniometerFactory(sample).model
         self._scan_model = generate_scan_model(sample, detector)
-        self._raw_data = DataFactory(data, cached_information=fixer.data_factory_cache)
 
         # update model for masking Eiger detectors
         for f0, f1, s0, s1 in determine_eiger_mask(self._detector_model):

--- a/format/FormatNexus.py
+++ b/format/FormatNexus.py
@@ -74,15 +74,15 @@ class FormatNexus(FormatHDF5):
                 len(reader.entries[0].instruments[0].detectors[0].modules) == 1
             ), "Currently only supports 1 NXdetector_module unless in a detector group"
 
-            self._detector_model = DetectorFactory(
-                detector, self._beam_factory.model
-            ).model
             self._raw_data = DataFactory(data, max_size=num_images)
+            self._detector_model = DetectorFactory(
+                detector, self._beam_factory.model, shape=self._raw_data.shape()
+            ).model
         else:
+            self._raw_data = detectorgroupdatafactory(data, instrument)
             self._detector_model = DetectorFactoryFromGroup(
                 instrument, self._beam_factory.model
             ).model
-            self._raw_data = detectorgroupdatafactory(data, instrument)
 
     def _setup_gonio_and_scan(self, sample, detector):
         """Set up rotation-specific models"""

--- a/newsfragments/189.bugfix
+++ b/newsfragments/189.bugfix
@@ -1,0 +1,1 @@
+Reading HDF5 / NeXus: get image dimensions from dataset shape not claimed image_ize


### PR DESCRIPTION
For single-panel NeXus files anyway, read the actual array dimensions in
the data rather than the asserted image_size data set (which has historically
been _sometimes_ back-to-front so needs reversing sometimes) - removes the
known backwards as every case where that was relevent is now handled by
actually reading the proper array dimensions.

Fixes #184