### PR TITLE
More PY3 support for FormatPY, the xfel legacy image pickle format

### DIFF
--- a/command_line/print_header.py
+++ b/command_line/print_header.py
@@ -15,6 +15,9 @@ def print_header():
     for arg in sys.argv[1:]:
         print("=== %s ===" % arg)
         format_class = dxtbx.format.Registry.get_format_class_for_file(arg)
+        if not format_class:
+            print("No format class found that can understand %s" % arg)
+            continue
         print("Using header reader: %s" % format_class.__name__)
         i = format_class(arg)
         beam = i.get_beam()

--- a/format/FormatPY.py
+++ b/format/FormatPY.py
@@ -13,7 +13,7 @@ import pickle
 class FormatPY(Format):
     """Let's take an educated guess as to how to recognize a Python
     pickle file containing a dictionary.  Not easy because there are
-    four pickle protocols in Python.  The lowest pickle format only
+    six pickle protocols in Python.  The lowest pickle format only
     gives us two unique bytes by which to recognize a dictionary,
     so also check if we can unpickle the file."""
 
@@ -22,11 +22,13 @@ class FormatPY(Format):
         try:
             with FormatPY.open_file(image_file, "rb") as fh:
                 tag = fh.read(4)
-                if (
+                if (  # pickle protocols 0-5 where the pickled object is a dictionary
                     tag[0:2] == b"(d"
                     or tag[0:2] == b"}q"
                     or tag[0:4] == b"\x80\x02}q"
-                    or tag[0:4] == b"\x80\x04\x95\xea"
+                    or tag[0:4] == b"\x80\x03}q"
+                    or tag[0:3] == b"\x80\x04\x95"
+                    or tag[0:3] == b"\x80\x05\x95"
                 ):
                     fh.seek(0)
                     if six.PY3:

--- a/format/FormatPYmultitile.py
+++ b/format/FormatPYmultitile.py
@@ -13,6 +13,8 @@ from xfel.cftbx.detector.cspad_detector import CSPadDetector
 from dxtbx.format.FormatPY import FormatPY
 from dxtbx.model import Detector
 
+from iotbx.detectors.npy import image_dict_to_unicode
+
 
 class FormatPYmultitile(FormatPY):
     @staticmethod
@@ -21,7 +23,7 @@ class FormatPYmultitile(FormatPY):
             with FormatPYmultitile.open_file(image_file, "rb") as fh:
                 if six.PY3:
                     data = pickle.load(fh, encoding="bytes")
-                    data = {key.decode("ascii"): value for key, value in data.items()}
+                    data = image_dict_to_unicode(data)
                 else:
                     data = pickle.load(fh)
         except IOError:

--- a/format/FormatPYunspecified.py
+++ b/format/FormatPYunspecified.py
@@ -11,7 +11,7 @@ from iotbx.detectors.cspad_detector_formats import (
     detector_format_version,
     reverse_timestamp,
 )
-from iotbx.detectors.npy import NpyImage
+from iotbx.detectors.npy import NpyImage, image_dict_to_unicode
 from scitbx.array_family import flex
 from spotfinder.applications.xfel import cxi_phil
 
@@ -29,13 +29,13 @@ class FormatPYunspecified(FormatPY):
             with FormatPYunspecified.open_file(image_file, "rb") as fh:
                 if six.PY3:
                     data = pickle.load(fh, encoding="bytes")
-                    headers = {key.decode("ascii") for key in data}
+                    data = image_dict_to_unicode(data)
                 else:
                     data = pickle.load(fh)
-                    headers = set(data)
         except IOError:
             return False
 
+        headers = set(data)
         wanted_header_items = {"SIZE1", "SIZE2", "TIMESTAMP"}
 
         return wanted_header_items.issubset(headers)
@@ -50,12 +50,7 @@ class FormatPYunspecified(FormatPY):
             with FormatPYunspecified.open_file(self._image_file, "rb") as fh:
                 if six.PY3:
                     data = pickle.load(fh, encoding="bytes")
-                    data = {
-                        key.decode("ascii"): value.decode("latin-1")
-                        if isinstance(value, bytes)
-                        else value
-                        for key, value in data.items()
-                    }
+                    data = image_dict_to_unicode(data)
                 else:
                     data = pickle.load(fh)
         else:

--- a/format/FormatPYunspecifiedStill.py
+++ b/format/FormatPYunspecifiedStill.py
@@ -11,6 +11,7 @@ from dxtbx.format.FormatPYunspecified import (
     FormatPYunspecifiedInMemory,
 )
 from dxtbx.format.FormatStill import FormatStill
+from iotbx.detectors.npy import image_dict_to_unicode
 
 
 class FormatPYunspecifiedStill(FormatStill, FormatPYunspecified):
@@ -25,10 +26,11 @@ class FormatPYunspecifiedStill(FormatStill, FormatPYunspecified):
         try:
             with FormatPYunspecified.open_file(image_file, "rb") as fh:
                 if six.PY3:
-                    data = pickle.load(fh, encoding="bytes")  # lgtm
+                    data = image_dict_to_unicode(
+                        pickle.load(fh, encoding="bytes")
+                    )  # lgtm
                     # the '# lgtm' comment disables an lgtm false positive and
                     # can be removed once we move to Python 3 only
-                    data = {key.decode("ascii"): value for key, value in data.items()}
                 else:
                     data = pickle.load(fh)
         except IOError:

--- a/newsfragments/205.bugfix
+++ b/newsfragments/205.bugfix
@@ -1,0 +1,1 @@
+Fix reading of legacy pickle-image files created from Python 3


### PR DESCRIPTION
Current dxtbx testing for FormatPY uses pickles that were created using py2.  While reprocessing old LCLS data I regenerated some image pickles on a py3 build and found I couldn't read them because of encoding problems.  This PR fixes that problem using a new function in iotbx/npy.py, image_dict_to_unicode.

Additionally, this makes the understand method of FormatPY more robust.  Adds pickle protocol 4 magic bytes check but also tries to de-pickle the file, as the pickle magic bytes aren't guaranteed to fully specify whether a file is a pickle.

Note, the only place image pickles are generated in xfel land is averaging XTC streams with Rayonix data.  Everyting else, including xtc_process using Rayonix data, uses cbfs.