### PR TITLE
Deprecate DataBlock Dumping

### DIFF
--- a/datablock.py
+++ b/datablock.py
@@ -8,6 +8,7 @@ import logging
 import math
 import operator
 import os.path
+import warnings
 from builtins import range
 from os.path import abspath, dirname, normpath, splitext
 
@@ -634,7 +635,7 @@ class ImageMetadataRecord(object):
         return not self == other
 
 
-def _openingpathiterator(pathnames):
+def _openingpathiterator(pathnames: Iterable[str]):
     """Utility function to efficiently open all paths.
 
     A path is a potential file or directory.
@@ -649,7 +650,6 @@ def _openingpathiterator(pathnames):
     Args:
         pathnames: Paths to attempt to open
     """
-    # type: (Iterable[str])
 
     # Store a tuple of (recurse, pathname) to track what was root level
     paths = collections.deque((True, x) for x in sorted(pathnames))
@@ -1596,6 +1596,11 @@ class DataBlockDumper(object):
             self._datablocks = [datablocks]
         else:
             self._datablocks = datablocks
+        warnings.warn(
+            "dxtbx.datablock.DataBlockDumper is deprecated and will be removed in the next release",
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
     def as_json(self, filename=None, compact=False):
         """Dump datablock as json."""

--- a/newsfragments/247.removal
+++ b/newsfragments/247.removal
@@ -1,0 +1,1 @@
+dxtbx.datablock.DataBlockDumper and dxtbx.serialize.dump are now deprecated and will be removed in the next release

--- a/serialize/dump.py
+++ b/serialize/dump.py
@@ -8,6 +8,12 @@ import warnings
 from dxtbx.datablock import DataBlockDumper
 from dxtbx.serialize.imageset import imageset_to_dict
 
+warnings.warn(
+    "dxtbx.serialize.dump is deprecated and will be removed in the next release",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
 
 def compact_simple_list(match):
     """Callback function. Given a simple list match, compact it and ensure

--- a/tests/test_split_singleimage_datablock.py
+++ b/tests/test_split_singleimage_datablock.py
@@ -34,7 +34,8 @@ def test_split_single_image_datablock(dials_regression, tmpdir):
     assert get_indices(subblock) == [2]
 
     dumped_filename = "split_datablock.json"
-    dump = DataBlockDumper(subblock)
+    with pytest.warns(DeprecationWarning):
+        dump = DataBlockDumper(subblock)
     dump.as_json(dumped_filename)
 
     db = DataBlockFactory.from_json_file(dumped_filename, check_format=True)[0]


### PR DESCRIPTION
As far as I can tell we don't dump datablocks anywhere any more (apart from the one test touched by this commit)

So I think we might be able to remove this?

Suggest adding deprecation notices for now, see how it goes, backport to 3.2.1, and then remove in time for 3.3