### PR TITLE
Unify script handling in command_line/

### DIFF
--- a/command_line/debug_memory.py
+++ b/command_line/debug_memory.py
@@ -8,8 +8,8 @@ from builtins import range
 import dxtbx
 
 
-def main():
-    frame = sys.argv[1]
+def run(args=None):
+    frame = args or sys.argv[1]
     powers = [2 ** n for n in range(20)]
 
     for j in range(powers[-1] + 1):
@@ -20,4 +20,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    run()

--- a/command_line/debug_memory.py
+++ b/command_line/debug_memory.py
@@ -1,19 +1,23 @@
 # LIBTBX_SET_DISPATCHER_NAME dev.dxtbx.debug_memory
-from __future__ import absolute_import, division, print_function
 
+import argparse
 import resource
-import sys
 from builtins import range
 
 import dxtbx
 
 
 def run(args=None):
-    frame = args or sys.argv[1]
+    parser = argparse.ArgumentParser(
+        description="Test memory usage by repeatedly loading an image"
+    )
+    parser.add_argument("image_frame", help="An image to reload repeatedly")
+    options = parser.parse_args(args)
+
     powers = [2 ** n for n in range(20)]
 
     for j in range(powers[-1] + 1):
-        dxtbx.load(frame)
+        dxtbx.load(options.image_frame)
         mem = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
         if j in powers:
             print(j, mem)

--- a/command_line/depends_on.py
+++ b/command_line/depends_on.py
@@ -1,6 +1,4 @@
-from __future__ import absolute_import, division, print_function
-
-import sys
+import argparse
 
 import h5py
 
@@ -24,7 +22,7 @@ def depends_on(in_name):
         if hasattr(thing, "keys"):
             for k in thing:
                 try:
-                    finder(thing[k], path="%s/%s" % (path, k))
+                    finder(thing[k], path=f"{path}/{k}")
                 except (IOError, TypeError, ValueError, KeyError):
                     pass
 
@@ -54,25 +52,30 @@ def depends_on(in_name):
     at = "."
     depth = 0
     while at in inverted:
-        print("%s+ %s" % (" " * depth, at))
+        print(f"{' ' * depth}+ {at}")
         at = inverted[at]
         depth += 2
-    print("%s+ %s" % (" " * depth, at))
+    print(f"{' ' * depth}+ {at}")
     print("")
 
-    print("Sample at %s depends on:" % sample)
+    print(f"Sample at {sample} depends on:")
     if "depends_on" in f[sample]:
         print(f[sample]["depends_on"][()])
     elif hasattr(f[sample], "attrs") and "depends_on" in f[sample].attrs:
         print(f[sample].attrs["depends_on"])
     else:
-        print("%s -> depends_on not found" % sample)
+        print(f"{sample} -> depends_on not found")
 
     f.close()
 
 
 def run(args=None):
-    depends_on(args or sys.argv[1])
+    parser = argparse.ArgumentParser(
+        description="Print depends_on hierarchy for Nexus files"
+    )
+    parser.add_argument("filename", help="The nexus file")
+    opts = parser.parse_args(args)
+    depends_on(opts.filename)
 
 
 if __name__ == "__main__":

--- a/command_line/depends_on.py
+++ b/command_line/depends_on.py
@@ -71,5 +71,9 @@ def depends_on(in_name):
     f.close()
 
 
+def run(args=None):
+    depends_on(args or sys.argv[1])
+
+
 if __name__ == "__main__":
-    depends_on(sys.argv[1])
+    run()

--- a/command_line/display_parallax_correction.py
+++ b/command_line/display_parallax_correction.py
@@ -10,8 +10,9 @@ from scitbx.array_family import flex
 from dxtbx.datablock import DataBlockFactory
 from dxtbx.model import ParallaxCorrectedPxMmStrategy
 
-if __name__ == "__main__":
-    datablocks = DataBlockFactory.from_args(sys.argv[1:])
+
+def run(args=None):
+    datablocks = DataBlockFactory.from_args(args or sys.argv[1:])
     assert len(datablocks) == 1
     detectors = datablocks[0].unique_detectors()
     assert len(detectors) == 1
@@ -43,5 +44,9 @@ if __name__ == "__main__":
     )
     fig.subplots_adjust(right=0.8)
     cax = fig.add_axes([0.9, 0.1, 0.03, 0.8])
