### PR TITLE
Move not copy data from imageset_ext

### DIFF
--- a/boost_python/imageset_ext.cc
+++ b/boost_python/imageset_ext.cc
@@ -375,7 +375,11 @@ namespace dxtbx { namespace boost_python {
     }
 
     // Return the image - don't copy
+#if __cplusplus > 199711L
     return std::move(result);
+#else
+    return result;
+#endif
   }
 
   /**

--- a/boost_python/imageset_ext.cc
+++ b/boost_python/imageset_ext.cc
@@ -374,8 +374,8 @@ namespace dxtbx { namespace boost_python {
       result.append(data.tile(i).data());
     }
 
-    // Return the image
-    return result;
+    // Return the image - don't copy
+    return std::move(result);
   }
 
   /**


### PR DESCRIPTION
Following from warning from clang:

```
/Users/graeme/svn/cctbx/modules/dxtbx/boost_python/imageset_ext.cc:378:12: warning:
      local variable 'result' will be copied despite being returned by name
      [-Wreturn-std-move]
    return result;
           ^~~~~~
/Users/graeme/svn/cctbx/modules/dxtbx/boost_python/imageset_ext.cc:378:12: note:
      call 'std::move' explicitly to avoid copying
    return result;
           ^~~~~~
           std::move(result)
```

This seems to work in my hands