### PR TITLE
Clear cache

### DIFF
--- a/boost_python/imageset_ext.cc
+++ b/boost_python/imageset_ext.cc
@@ -645,6 +645,7 @@ namespace dxtbx { namespace boost_python {
       .def("as_imageset", &ImageSet::as_imageset)
       .def("complete_set", &ImageSet::complete_set)
       .def("partial_set", &ImageSet::partial_set)
+      .def("clear_cache", &ImageSet::clear_cache)
       .def("__eq__", &ImageSet::operator==)
       .def("__ne__", &ImageSet::operator!=)
       .def("update_detector_px_mm_data", &ImageSet_update_detector_px_mm_data)

--- a/imageset.h
+++ b/imageset.h
@@ -1070,6 +1070,11 @@ public:
     return !(*this == other);
   }
 
+  void clear_cache() {
+    data_cache_ = DataCache<ImageBuffer>();
+    double_raw_data_cache_ = DataCache<Image<double> >();
+  }
+
 protected:
   ImageSetData data_;
   scitbx::af::shared<std::size_t> indices_;

--- a/imageset.h
+++ b/imageset.h
@@ -1070,6 +1070,11 @@ public:
     return !(*this == other);
   }
 
+  /**
+   * Clear the imageset cache. Useful for when many imagesets are
+   * held in memory. After reading an image the cache can be
+   * manually cleared before moving onto the next imageset.
+   */
   void clear_cache() {
     data_cache_ = DataCache<ImageBuffer>();
     double_raw_data_cache_ = DataCache<Image<double> >();

--- a/newsfragments/218.bugfix
+++ b/newsfragments/218.bugfix
@@ -1,0 +1,1 @@
+Add clear_cache() to imageset

--- a/newsfragments/218.bugfix
+++ b/newsfragments/218.bugfix
@@ -1,1 +1,0 @@
-Add clear_cache() to imageset

--- a/newsfragments/218.feature
+++ b/newsfragments/218.feature
@@ -1,0 +1,1 @@
+Add clear_cache() method to clear internal imageset cache


### PR DESCRIPTION
Fixes memory leak in dials/dials@87929e297d81a20eec933ea6b6b006db5a75972c

In MPI mode, transmitting only the index into the experiment list is much faster than transmitting a sliced experiment list.  However, the slices now stay in memory instead of going through MPI pickling and thus falling out of scope. This causes a leak because of the caching in imageset.  Adding the ability to clear the cache means the memory can be freed, and later, the imageset can be serialized (especially relevant for composite mode).

Corresponding PR to dials.stills_process will be issued when this is approved.