### PR TITLE
re-enable Azure cache

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -20,7 +20,7 @@ jobs:
   - job: setup
     displayName: syntax validation
     pool:
-      vmImage: ubuntu-latest
+      vmImage: ubuntu-20.04
     steps:
       - checkout: none
 
@@ -53,7 +53,7 @@ jobs:
     displayName: flake8 validation
     dependsOn: setup
     pool:
-      vmImage: ubuntu-latest
+      vmImage: ubuntu-20.04
     steps:
       - checkout: none
 

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -21,6 +21,13 @@ jobs:
     displayName: syntax validation
     pool:
       vmImage: ubuntu-20.04
+
+    # Silence a warning. This can be removed in April 2021
+    # https://github.com/microsoft/azure-pipelines-agent/blob/master/docs/design/percentEncoding.md
+    variables:
+    - name: DECODE_PERCENTS
+      value: true
+
     steps:
       - checkout: none
 

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -1,6 +1,6 @@
 variables:
-  CACHE_VERSION: 20201102
-  ENABLE_CACHE: 0
+  CACHE_VERSION: 20210205
+  ENABLE_CACHE: 1
 
 schedules:
   # nightly builds to populate caches

--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -1,7 +1,7 @@
 jobs:
 - job: linux
   pool:
-    vmImage: ubuntu-latest
+    vmImage: ubuntu-20.04
   dependsOn: setup
   condition: eq(variables['ENABLE_CACHE'], '1')
   variables:
@@ -22,7 +22,7 @@ jobs:
 
 - job: linux_uncached
   pool:
-    vmImage: ubuntu-latest
+    vmImage: ubuntu-20.04
   dependsOn: setup
   condition: eq(variables['ENABLE_CACHE'], '0')
   variables:
@@ -40,7 +40,7 @@ jobs:
 
 - job: linux_prebuilt_cctbx
   pool:
-    vmImage: ubuntu-latest
+    vmImage: ubuntu-20.04
   variables:
     PYTHON_VERSION: 3.6
   timeoutInMinutes: 90

--- a/.azure-pipelines/ci-conda-env.txt
+++ b/.azure-pipelines/ci-conda-env.txt
@@ -14,7 +14,7 @@ conda-forge::hdf5-external-filter-plugins==0.1.0[build_number='>=5']
 conda-forge::jpeg
 conda-forge::matplotlib-base
 conda-forge::mrcfile
-conda-forge::numpy>=1.16
+conda-forge::numpy>=1.16,<1.20
 conda-forge::pillow>=5.4.1
 conda-forge::pip
 conda-forge::procrunner>=2.2.0

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -13,4 +13,4 @@ comment:
   layout: "diff, flags"
   branches:
     - master
-  after_n_builds: 2
+  after_n_builds: 6

--- a/newsfragments/300.misc
+++ b/newsfragments/300.misc
@@ -1,0 +1,1 @@
+Re-enable build caches in Azure. Limit numpy to <1.20 in Azure to avoid deprecation warnings


### PR DESCRIPTION
We had those disabled for nearly 3 months in
0a85032
due to an Azure cache integrity bug.

It _looks_ like this is no longer an issue.

This also limits `numpy` to `<1.20` in the dxtbx azure environment to avoid a deprecation warning caused by `h5py`.