-    cbar = fig.colorbar(im, cax=cax)
+    fig.colorbar(im, cax=cax)
     pylab.show()
+
+
+if __name__ == "__main__":
+    run()

--- a/command_line/dlsnxs2cbf.py
+++ b/command_line/dlsnxs2cbf.py
@@ -4,5 +4,11 @@ import sys
 
 import dxtbx.util.dlsnxs2cbf
 
+
+def run(args=None):
+    args = args or sys.argv[1:]
+    dxtbx.util.dlsnxs2cbf.make_cbf(args[0], args[1])
+
+
 if __name__ == "__main__":
-    dxtbx.util.dlsnxs2cbf.make_cbf(sys.argv[1], sys.argv[2])
+    run()

--- a/command_line/dlsnxs2cbf.py
+++ b/command_line/dlsnxs2cbf.py
@@ -1,13 +1,16 @@
-from __future__ import absolute_import, division, print_function
-
-import sys
+import argparse
 
 import dxtbx.util.dlsnxs2cbf
 
 
 def run(args=None):
-    args = args or sys.argv[1:]
-    dxtbx.util.dlsnxs2cbf.make_cbf(args[0], args[1])
+    parser = argparse.ArgumentParser(description="Convert an nxs file to multiple cbfs")
+    parser.add_argument("nexus_file", help="Input nexus file")
+    parser.add_argument(
+        "template", help="Template cbf output name e.g. 'image_%04d.cbf'"
+    )
+    options = parser.parse_args(args)
+    dxtbx.util.dlsnxs2cbf.make_cbf(options.nexus_file, options.template)
 
 
 if __name__ == "__main__":

--- a/command_line/image2pickle.py
+++ b/command_line/image2pickle.py
@@ -67,9 +67,8 @@ def crop_image_pickle(
     return data
 
 
-def run(argv=None):
-    if argv is None:
-        argv = sys.argv[1:]
+def run(args=None):
+    args = args or sys.argv[1:]
 
     command_line = (
         libtbx.option_parser.option_parser(
@@ -157,7 +156,7 @@ def run(argv=None):
             dest="overload",
             help="Override the detector overload value (ADU)",
         )
-    ).process(args=argv)
+    ).process(args)
 
     paths = command_line.args
     if len(paths) <= 0:
