### PR TITLE
Strip timezone

### DIFF
--- a/newsfragments/235.bugfix
+++ b/newsfragments/235.bugfix
@@ -1,0 +1,1 @@
+dxtbx.dlsnxs2cbf: strip timezone when making CBF file timestamps

--- a/util/dlsnxs2cbf.py
+++ b/util/dlsnxs2cbf.py
@@ -68,7 +68,10 @@ def compute_cbf_header(f, nn=0):
     L = instrument["beam/incident_wavelength"][()]
     A = instrument["attenuator/attenuator_transmission"][()]
 
-    timestamp = f["/entry/start_time"][()].decode()
+    # this timestamp _should_ be in UTC - so can ignore timezone info - at
+    # least for purposes here (causes errors for old versions of dxtbx reading
+    # the data) - 19 chars needed
+    timestamp = f["/entry/start_time"][()].decode()[:19]
     omega = f["/entry/sample/transformations/omega"][()]
     omega_increment = f["/entry/sample/transformations/omega_increment_set"][()]
     chi = f["/entry/sample/transformations/chi"][()]


### PR DESCRIPTION
So just take 1st 19 characters of timestamp; good for another 7980 years or so. 