### PR TITLE
Fix FormatSMVADSC breaking with non-integer pedestal

### DIFF
--- a/format/FormatSMVADSC.py
+++ b/format/FormatSMVADSC.py
@@ -76,7 +76,7 @@ class FormatSMVADSC(FormatSMV):
         pedestal that is present"""
 
         if pedestal is None:
-            pedestal = int(self._header_dictionary.get("IMAGE_PEDESTAL", 0))
+            pedestal = float(self._header_dictionary.get("IMAGE_PEDESTAL", 0))
 
         overload = 65535 - pedestal
         underload = -1 - pedestal
@@ -178,7 +178,7 @@ class FormatSMVADSC(FormatSMV):
             self._adsc_trusted_range(),
             [],
             gain=self._adsc_module_gain(),
-            pedestal=int(self._header_dictionary.get("IMAGE_PEDESTAL", 0)),
+            pedestal=float(self._header_dictionary.get("IMAGE_PEDESTAL", 0)),
         )
 
     def _beam(self):

--- a/format/FormatSMVRigakuSaturnNoTS.py
+++ b/format/FormatSMVRigakuSaturnNoTS.py
@@ -156,7 +156,7 @@ class FormatSMVRigakuSaturnNoTS(FormatSMVRigaku):
             pixel_size,
             image_size,
             (underload, overload),
-            pedestal=int(self._header_dictionary.get("IMAGE_PEDESTAL"), 0),
+            pedestal=float(self._header_dictionary.get("IMAGE_PEDESTAL"), 0),
         )
 
     def _beam(self):

--- a/newsfragments/216.bugfix
+++ b/newsfragments/216.bugfix
@@ -1,0 +1,1 @@
+Don't crash handling FormatSMVADSC images with floating-point pedestal values

--- a/tests/format/test_FormatSMVADSC.py
+++ b/tests/format/test_FormatSMVADSC.py
@@ -1,0 +1,20 @@
+import os
+
+import dxtbx
+
+
+def test_noninteger_pedestal(dials_regression, tmpdir):
+    filename = os.path.join(
+        dials_regression, "image_examples/APS_14BMC/q315_1_001.img",
+    )
+    # Read this file in as data
+    with open(filename, "rb") as f:
+        data = f.read()
+
+    # Write out with an inserted header item of a noninteger pedestal
+    test_file = tmpdir / "test_pedestal_001.img"
+    with test_file.open("wb") as f:
+        f.write(data.replace(b"DIM=2;\n", b"DIM=2;\nIMAGE_PEDESTAL=42.0;\n"))
+
+    # Make sure this loads
+    dxtbx.load(str(test_file))

--- a/tests/format/test_FormatSMVADSC.py
+++ b/tests/format/test_FormatSMVADSC.py
@@ -17,4 +17,4 @@ def test_noninteger_pedestal(dials_regression, tmpdir):
         f.write(data.replace(b"DIM=2;\n", b"DIM=2;\nIMAGE_PEDESTAL=42.0;\n"))
 
     # Make sure this loads
-    dxtbx.load(str(test_file))
+    dxtbx.load(test_file)


### PR DESCRIPTION
Thanks to Christina Zimanyi on dials-support for the bug report:
```
  File "/Applications/ccp4-7.1/lib/py2/site-packages/dxtbx/format/FormatSMVADSC.py", line 79, in _adsc_trusted_range
    pedestal = int(self._header_dictionary.get("IMAGE_PEDESTAL", 0))
ValueError: Please report this error to dials-support@lists.sourceforge.net: invalid literal for int() with base 10: '93.0'
```
This appears to be triggered by an image file with a noninteger entry for `IMAGE_PEDESTAL`, whereas the code assumes that the header is always an integer - which has apparently held until now.

This fix just changes this to a float - it looks like it's always eventually passed into `DetectorFactory.make_detector`, which defaults and sets as floats anyway, so this shouldn't break anything.

I've added a test that rewrites part of an img file to try to provide a replication test.