### PR TITLE
drop dxtbx mock dependency

### DIFF
--- a/.azure-pipelines/ci-conda-env.txt
+++ b/.azure-pipelines/ci-conda-env.txt
@@ -13,7 +13,6 @@ conda-forge::hdf5<1.11
 conda-forge::hdf5-external-filter-plugins
 conda-forge::jpeg
 conda-forge::matplotlib-base
-conda-forge::mock
 conda-forge::mrcfile
 conda-forge::numpy>=1.16
 conda-forge::pillow>=5.4.1

--- a/libtbx_config
+++ b/libtbx_config
@@ -2,7 +2,6 @@
     "modules_required_for_use": ["iotbx", "cbflib_adaptbx"],
     "python_required": [
         "dials-data>=2.0.30",
-        "mock>=2.0",
         "procrunner>=1.0.2",
         "pytest>=4.5,<5.0",
     ],

--- a/newsfragments/260.misc
+++ b/newsfragments/260.misc
@@ -1,0 +1,1 @@
+dxtbx tests now use unittest.mock instead of mock

--- a/tests/test_datablock.py
+++ b/tests/test_datablock.py
@@ -1,12 +1,10 @@
-from __future__ import absolute_import, division, print_function
-
 import errno
 import json
 import os
 from collections import namedtuple
 from pprint import pprint
+from unittest import mock
 
-import mock
 import pytest
 import six.moves.cPickle as pickle
 
@@ -25,8 +23,7 @@ def centroid_test_data(dials_regression):
 @pytest.fixture
 def single_sequence_filenames(centroid_test_data):
     filenames = [
-        os.path.join(centroid_test_data, "centroid_000{}.cbf".format(i))
-        for i in range(1, 10)
+        os.path.join(centroid_test_data, f"centroid_000{i}.cbf") for i in range(1, 10)
     ]
     return filenames
 
@@ -34,7 +31,7 @@ def single_sequence_filenames(centroid_test_data):
 @pytest.fixture
 def multiple_sequence_filenames(centroid_test_data):
     filenames = [
-        os.path.join(centroid_test_data, "centroid_000{}.cbf".format(i))
+        os.path.join(centroid_test_data, f"centroid_000{i}.cbf")
         for i in [1, 2, 3, 7, 8, 9]
     ]
     return filenames

--- a/tests/test_filecache_controller.py
+++ b/tests/test_filecache_controller.py
@@ -1,8 +1,6 @@
-# coding: utf-8
-from __future__ import absolute_import, division, print_function
+from unittest.mock import Mock, create_autospec
 
 import pytest
-from mock import Mock, create_autospec
 
 import dxtbx.filecache
 import dxtbx.filecache_controller as fcc


### PR DESCRIPTION
and use the standard library implementation (`unittest.mock`) instead of the `mock` package.

This is independent of the `pytest-mock` PRs going around in parallel