### PR TITLE
DataFactory: if VDS don't also include individual external datasets

### DIFF
--- a/format/FormatHDF5EigerNearlyNexus.py
+++ b/format/FormatHDF5EigerNearlyNexus.py
@@ -142,6 +142,7 @@ class EigerNXmxFixer(object):
                 shape=shape,
                 ndim=handle_orig_entry.ndim,
                 filename=handle_orig_entry.file.filename,
+                is_virtual=False,
             )
         for d in delete:
             del handle[d]

--- a/format/nexus.py
+++ b/format/nexus.py
@@ -1351,13 +1351,16 @@ class DataFactory(object):
             if ohk.ndim == 1:
                 continue
 
-            datasets.append(
-                DataSetInformation(
-                    accessor=(lambda obj=obj, key=key: obj.handle[key]),
-                    file=filename,
-                    shape=ohk.shape,
-                )
+            dsi = DataSetInformation(
+                accessor=(lambda obj=obj, key=key: obj.handle[key]),
+                file=filename,
+                shape=ohk.shape,
             )
+            if ohk.is_virtual:
+                datasets = [dsi]
+                break
+            else:
+                datasets.append(dsi)
 
         self._datasets = tuple(datasets)
         self._num_images = 0

--- a/format/nexus.py
+++ b/format/nexus.py
@@ -1314,7 +1314,9 @@ class MultiPanelDataList(object):
         return tuple(all_data)
 
 
-DataFactoryCache = collections.namedtuple("DataFactoryCache", "ndim shape filename")
+DataFactoryCache = collections.namedtuple(
+    "DataFactoryCache", "ndim shape filename is_virtual"
+)
 
 
 class DataFactory(object):

--- a/newsfragments/285.bugfix
+++ b/newsfragments/285.bugfix
@@ -1,0 +1,1 @@
+Fix bug in ``nexus.DataFactory`` that allowed access to twice as many images as available on disk for VDS nexus files.

--- a/tests/format/test_nexus.py
+++ b/tests/format/test_nexus.py
@@ -1,0 +1,17 @@
+import h5py
+import pytest
+
+from dxtbx.format import nexus
+
+
+def test_data_factory_nxs(dials_data):
+    nxs_file = dials_data("vmxi_thaumatin") / "image_15799.nxs"
+    with h5py.File(nxs_file) as fh:
+        data = fh["/entry/data"]
+        data_factory = nexus.DataFactory(nexus.NXdata(data))
+        for i in (0, data["data"].shape[0] - 1):
+            assert data_factory[i].size()
+        # If we try and access an image beyond the size of the dataset it should fail.
+        # See https://github.com/cctbx/dxtbx/issues/285
+        with pytest.raises(IndexError):
+            data_factory[data["data"].shape[0]]


### PR DESCRIPTION
Fix bug in `nexus.DataFactory` that allowed access to twice as many images as available on disk for VDS nexus files.

If the node contains a VDS, then only use this dataset.

Fixes #285