@@ -356,4 +355,4 @@ def save_image(
 
 
 if __name__ == "__main__":
-    run(sys.argv[1:])
+    run()

--- a/command_line/install_format.py
+++ b/command_line/install_format.py
@@ -79,7 +79,7 @@ setup(
     ).check_returncode()
 
 
-def run():
+def run(args=None):
     parser = optparse.OptionParser(
         usage="dxtbx.install_format (--user | --global) [/path/to/format/class.py] [URL]",
         description=(
@@ -112,7 +112,7 @@ def run():
             "affects all python installations for the current user, files go to ~/.dxtbx)"
         ),
     )
-    options, args = parser.parse_args()
+    options, args = parser.parse_args(args)
 
     if options.glob:
         import libtbx.load_env

--- a/command_line/overload.py
+++ b/command_line/overload.py
@@ -17,7 +17,11 @@ def overload(image_file):
     return False
 
 
-if __name__ == "__main__":
-    for image_file in sys.argv[1:]:
+def run(args=None):
+    for image_file in args or sys.argv[1:]:
         if overload(image_file):
             print(image_file)
+
+
+if __name__ == "__main__":
+    run()

--- a/command_line/overload.py
+++ b/command_line/overload.py
@@ -1,6 +1,4 @@
-from __future__ import absolute_import, division, print_function
-
-import sys
+import argparse
 
 from dxtbx import load
 
@@ -18,7 +16,10 @@ def overload(image_file):
 
 
 def run(args=None):
-    for image_file in args or sys.argv[1:]:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("image_file", nargs="+")
+    options = parser.parse_args(args)
+    for image_file in options.image_file:
         if overload(image_file):
             print(image_file)
 

--- a/command_line/plot_detector_models.py
+++ b/command_line/plot_detector_models.py
@@ -110,7 +110,8 @@ def plot_group(
                 ax.text(vcen[0], vcen[1], vcen[2], "%d" % g.index())
 
 
-def run(args):
+def run(args=None):
+    args = args or sys.argv[1:]
     user_phil = []
     files = []
     for arg in args:
@@ -172,4 +173,4 @@ def run(args):
 
 
 if __name__ == "__main__":
-    run(sys.argv[1:])
+    run()

--- a/command_line/print_header.py
+++ b/command_line/print_header.py
@@ -8,11 +8,11 @@ import dxtbx.format.Registry
 from dxtbx.format.FormatMultiImage import FormatMultiImage
 
 
-def print_header():
+def print_header(args=None):
+    args = args or sys.argv[1:]
     # this will do the lookup for every frame - this is strictly not needed
     # if all frames are from the same instrument
-
-    for arg in sys.argv[1:]:
+    for arg in args:
         print("=== %s ===" % arg)
         format_class = dxtbx.format.Registry.get_format_class_for_file(arg)
         if not format_class:
@@ -52,5 +52,9 @@ def print_header():
                 print("Could not read image data")
 
 
+def run(args=None):
+    print_header(args)
+
+
 if __name__ == "__main__":
-    print_header()
+    run()

--- a/command_line/print_header.py
+++ b/command_line/print_header.py
@@ -1,6 +1,4 @@
-from __future__ import absolute_import, division, print_function
-
-import sys
+import argparse
 
 from scitbx.array_family import flex
 
@@ -8,17 +6,16 @@ import dxtbx.format.Registry
 from dxtbx.format.FormatMultiImage import FormatMultiImage
 
 
-def print_header(args=None):
-    args = args or sys.argv[1:]
+def print_header(filenames):
     # this will do the lookup for every frame - this is strictly not needed
     # if all frames are from the same instrument
-    for arg in args:
-        print("=== %s ===" % arg)
+    for arg in filenames:
+        print(f"=== {arg} ===")
         format_class = dxtbx.format.Registry.get_format_class_for_file(arg)
         if not format_class:
-            print("No format class found that can understand %s" % arg)
+            print(f"No format class found that can understand {arg}")
             continue
-        print("Using header reader: %s" % format_class.__name__)
+        print(f"Using header reader: {format_class.__name__}")
         i = format_class(arg)
         beam = i.get_beam()
         goniometer = i.get_goniometer()
@@ -53,7 +50,10 @@ def print_header(args=None):
 
 
 def run(args=None):
-    print_header(args)
+    parser = argparse.ArgumentParser(description="Print headers for images")
+    parser.add_argument("image_files", nargs="+", metavar="FILE", help="Image files")
+    options = parser.parse_args(args)
+    print_header(options.image_files)
 
 
 if __name__ == "__main__":

--- a/command_line/print_matching_images.py
+++ b/command_line/print_matching_images.py
@@ -1,18 +1,19 @@
-from __future__ import absolute_import, division, print_function
-
-import sys
+import argparse
 
 from dxtbx.sequence_filenames import find_matching_images
 
 
-def print_matching_images(image):
-    matching_images = find_matching_images(image)
-    for mi in matching_images:
-        print(mi)
-
-
 def run(args=None):
-    return print_matching_images(args or sys.argv[1])
+    parser = argparse.ArgumentParser(
+        description="Find images that match a template specification"
+    )
+    parser.add_argument(
+        "template", help="The template specification", metavar="TEMPLATE"
+    )
+    options = parser.parse_args(args)
+
+    for mi in find_matching_images(options.template):
+        print(mi)
 
 
 if __name__ == "__main__":

--- a/command_line/print_matching_images.py
+++ b/command_line/print_matching_images.py
@@ -11,5 +11,9 @@ def print_matching_images(image):
         print(mi)
 
 
+def run(args=None):
+    return print_matching_images(args or sys.argv[1])
+
+
 if __name__ == "__main__":
-    print_matching_images(sys.argv[1])
+    run()

--- a/command_line/radial_average.py
+++ b/command_line/radial_average.py
@@ -92,7 +92,9 @@ master_phil = iotbx.phil.parse(
 )
 
 
-def run(args, imageset=None):
+def run(args=None, imageset=None):
+    args = sys.argv[1:] if args is None else args
+
     # Parse input
     try:
         len(args)
@@ -420,4 +422,4 @@ def run(args, imageset=None):
 
 
 if __name__ == "__main__":
-    run(sys.argv[1:])
+    run()

--- a/command_line/read_sequence.py
+++ b/command_line/read_sequence.py
@@ -28,5 +28,9 @@ def read_sequence(list_of_images):
         print("Reading %d frames took %.2fs" % (len(indices), t1 - t0))
 
 
+def run(args=None):
+    return read_sequence(args or sys.argv[1:])
+
+
 if __name__ == "__main__":
-    read_sequence(sys.argv[1:])
+    run()

--- a/command_line/read_sequence.py
+++ b/command_line/read_sequence.py
@@ -2,17 +2,16 @@
 
 """Tool to benchmark overall time cost for simply reading data"""
 
-from __future__ import absolute_import, division, print_function
-
-import sys
+import argparse
 import time
+from typing import List
 
 from dxtbx.imageset import ImageSetFactory
 
 
-def read_sequence(list_of_images):
+def read_sequence(images: List[str]):
 
-    sequences = ImageSetFactory.new(list_of_images)
+    sequences = ImageSetFactory.new(images)
 
     for sequence in sequences:
         print(sequence.get_detector())
@@ -25,11 +24,16 @@ def read_sequence(list_of_images):
             sequence.get_raw_data(i)
         t1 = time.time()
 
-        print("Reading %d frames took %.2fs" % (len(indices), t1 - t0))
+        print(f"Reading {len(indices)} frames took {t1-t0:.2f}s")
 
 
 def run(args=None):
-    return read_sequence(args or sys.argv[1:])
+    parser = argparse.ArgumentParser(
+        description="Benchmark the time to read a set of images"
+    )
+    parser.add_argument("images", metavar="IMAGE", help="Images to read", nargs="+")
+    options = parser.parse_args(args)
+    return read_sequence(options.images)
 
 
 if __name__ == "__main__":

--- a/command_line/saturation.py
+++ b/command_line/saturation.py
@@ -29,7 +29,12 @@ def saturation(image_file):
         )
 
 
-if __name__ == "__main__":
-    for image_file in sys.argv[1:]:
+def run(args=None):
+    args = args or sys.argv[1:]
+    for image_file in args:
         i, s = saturation(image_file)
         print("%6d %.6f" % (i, s))
+
+
+if __name__ == "__main__":
+    run()

--- a/command_line/saturation.py
+++ b/command_line/saturation.py
@@ -1,6 +1,4 @@
-from __future__ import absolute_import, division, print_function
-
-import sys
+import argparse
 
 from dxtbx import load
 
@@ -30,10 +28,13 @@ def saturation(image_file):
 
 
 def run(args=None):
-    args = args or sys.argv[1:]
-    for image_file in args:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("images", metavar="IMAGE", help="Image files", nargs="+")
+    options = parser.parse_args(args)
+
+    for image_file in options.images:
         i, s = saturation(image_file)
-        print("%6d %.6f" % (i, s))
+        print(f"{i:6d} {s:.6f}")
 
 
 if __name__ == "__main__":

--- a/command_line/show_mask_info.py
+++ b/command_line/show_mask_info.py
@@ -1,15 +1,18 @@
 # LIBTBX_SET_DISPATCHER_NAME dxtbx.show_mask_info
 
+import argparse
 import sys
 
 from dxtbx.model.experiment_list import ExperimentListFactory
 from dxtbx.util import show_mask_info
 
 
-def run(args):
-    filenames = args or sys.argv[1:]
+def run(args=None):
+    parser = argparse.ArgumentParser()
+    parser.add_argument("filenames", metavar="IMAGE", nargs="+")
+    options = parser.parse_args(args)
     try:
-        el = ExperimentListFactory.from_filenames(filenames)
+        el = ExperimentListFactory.from_filenames(options.filenames)
     except FileNotFoundError as e:
         sys.exit(str(e))
 

--- a/command_line/show_mask_info.py
+++ b/command_line/show_mask_info.py
@@ -6,7 +6,8 @@ from dxtbx.model.experiment_list import ExperimentListFactory
 from dxtbx.util import show_mask_info
 
 
-def main(filenames):
+def run(args):
+    filenames = args or sys.argv[1:]
     try:
         el = ExperimentListFactory.from_filenames(filenames)
     except FileNotFoundError as e:
@@ -16,4 +17,4 @@ def main(filenames):
 
 
 if __name__ == "__main__":
-    main(sys.argv[1:])
+    run()

--- a/command_line/show_matching_formats.py
+++ b/command_line/show_matching_formats.py
@@ -27,5 +27,9 @@ def show_matching_formats(files):
             print("File not found.")
 
 
+def run(args=None):
+    show_matching_formats(args or sys.argv[1:])
+
+
 if __name__ == "__main__":
-    show_matching_formats(sys.argv[1:])
+    run()

--- a/command_line/show_matching_formats.py
+++ b/command_line/show_matching_formats.py
@@ -1,7 +1,5 @@
-from __future__ import absolute_import, division, print_function
-
+import argparse
 import os
-import sys
 
 import dxtbx.format.Registry
 
@@ -13,14 +11,14 @@ def recurse(parentformat, filename):
         understood = dxtbx.format.Registry.get_format_class_for(subformat).understand(
             filename
         )
-        print("%s: %s" % (subformat, understood))
+        print(f"{subformat}: {understood}")
         if understood:
             recurse(subformat, filename)
 
 
 def show_matching_formats(files):
     for filename in files:
-        print("\n=== %s ===" % filename)
+        print(f"\n=== {filename} ===")
         if os.path.exists(filename):
             recurse("Format", filename)
         else:
@@ -28,7 +26,10 @@ def show_matching_formats(files):
 
 
 def run(args=None):
-    show_matching_formats(args or sys.argv[1:])
+    parser = argparse.ArgumentParser()
+    parser.add_argument("filenames", metavar="IMAGE", nargs="+")
+    options = parser.parse_args(args)
+    show_matching_formats(options.filenames)
 
 
 if __name__ == "__main__":

--- a/command_line/show_registry.py
+++ b/command_line/show_registry.py
@@ -1,35 +1,29 @@
-from __future__ import absolute_import, division, print_function
+import argparse
 
-import sys
+from dxtbx.format import Registry
 
-import dxtbx.format.Registry
-
-dag = dxtbx.format.Registry.get_format_class_dag()
+dag = Registry.get_format_class_dag()
 
 
-def print_class(class_name, filename=None, depth=1):
-    if filename is None:
-        print("% 5d" % depth, "  " * depth, class_name)
+def print_class(class_name: str, filename: str = None, depth=1):
+    """Print a Format class name if it matches a file"""
+    if filename is None or (
+        Registry.get_format_class_for(class_name).understand(filename)
+    ):
+        print(f"{depth: 5} {'  ' * depth} {class_name}")
     else:
-        format_class = dxtbx.format.Registry.get_format_class_for(class_name)
-        if format_class.understand(filename):
-            print("% 5d" % depth, "  " * depth, class_name)
-        else:
-            return
+        return
+
     for child in dag.get(class_name, []):
         print_class(child, filename, depth + 1)
 
 
-def show_registry(filename=None):
-    if filename is None:
-        extrabit = ""
+def show_registry(filename: str = None):
+    if filename:
+        print(f"Format classes that understand {filename}:")
     else:
-        extrabit = " that understand image %s" % filename
-    print(
-        "Showing hierarchy of classes in the dxtbx registry%s. The root classes are shown with depth of 1, and subclasses are shown indented and with a higher depth number."
-        % extrabit
-    )
-    print()
+        print("Format classes in the dxtbx registry:")
+
     print("Depth  Class name")
     print("    0  Format")
 
@@ -37,8 +31,16 @@ def show_registry(filename=None):
         print_class(class_name, filename)
 
 
+def run(args=None):
+    parser = argparse.ArgumentParser(
+        description="Show hierarchy of dxtbx format classes"
+    )
+    parser.add_argument(
+        "filename", help="Only show classes that understand this file", nargs="?"
+    )
+    opts = parser.parse_args(args)
+    show_registry(opts.filename)
+
+
 if __name__ == "__main__":
-    if len(sys.argv) == 2:
-        show_registry(sys.argv[1])
-    else:
-        show_registry()
+    run()


### PR DESCRIPTION
Similar to dials/dials#1435, this makes the command_line/ scripts all runnable the same way:
- Every script has a run(args=None) method
- Cleaned up show_registry a bit as handling args or None was messy
- Removed Script pattern in detector_superpose
- Added simple `ArgumentParser` handling to many of the scripts that opaquely selected or sliced sys.argv