### PR TITLE
Enable SWMR-mode reading NeXus files

### DIFF
--- a/format/nexus.py
+++ b/format/nexus.py
@@ -485,7 +485,7 @@ class NXmxReader(object):
     def __init__(self, filename=None, handle=None):
         # Get the file handle
         if filename is not None:
-            handle = h5py.File(filename, "r")
+            handle = h5py.File(filename, "r", swmr=True)
 
         # Find the NXmx entries
         self.entries = []


### PR DESCRIPTION
From limited testing, there doesn't appear to be any performance difference between default and `swmr=True`.

Using master (on a machine with 4 cores):
```
$ time dials.find_spots /dls/i04/data/2020/cm26459-3/xraycentring/manual/xrc_43_master.h5
real	0m36.562s
user	1m24.326s
sys	0m25.553s
```

Using this branch:
```
$ time dials.find_spots /dls/i04/data/2020/cm26459-3/xraycentring/manual/xrc_43_master.h5
real	0m36.870s
user	1m25.365s
sys	0m25.619s
```