### PR TITLE
Update isort to 5.4.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,10 +2,9 @@ repos:
 
 # Automatically sort imports
 - repo: https://github.com/timothycrosley/isort.git
-  rev: 4.3.21
+  rev: 5.4.2
   hooks:
   - id: isort
-    additional_dependencies: [toml]
 
 # Automatic source code formatting
 - repo: https://github.com/psf/black

--- a/command_line/detector_superpose.py
+++ b/command_line/detector_superpose.py
@@ -13,6 +13,7 @@ from xfel.command_line.cspad_detector_congruence import iterate_detector_at_leve
 
 import dials.util
 from dials.util.options import OptionParser
+
 from dxtbx.model.experiment_list import ExperimentListFactory
 from dxtbx.serialize import dump
 

--- a/command_line/display_parallax_correction.py
+++ b/command_line/display_parallax_correction.py
@@ -3,6 +3,8 @@ from __future__ import absolute_import, division, print_function
 import sys
 from builtins import range
 
+from matplotlib import pylab
+
 from scitbx.array_family import flex
 
 from dxtbx.datablock import DataBlockFactory
@@ -19,7 +21,6 @@ if __name__ == "__main__":
     assert isinstance(px_mm, ParallaxCorrectedPxMmStrategy)
     print("Mu: %f mm^-1 " % px_mm.mu())
     print("t0: %f mm" % px_mm.t0())
-    from matplotlib import pylab
 
     image_size = detector[0].get_image_size()[::-1]
     xcorr = flex.double(flex.grid(image_size))

--- a/format/FormatCBFCspad.py
+++ b/format/FormatCBFCspad.py
@@ -4,10 +4,11 @@ from __future__ import absolute_import, division, print_function
 
 from builtins import range
 
+import pycbf
+
 from cctbx.eltbx import attenuation_coefficient
 from scitbx.matrix import col, sqr
 
-import pycbf
 from dxtbx.format.FormatCBFFull import FormatCBFFullStill
 from dxtbx.format.FormatCBFMultiTileHierarchy import FormatCBFMultiTileHierarchyStill
 from dxtbx.model import ParallaxCorrectedPxMmStrategy

--- a/format/FormatCBFFull.py
+++ b/format/FormatCBFFull.py
@@ -9,11 +9,11 @@ from __future__ import absolute_import, division, print_function
 import sys
 
 import numpy as np
+import pycbf
 
 from iotbx.detectors.cbf import CBFImage
 from scitbx.array_family import flex
 
-import pycbf
 from dxtbx.format.Format import bz2, gzip
 from dxtbx.format.FormatCBF import FormatCBF
 from dxtbx.format.FormatStill import FormatStill

--- a/format/FormatCBFMini.py
+++ b/format/FormatCBFMini.py
@@ -10,13 +10,14 @@ import binascii
 import os
 import sys
 
+import pycbf
+
 from boost.python import streambuf
 from cbflib_adaptbx import uncompress
 from cctbx.eltbx import attenuation_coefficient
 from iotbx.detectors.pilatus_minicbf import PilatusImage
 from scitbx.array_family import flex
 
-import pycbf
 from dxtbx.ext import read_int32
 from dxtbx.format.FormatCBF import FormatCBF
 from dxtbx.format.FormatCBFMiniPilatusHelpers import get_pilatus_timestamp

--- a/format/FormatCBFMultiTile.py
+++ b/format/FormatCBFMultiTile.py
@@ -6,10 +6,10 @@ import sys
 from builtins import range
 
 import numpy
+import pycbf
 
 from scitbx.array_family import flex
 
-import pycbf
 from dxtbx.format.FormatCBF import FormatCBF
 from dxtbx.format.FormatCBFFull import FormatCBFFull
 from dxtbx.format.FormatStill import FormatStill

--- a/format/FormatCBFMultiTileHierarchy.py
+++ b/format/FormatCBFMultiTileHierarchy.py
@@ -10,11 +10,12 @@ import struct
 import sys
 from builtins import range
 
