### PR TITLE
Allow gain set in the SMV header to override guesswork

### DIFF
--- a/format/FormatSMVADSC.py
+++ b/format/FormatSMVADSC.py
@@ -95,6 +95,10 @@ class FormatSMVADSC(FormatSMV):
         # Values may refer to gain in ADU per incident photon rather than the
         # more appropriate ADU per captured photon.
 
+        # Allow gain set in the header to override the guesswork here
+        if "GAIN" in self._header_dictionary:
+            return float(self._header_dictionary["GAIN"])
+
         # Get the binning level
         bin_lev = str(self._header_dictionary.get("BIN"))
 

--- a/newsfragments/242.bugfix
+++ b/newsfragments/242.bugfix
@@ -1,0 +1,1 @@
+SMV Formats: Use explicit gain values in the header if present, rather than guessing


### PR DESCRIPTION
This is based on  pragmatic acceptance that FormatSMVADSC will recognise
more than just ADSC CCD detector images (see #161). Images where GAIN
is set in the header should use this value rather than do the ADSC
module GAIN guesswork.