### PR TITLE
Add number of images to Scan ostream.

### DIFF
--- a/model/scan.h
+++ b/model/scan.h
@@ -531,6 +531,7 @@ namespace dxtbx { namespace model {
     oscillation[0] = rad_as_deg(oscillation[0]);
     oscillation[1] = rad_as_deg(oscillation[1]);
     os << "Scan:\n";
+    os << "    number of images:   " << s.get_num_images() << "\n";
     os << "    image range:   " << s.get_image_range().const_ref() << "\n";
     os << "    oscillation:   " << oscillation.const_ref() << "\n";
     if (s.num_images_ > 0) {

--- a/newsfragments/271.feature
+++ b/newsfragments/271.feature
@@ -1,0 +1,1 @@
+Show image counts when displaying ``Scan`` objects (e.g. ``dials.show``)


### PR DESCRIPTION
I've often wanted to quickly get the number of images from `dials.show` output, but sometimes this involves mental arithmetic and is not particularly `grep` friendly.

```
Scan:
    image range:   {74,660}
    oscillation:   {0,0.0344}
    exposure time: 0.1
```
It seems to me it would be useful to also have a `number of images` field. This PR adds that:
```
Scan:
    number of images:   587
    image range:   {74,660}
    oscillation:   {0,0.0344}
    exposure time: 0.1
```