### PR TITLE
Update i23 bad pixel mask

### DIFF
--- a/format/FormatCBFMiniPilatusDLS12M.py
+++ b/format/FormatCBFMiniPilatusDLS12M.py
@@ -170,7 +170,11 @@ class FormatCBFMiniPilatusDLS12M(FormatCBFMiniPilatus):
         cy = 97  # chip pixels y
         dx = 7  # module gap size
 
-        if timestamp > calendar.timegm((2020, 2, 21, 0, 0, 0)):
+        if timestamp > calendar.timegm((2020, 9, 8, 0, 0, 0)):
+            # 2020 run 4
+            # Detector serviced by Dectris, no bad modules
+            pass
+        elif timestamp > calendar.timegm((2020, 2, 21, 0, 0, 0)):
             # 2020 run 1
             # module @ row 1 column 4
             # blank chip @ row 15 column 4 (chip row 0, column 1)

--- a/newsfragments/220.bugfix
+++ b/newsfragments/220.bugfix
@@ -1,0 +1,1 @@
+Update DLS I23 bad pixel mask after detector has been cleaned, fixing previously bad modules.

--- a/tests/format/test_FormatCBFMiniPilatusDLS12M.py
+++ b/tests/format/test_FormatCBFMiniPilatusDLS12M.py
@@ -33,6 +33,8 @@ n_pixels_vertical_gaps = 195 * 7 * 4 * 24
             False,
             293699 + n_pixels_vertical_gaps,
         ),
+        (calendar.timegm((2020, 9, 8, 0, 0, 1)), True, 3053),
+        (calendar.timegm((2020, 9, 8, 0, 0, 1)), False, 3053 + n_pixels_vertical_gaps),
     ),
 )
 def test_bad_pixel_mask(


### PR DESCRIPTION
The detector was serviced/cleaned during shutdown 3 and therefore no longer has any bad modules.