### PR TITLE
Fix HDF5 plugin handling

### DIFF
--- a/.azure-pipelines/ci-conda-env.txt
+++ b/.azure-pipelines/ci-conda-env.txt
@@ -10,7 +10,7 @@ conda-forge::eigen
 conda-forge::future
 conda-forge::h5py<3
 conda-forge::hdf5<1.11
-conda-forge::hdf5-external-filter-plugins
+conda-forge::hdf5-external-filter-plugins==0.1.0[build_number='>=5']
 conda-forge::jpeg
 conda-forge::matplotlib-base
 conda-forge::mock

--- a/__init__.py
+++ b/__init__.py
@@ -16,15 +16,18 @@ if sys.version_info.major == 2:
         UserWarning,
     )
 
-plugin_path = libtbx.env.under_base(os.path.join("lib", "plugins"))
-new_plugin_path = libtbx.env.under_base(os.path.join("lib", "hdf5", "plugin"))
-if os.path.exists(plugin_path) and not os.path.exists(new_plugin_path):
+# DeprecationWarning until 2020-11-30, then UserWarning
+# Remove after DIALS 3.3 release branch is made
+_legacy_plugin_path = libtbx.env.under_base(os.path.join("lib", "plugins"))
+_hdf5_plugin_path = libtbx.env.under_base(os.path.join("lib", "hdf5", "plugin"))
+if os.path.exists(_legacy_plugin_path) and not os.path.exists(_hdf5_plugin_path):
     # Set up the plugin path for HDF5 to pick up compression plugins from legacy location
     os.environ["HDF5_PLUGIN_PATH"] = (
-        plugin_path + os.pathsep + os.getenv("HDF5_PLUGIN_PATH", "")
+        _legacy_plugin_path + os.pathsep + os.getenv("HDF5_PLUGIN_PATH", "")
     )
     warnings.warn(
-        "You are using an outdated version of the hdf5-external-filter-plugins package.",
+        "You are using an outdated version of the hdf5-external-filter-plugins package.\n"
+        "Please update your environment using 'conda install hdf5-external-filter-plugins'",
         DeprecationWarning,
     )
 

--- a/__init__.py
+++ b/__init__.py
@@ -16,11 +16,12 @@ if sys.version_info.major == 2:
         UserWarning,
     )
 
-# Set up the plugin path for HDF5 to pick up compression plugins.
-plugin_path = libtbx.env.under_base(os.path.join("lib", "plugins"))
-os.environ["HDF5_PLUGIN_PATH"] = (
-    plugin_path + os.pathsep + os.getenv("HDF5_PLUGIN_PATH", "")
-)
+if not os.getenv("HDF5_PLUGIN_PATH"):
+    # Set up the plugin path for HDF5 to pick up compression plugins.
+    plugin_path = libtbx.env.under_base(os.path.join("lib", "plugins"))
+    os.environ["HDF5_PLUGIN_PATH"] = (
+        plugin_path + os.pathsep + os.getenv("HDF5_PLUGIN_PATH", "")
+    )
 
 logging.getLogger("dxtbx").addHandler(logging.NullHandler())
 

--- a/__init__.py
+++ b/__init__.py
@@ -16,11 +16,16 @@ if sys.version_info.major == 2:
         UserWarning,
     )
 
-if not os.getenv("HDF5_PLUGIN_PATH"):
-    # Set up the plugin path for HDF5 to pick up compression plugins.
-    plugin_path = libtbx.env.under_base(os.path.join("lib", "plugins"))
+plugin_path = libtbx.env.under_base(os.path.join("lib", "plugins"))
+new_plugin_path = libtbx.env.under_base(os.path.join("lib", "hdf5", "plugin"))
+if os.path.exists(plugin_path) and not os.path.exists(new_plugin_path):
+    # Set up the plugin path for HDF5 to pick up compression plugins from legacy location
     os.environ["HDF5_PLUGIN_PATH"] = (
         plugin_path + os.pathsep + os.getenv("HDF5_PLUGIN_PATH", "")
+    )
+    warnings.warn(
+        "You are using an outdated version of the hdf5-external-filter-plugins package.",
+        DeprecationWarning,
     )
 
 logging.getLogger("dxtbx").addHandler(logging.NullHandler())

--- a/newsfragments/258.removal
+++ b/newsfragments/258.removal
@@ -1,0 +1,1 @@
+Deprecate the HDF5 plugin discovery patch that is applied when dxtbx is imported before h5py. Please update your HDF5 plugins package.


### PR DESCRIPTION
Pick up the plugins from their correct location.
Don't override the HDF5 plugin path if one is given in the environment.

Existing installations should update their hdf5-external-filter-plugins package.

Resolves #256