### PR TITLE
Exercise getting image data out of the NearlyNexus format

### DIFF
--- a/newsfragments/225.misc
+++ b/newsfragments/225.misc
@@ -1,0 +1,1 @@
+Extend FormatHDF5EigerNearlyNexus test to exercise getting image data

--- a/tests/format/test_FormatHDF5EigerNearlyNexus.py
+++ b/tests/format/test_FormatHDF5EigerNearlyNexus.py
@@ -44,6 +44,10 @@ def test_semi_synthetic_dectris_eiger_nearly_nexus(dials_data, tmpdir):
     imageset = expts[0].imageset
     assert imageset.get_format_class() == FormatHDF5EigerNearlyNexus
 
+    image = imageset.get_raw_data(0)[0]
+    assert min(image) == 0
+    assert max(image) == 65535
+
     detector = imageset.get_detector()
     gonio = imageset.get_goniometer()
     scan = imageset.get_scan()


### PR DESCRIPTION
Add a simple check that the image data can be read, which is where CCP4 builds of DIALS have failed in the past.