### PR TITLE
Remove historic deprecations

### DIFF
--- a/newsfragments/248.removal
+++ b/newsfragments/248.removal
@@ -1,0 +1,1 @@
+remove deprecated dxtbx.serialize.dump.experiment_list, dxtbx.serialize.filename.load_path, and as_str argument to dxtbx.serialize.xds.to_xds().XDS_INP()

--- a/serialize/dump.py
+++ b/serialize/dump.py
@@ -103,14 +103,3 @@ def datablock(obj, outfile, **kwargs):
     """Dump the given object to file."""
     dump = DataBlockDumper(obj)
     dump.as_file(outfile, **kwargs)
-
-
-def experiment_list(obj, outfile):
-    """Dump an experiment list."""
-    warnings.warn(
-        "use .as_file() on the experimentlist directly",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-
-    obj.as_file(outfile)

--- a/serialize/filename.py
+++ b/serialize/filename.py
@@ -1,26 +1,4 @@
-from __future__ import absolute_import, division, print_function
-
 import os
-import warnings
-
-
-def load_path(path, directory=None):
-    """[DEPRECATED: Use resolve_path] Load a filename from a JSON file.
-
-    First expand any environment and user variables. Then create the absolute path
-    from the current directory (i.e. the directory in which the JSON file is
-    located.
-
-    Params:
-      path The path to the file.
-
-    """
-    warnings.warn(
-        "Use dxtbx.filename.resolve_path instead of load_path",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    return resolve_path(path, directory)
 
 
 def resolve_path(path, directory=None):

--- a/serialize/xds.py
+++ b/serialize/xds.py
@@ -1,7 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
-import warnings
-
 from cctbx import uctbx
 from cctbx.eltbx import attenuation_coefficient
 from cctbx.sgtbx import space_group, space_group_symbols
@@ -288,14 +284,7 @@ class to_xds(object):
         real_space_b=None,
         real_space_c=None,
         job_card="XYCORR INIT COLSPOT IDXREF DEFPIX INTEGRATE CORRECT",
-        as_str=None,
     ):
-        if as_str:
-            warnings.warn(
-                "as_str= parameter is deprecated and will be removed in the future",
-                DeprecationWarning,
-                stacklevel=2,
-            )
         result = []
 
         assert [real_space_a, real_space_b, real_space_c].count(None) in (0, 3)

--- a/tests/serialize/test_filename.py
+++ b/tests/serialize/test_filename.py
@@ -1,10 +1,6 @@
-from __future__ import absolute_import, division, print_function
-
 import os
 
-import pytest
-
-from dxtbx.serialize.filename import load_path, resolve_path
+from dxtbx.serialize.filename import resolve_path
 
 
 def test_resolve_path(monkeypatch):
@@ -15,11 +11,3 @@ def test_resolve_path(monkeypatch):
     new_path = os.path.join("$HELLO_WORLD", "path")
     path = resolve_path(new_path)
     assert path == os.path.abspath(os.path.join("EXPANDED", "path"))
-
-
-def test_load_path_deprecated(monkeypatch):
-    monkeypatch.setenv("HELLO_WORLD", "EXPANDED")
-    new_path = os.path.join("~", "$HELLO_WORLD", "path")
-    with pytest.deprecated_call():
-        path = load_path(new_path)
-    assert path == resolve_path(new_path)


### PR DESCRIPTION
* remove `dxtbx.serialize.dump.experiment_list` (deprecated 07/2019)
* remove `dxtbx.serialize.filename.load_path` (deprecated 05/2019)
* remove the `as_str` argument of `dxtbx.serialize.xds.to_xds().XDS_INP()` (deprecated 11/2019)
* left one flake8 warning (unused `import warnings`) to avoid a conflict with #247