+import pycbf
+
 from libtbx.utils import Sorry
 from scitbx.array_family import flex
 from scitbx.matrix import col, sqr
 
-import pycbf
 from dxtbx.format.FormatCBFMultiTile import FormatCBFMultiTile, FormatCBFMultiTileStill
 from dxtbx.model import Detector
 

--- a/format/FormatNexus.py
+++ b/format/FormatNexus.py
@@ -162,7 +162,7 @@ class FormatNexusStill(FormatMultiImageLazy, FormatNexus, FormatStill):
     def understand(image_file):
         is_nexus_still = False
         try:
-            from dxtbx.format.nexus import find_entries, find_class
+            from dxtbx.format.nexus import find_class, find_entries
 
             # Get the file handle
             with h5py.File(image_file, "r") as handle:

--- a/format/FormatXTCCspad.py
+++ b/format/FormatXTCCspad.py
@@ -4,6 +4,7 @@ import sys
 from builtins import range
 
 import numpy as np
+import psana
 
 from cctbx.eltbx import attenuation_coefficient
 from libtbx.phil import parse
@@ -12,13 +13,12 @@ from scitbx.matrix import col
 from xfel.cftbx.detector.cspad_cbf_tbx import read_slac_metrology
 from xfel.cxi.cspad_ana.cspad_tbx import env_distance
 
-import psana
 from dxtbx.format.FormatXTC import FormatXTC, locator_str
 from dxtbx.model import Detector, ParallaxCorrectedPxMmStrategy
 
 try:
-    from xfel.cxi.cspad_ana import cspad_tbx
     from xfel.cftbx.detector import cspad_cbf_tbx
+    from xfel.cxi.cspad_ana import cspad_tbx
 except ImportError:
     # xfel not configured
     pass

--- a/format/FormatXTCJungfrau.py
+++ b/format/FormatXTCJungfrau.py
@@ -4,12 +4,12 @@ import sys
 from builtins import range
 
 import numpy as np
+import psana
 
 from libtbx.phil import parse
 from scitbx.array_family import flex
 from scitbx.matrix import col
 
-import psana
 from dxtbx.format.FormatXTC import FormatXTC, locator_str
 from dxtbx.model import Detector
 

--- a/format/FormatXTCRayonix.py
+++ b/format/FormatXTCRayonix.py
@@ -2,10 +2,11 @@ from __future__ import absolute_import, division, print_function
 
 import sys
 
+import psana
+
 from libtbx.phil import parse
 from scitbx.array_family import flex
 
-import psana
 from dxtbx.format.FormatXTC import FormatXTC, locator_str
 
 try:

--- a/format/cbf_writer.py
+++ b/format/cbf_writer.py
@@ -11,6 +11,7 @@ from __future__ import absolute_import, division, print_function
 import os
 import sys
 
+import pycbf
 import six
 
 from scitbx.array_family import flex
@@ -21,7 +22,6 @@ from xfel.cftbx.detector.cspad_cbf_tbx import (
 )
 
 import dxtbx.format.Registry
-import pycbf
 
 
 class FullCBFWriter(object):

