### PR TITLE
Use energy in keV for the gain for the ePix and JungFrau detectors at LCLS

### DIFF
--- a/format/FormatXTCEpix.py
+++ b/format/FormatXTCEpix.py
@@ -5,6 +5,7 @@ from builtins import range
 
 import numpy as np
 
+from cctbx import factor_kev_angstrom
 from libtbx.phil import parse
 from scitbx.array_family import flex
 from scitbx.matrix import col
@@ -74,6 +75,8 @@ class FormatXTCEpix(FormatXTC):
             index = 0
         assert len(self.params.detector_address) == 1
 
+        wavelength = self.get_beam(index).get_wavelength()
+
         det = self._get_psana_detector(run)
 
         geom = det.pyda.geoaccess(self._get_event(index).run())
@@ -134,6 +137,7 @@ class FormatXTCEpix(FormatXTC):
                 p.set_pixel_size((pixel_size, pixel_size))
                 p.set_image_size((dim_fast // 2, dim_slow // 2))
                 p.set_trusted_range((-1, 2e6))
+                p.set_gain(factor_kev_angstrom / wavelength)
                 p.set_name(val)
         self._cached_detector[run.run()] = d
         return d

--- a/newsfragments/250.feature
+++ b/newsfragments/250.feature
@@ -1,0 +1,1 @@
+Set the per-shot gain for the ePix and Jungfrau detectors at LCLS.


### PR DESCRIPTION
The pixel values reported by the Jungfrau and ePix detectors are in units of keV.  Because of this, we have been using two settings in dials.stills_process to handle the data:

spotfinding.threshold.gain=9.8
integration.summation.detector_gain=9.8

Here, 9.8 is a surrogate for the average beam energy in keV over the whole run.  The first parameter sets the gain for spotfinding to work and the second parameter is used as a scalar during integration, applied to the intensity variance (see Eq 11 of Leslie 1999).  In Brewster 2019 we showed this made a big difference for handling errors.

Fine and good.  We processed most of the data from the Sept-Oct 2020 LCLS experiments this way.  But doing it this way ignores the shot-to-shot variation in energy. This PR changes FormatXTCJungfrau and FormatXTCEpix to apply the gain up front to each shot.  Then, when get_corrected_data is called, the gain is applied to the pixels [directly](https://github.com/cctbx/dxtbx/blob/master/imageset.h#L691).

With this change, we get these benefits:
- We can drop these parameters from our phil files, which parameters varied depending on the experiment.
-  We get the shot-by-shot variation in pulse energy so the gain will vary from shot to shot.  (Note, the sync_geometry update in dials/dials#1409 was a prerequisite for doing this while also using a reference geometry.)
