### PR TITLE
Apply static format masks to Lazy ImageSets

### DIFF
--- a/newsfragments/227.bugfix
+++ b/newsfragments/227.bugfix
@@ -1,0 +1,1 @@
+When creating "Lazy" ImageSets the static mask from the image file was not being properly applied


### PR DESCRIPTION
Separating bugfix from #227 by @dwpaley

> Bugfix in FormatMultiImage: If we're creating an ImageSetLazy, we still need to get the static mask from the format class and add it to the imageset.
>
> Co-authored-by: Aaron Brewster <asbrewster@lbl.gov>