--- a/format/nexus.py
+++ b/format/nexus.py
@@ -29,9 +29,9 @@ from dxtbx.model import (
 
 try:
     from dxtbx_format_nexus_ext import (
-        dataset_as_flex_int,
         dataset_as_flex_double,
         dataset_as_flex_float,
+        dataset_as_flex_int,
     )
 except ImportError:
     # Workaround for psana build, which doesn't link HDF5 properly

--- a/model/beam.py
+++ b/model/beam.py
@@ -3,9 +3,10 @@ from __future__ import absolute_import, division, print_function
 import math
 from builtins import object, range
 
+import pycbf
+
 import libtbx.phil
 
-import pycbf
 from dxtbx_model_ext import Beam
 
 beam_phil_scope = libtbx.phil.parse(

--- a/model/detector.py
+++ b/model/detector.py
@@ -3,11 +3,12 @@ from __future__ import absolute_import, division, print_function
 import os
 from builtins import object, range
 
+import pycbf
+
 import libtbx.phil
 from cctbx.eltbx import attenuation_coefficient
 from scitbx import matrix
 
-import pycbf
 from dxtbx.model.detector_helpers import (
     detector_helper_sensors,
     find_gain_value,

--- a/model/goniometer.py
+++ b/model/goniometer.py
@@ -3,10 +3,11 @@ from __future__ import absolute_import, division, print_function
 import math
 from builtins import object, range
 
+import pycbf
+
 import libtbx.phil
 from scitbx.array_family import flex
 
-import pycbf
 from dxtbx_model_ext import Goniometer, KappaGoniometer, MultiAxisGoniometer
 
 __all__ = [

--- a/model/scan.py
+++ b/model/scan.py
@@ -3,10 +3,11 @@ from __future__ import absolute_import, division, print_function
 import os
 from builtins import object, range
 
+import pycbf
+
 import libtbx.phil
 from scitbx.array_family import flex
 
-import pycbf
 from dxtbx.model.scan_helpers import scan_helper_image_files, scan_helper_image_formats
 from dxtbx_model_ext import Scan
 

--- a/newsfragments/211.misc
+++ b/newsfragments/211.misc
@@ -1,0 +1,1 @@
+Update isort to 5.4.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,10 +9,4 @@ filename = "CHANGELOG.rst"
 [tool.isort]
 known_cctbx="boost,boost_adaptbx,cbflib_adaptbx,cctbx,chiltbx,clipper_adaptbx,cma_es,cootbx,crys3d,cudatbx,fable,fast_linalg,fftw3tbx,gltbx,iota,iotbx,libtbx,mmtbx,omptbx,prime,rstbx,scitbx,simtbx,smtbx,spotfinder,tbxx,ucif,wxtbx,xfel"
 sections="FUTURE,STDLIB,THIRDPARTY,CCTBX,FIRSTPARTY,LOCALFOLDER"
-# Explicitly black-compatible settings
-multi_line_output=3
-include_trailing_comma=true
-force_grid_wrap=0
-use_parentheses=true
-line_length=88
-ensure_newline_before_comments=true
+profile="black"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,8 @@ package_dir = ".."
 filename = "CHANGELOG.rst"
 
 [tool.isort]
+sections="FUTURE,STDLIB,THIRDPARTY,CCTBX,DIALS,FIRSTPARTY,LOCALFOLDER"
+known_firstparty="dxtbx_*"
 known_cctbx="boost,boost_adaptbx,cbflib_adaptbx,cctbx,chiltbx,clipper_adaptbx,cma_es,cootbx,crys3d,cudatbx,fable,fast_linalg,fftw3tbx,gltbx,iota,iotbx,libtbx,mmtbx,omptbx,prime,rstbx,scitbx,simtbx,smtbx,spotfinder,tbxx,ucif,wxtbx,xfel"
-sections="FUTURE,STDLIB,THIRDPARTY,CCTBX,FIRSTPARTY,LOCALFOLDER"
+known_dials="dials"
 profile="black"

--- a/tests/test_image_readers.py
+++ b/tests/test_image_readers.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function
 import os
 
 import pycbf
+
 from dxtbx.format.image import cbf_read_buffer
 from dxtbx.model.detector import DetectorFactory
 

--- a/tests/test_split_singleimage_datablock.py
+++ b/tests/test_split_singleimage_datablock.py
@@ -6,7 +6,6 @@ import pytest
 
 from dxtbx.datablock import DataBlockDumper, DataBlockFactory
 
-
 """
 Test deserializing a datablock that has single file indices while using check_format = True or False
 """


### PR DESCRIPTION
Isort had a big release (or set of releases), which makes it's classification of dependencies a lot more deterministic and reliable in the face of changing environments (https://github.com/timothycrosley/isort/issues/1147), as well as adding adds a load of controls for when it works.

This updates it, the main side-effect of is that `psana` and `pycbf` are now treated as third-party; this probably makes sense as a classification for import sorting. It also separates dials, which I've added in as an extra, manual section - it makes sense to keep this close to dxtbx where used, although we should probably try to remove these few recursive dependencies where they aren't protected.