### PR TITLE
Deprecate datablock.*Diff pseudoclasses

### DIFF
--- a/datablock.py
+++ b/datablock.py
@@ -1823,15 +1823,15 @@ class SequenceDiff:
     def __init__(self, tolerance):
         warnings.warn(
             "dxtbx.datablock.SequenceDiff is deprecated. "
-            "Use dxtbx.model.experiment_list.sequence_diff instead",
+            "Use dxtbx.model.compare.sequence_diff instead",
             DeprecationWarning,
             stacklevel=2,
         )
         self._tolerance = tolerance
 
     def __call__(self, sequence1, sequence2):
-        import dxtbx.model.experiment_list  # do not float this import (circular)
+        import dxtbx.model.compare  # do not float this import (circular)
 
-        return dxtbx.model.experiment_list.sequence_diff(
+        return dxtbx.model.compare.sequence_diff(
             sequence1, sequence2, tolerance=self._tolerance
         ).split("\n")

--- a/datablock.py
+++ b/datablock.py
@@ -7,6 +7,7 @@ import math
 import operator
 import os.path
 import pickle
+import warnings
 
 import libtbx
 from scitbx import matrix
@@ -1820,38 +1821,17 @@ class ScanDiff:
 
 class SequenceDiff:
     def __init__(self, tolerance):
-
-        if tolerance is None:
-            self.b_diff = BeamDiff()
-            self.d_diff = DetectorDiff()
-            self.g_diff = GoniometerDiff()
-            self.s_diff = ScanDiff()
-        else:
-            self.b_diff = BeamDiff(
-                wavelength_tolerance=tolerance.beam.wavelength,
-                direction_tolerance=tolerance.beam.direction,
-                polarization_normal_tolerance=tolerance.beam.polarization_normal,
-                polarization_fraction_tolerance=tolerance.beam.polarization_fraction,
-            )
-
-            self.d_diff = DetectorDiff(
-                fast_axis_tolerance=tolerance.detector.fast_axis,
-                slow_axis_tolerance=tolerance.detector.slow_axis,
-                origin_tolerance=tolerance.detector.origin,
-            )
-
-            self.g_diff = GoniometerDiff(
-                rotation_axis_tolerance=tolerance.goniometer.rotation_axis,
-                fixed_rotation_tolerance=tolerance.goniometer.fixed_rotation,
-                setting_rotation_tolerance=tolerance.goniometer.setting_rotation,
-            )
-
-            self.s_diff = ScanDiff(scan_tolerance=tolerance.scan.oscillation)
+        warnings.warn(
+            "dxtbx.datablock.SequenceDiff is deprecated. "
+            "Use dxtbx.model.experiment_list.sequence_diff instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        self._tolerance = tolerance
 
     def __call__(self, sequence1, sequence2):
-        text = []
-        text.extend(self.b_diff(sequence1.get_beam(), sequence2.get_beam()))
-        text.extend(self.d_diff(sequence1.get_detector(), sequence2.get_detector()))
-        text.extend(self.g_diff(sequence1.get_goniometer(), sequence2.get_goniometer()))
-        text.extend(self.s_diff(sequence1.get_scan(), sequence2.get_scan()))
-        return text
+        import dxtbx.model.experiment_list  # do not float this import (circular)
+
+        return dxtbx.model.experiment_list.sequence_diff(
+            sequence1, sequence2, tolerance=self._tolerance
+        ).split("\n")

--- a/datablock.py
+++ b/datablock.py
@@ -3,17 +3,15 @@ import errno
 import itertools
 import json
 import logging
-import math
 import operator
 import os.path
 import pickle
 import warnings
 
 import libtbx
-from scitbx import matrix
 
 import dxtbx.imageset
-import dxtbx.model
+import dxtbx.model.compare
 from dxtbx.format.Format import Format
 from dxtbx.format.FormatMultiImage import FormatMultiImage
 from dxtbx.format.image import ImageBool, ImageDouble
@@ -1656,17 +1654,7 @@ class GoniometerComparison:
         )
 
 
-def _all_equal(a, b):
-    return all(x[0] == x[1] for x in zip(a, b))
-
-
-def _all_approx_equal(a, b, tolerance):
-    return all(abs(x[0] - x[1]) < tolerance for x in zip(a, b))
-
-
 class BeamDiff:
-    """A class to provide simple beam comparison"""
-
     def __init__(
         self,
         wavelength_tolerance=1e-6,
@@ -1674,149 +1662,93 @@ class BeamDiff:
         polarization_normal_tolerance=1e-6,
         polarization_fraction_tolerance=1e-6,
     ):
+        warnings.warn(
+            "dxtbx.datablock.BeamDiff is deprecated. "
+            "Use dxtbx.model.compare.beam_diff instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         self.wavelength_tolerance = wavelength_tolerance
         self.direction_tolerance = direction_tolerance
         self.polarization_normal_tolerance = polarization_normal_tolerance
         self.polarization_fraction_tolerance = polarization_fraction_tolerance
 
     def __call__(self, a, b):
-        aw = a.get_wavelength()
-        bw = b.get_wavelength()
-        ad = matrix.col(a.get_sample_to_source_direction())
-        bd = matrix.col(b.get_sample_to_source_direction())
-        an = matrix.col(a.get_polarization_normal())
-        bn = matrix.col(b.get_polarization_normal())
-        af = a.get_polarization_fraction()
-        bf = b.get_polarization_fraction()
-        text = []
-        if abs(aw - bw) > self.wavelength_tolerance:
-            text.append(f" Wavelength: {aw:f}, {bw:f}")
-        if abs(ad.angle(bd)) > self.direction_tolerance:
-            text.append(" Direction: {}, {}".format(tuple(ad), tuple(bd)))
-        if abs(an.angle(bn)) > self.polarization_normal_tolerance:
-            text.append(" Polarization Normal: {}, {}".format(tuple(an), tuple(bn)))
-        if abs(af - bf) > self.polarization_fraction_tolerance:
-            text.append(f" Polarization Fraction: {af}, {bf}")
-        if len(text) > 0:
-            text = ["Beam:"] + text
-        return text
+        return dxtbx.model.compare.beam_diff(
+            a,
+            b,
+            wavelength_tolerance=self.wavelength_tolerance,
+            direction_tolerance=self.direction_tolerance,
+            polarization_normal_tolerance=self.polarization_normal_tolerance,
+            polarization_fraction_tolerance=self.polarization_fraction_tolerance,
+        ).split("\n")
 
 
 class DetectorDiff:
-    """A class to provide simple detector comparison"""
-
     def __init__(
         self, fast_axis_tolerance=1e-6, slow_axis_tolerance=1e-6, origin_tolerance=1e-6
     ):
-
+        warnings.warn(
+            "dxtbx.datablock.DetectorDiff is deprecated. "
+            "Use dxtbx.model.compare.detector_diff instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         self.fast_axis_tolerance = fast_axis_tolerance
         self.slow_axis_tolerance = slow_axis_tolerance
         self.origin_tolerance = origin_tolerance
 
     def __call__(self, a, b):
-        text = []
-        if len(a) != len(b):
-            text.append("Num Panels: %d, %d" % (len(a), len(b)))
-        for i, (aa, bb) in enumerate(zip(a, b)):
-            a_image_size = aa.get_image_size()
-            b_image_size = bb.get_image_size()
-            a_pixel_size = aa.get_pixel_size()
-            b_pixel_size = bb.get_pixel_size()
-            a_trusted_range = aa.get_trusted_range()
-            b_trusted_range = bb.get_trusted_range()
-            a_fast = aa.get_fast_axis()
-            b_fast = bb.get_fast_axis()
-            a_slow = aa.get_slow_axis()
-            b_slow = bb.get_slow_axis()
-            a_origin = aa.get_origin()
-            b_origin = bb.get_origin()
-            temp_text = []
-            if not _all_equal(a_image_size, b_image_size):
-                temp_text.append(f"  Image size: {a_image_size}, {b_image_size}")
-            if not _all_approx_equal(a_pixel_size, b_pixel_size, 1e-7):
-                temp_text.append(f"  Pixel size: {a_pixel_size}, {b_pixel_size}")
-            if not _all_approx_equal(a_trusted_range, b_trusted_range, 1e-7):
-                temp_text.append(
-                    f"  Trusted Range: {a_trusted_range}, {b_trusted_range}"
-                )
-            if not _all_approx_equal(a_fast, b_fast, self.fast_axis_tolerance):
-                temp_text.append(f"  Fast axis: {a_fast}, {b_fast}")
-            if not _all_approx_equal(a_slow, b_slow, self.slow_axis_tolerance):
-                temp_text.append(f"  Slow axis: {a_slow}, {b_slow}")
-            if not _all_approx_equal(a_origin, b_origin, self.origin_tolerance):
-                temp_text.append(f"  Origin: {a_origin}, {b_origin}")
-            if len(temp_text) > 0:
-                text.append(" panel %d:" % i)
-                text.extend(temp_text)
-        if len(text) > 0:
-            text = ["Detector:"] + text
-        return text
+        return dxtbx.model.compare.detector_diff(
+            a,
+            b,
+            fast_axis_tolerance=self.fast_axis_tolerance,
+            slow_axis_tolerance=self.slow_axis_tolerance,
+            origin_tolerance=self.origin_tolerance,
+        ).split("\n")
 
 
 class GoniometerDiff:
-    """A class to provide simple goniometer comparison"""
-
     def __init__(
         self,
         rotation_axis_tolerance=1e-6,
         fixed_rotation_tolerance=1e-6,
         setting_rotation_tolerance=1e-6,
     ):
+        warnings.warn(
+            "dxtbx.datablock.GoniometerDiff is deprecated. "
+            "Use dxtbx.model.compare.goniometer_diff instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         self.rotation_axis_tolerance = rotation_axis_tolerance
         self.fixed_rotation_tolerance = fixed_rotation_tolerance
         self.setting_rotation_tolerance = setting_rotation_tolerance
 
     def __call__(self, a, b):
-        a_axis = matrix.col(a.get_rotation_axis())
-        b_axis = matrix.col(b.get_rotation_axis())
-        a_fixed = a.get_fixed_rotation()
-        b_fixed = b.get_fixed_rotation()
-        a_setting = a.get_setting_rotation()
-        b_setting = b.get_setting_rotation()
-        text = []
-        if abs(a_axis.angle(b_axis)) > self.rotation_axis_tolerance:
-            text.append(" Rotation axis: {}, {}".format(tuple(a_axis), tuple(b_axis)))
-        if not _all_approx_equal(a_fixed, b_fixed, self.fixed_rotation_tolerance):
-            text.append(f" Fixed rotation: {a_fixed}, {b_fixed}")
-        if not _all_approx_equal(a_setting, b_setting, self.setting_rotation_tolerance):
-            text.append(f" Setting rotation: {a_setting}, {b_setting}")
-        if len(text) > 0:
-            text = ["Goniometer:"] + text
-        return text
+        return dxtbx.model.compare.goniometer_diff(
+            a,
+            b,
+            rotation_axis_tolerance=self.rotation_axis_tolerance,
+            fixed_rotation_tolerance=self.fixed_rotation_tolerance,
+            setting_rotation_tolerance=self.setting_rotation_tolerance,
+        ).split("\n")
 
 
 class ScanDiff:
-    """A class to provide scan comparison"""
-
     def __init__(self, scan_tolerance=0.03):
+        warnings.warn(
+            "dxtbx.datablock.ScanDiff is deprecated. "
+            "Use dxtbx.model.compare.scan_diff instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         self.scan_tolerance = scan_tolerance
 
     def __call__(self, a, b):
-        eps = self.scan_tolerance * abs(a.get_oscillation()[1])
-        a_image_range = a.get_image_range()
-        b_image_range = b.get_image_range()
-        a_oscillation = a.get_oscillation()
-        b_oscillation = b.get_oscillation()
-        a_osc_range = a.get_oscillation_range()
-        b_osc_range = b.get_oscillation_range()
-
-        def mod_2pi(x):
-            return x - 2 * math.pi * math.floor(x / (2 * math.pi))
-
-        diff_2pi = abs(mod_2pi(a_osc_range[1]) - mod_2pi(b_osc_range[0]))
-        diff_abs = abs(a_osc_range[1] - b_osc_range[0])
-        text = []
-        if not (a_image_range[1] + 1 == b_image_range[0]):
-            text.append(f" Incompatible image range: {a_image_range}, {b_image_range}")
-        if abs(a_oscillation[1] - b_oscillation[1]) > eps:
-            text.append(f" Incompatible Oscillation: {a_oscillation}, {b_oscillation}")
-        if min(diff_2pi, diff_abs) > eps * a.get_num_images():
-            text.append(
-                f" Incompatible Oscillation Range: {a_osc_range}, {b_osc_range}"
-            )
-        if len(text) > 0:
-            text = ["Scan:"] + text
-        return text
+        return dxtbx.model.compare.scan_diff(
+            a, b, scan_tolerance=self.scan_tolerance
+        ).split("\n")
 
 
 class SequenceDiff:
@@ -1830,8 +1762,6 @@ class SequenceDiff:
         self._tolerance = tolerance
 
     def __call__(self, sequence1, sequence2):
-        import dxtbx.model.compare  # do not float this import (circular)
-
         return dxtbx.model.compare.sequence_diff(
             sequence1, sequence2, tolerance=self._tolerance
         ).split("\n")

--- a/format/test_cbf_mini_as_file.py
+++ b/format/test_cbf_mini_as_file.py
@@ -9,9 +9,9 @@ from dxtbx.datablock import (
     DataBlockFactory,
     DetectorComparison,
     GoniometerComparison,
-    SequenceDiff,
 )
 from dxtbx.format.FormatCBFMini import FormatCBFMini
+from dxtbx.model.experiment_list import sequence_diff
 
 
 @pytest.mark.parametrize(
@@ -43,8 +43,7 @@ def test_cbf_writer(image_file, dials_regression, run_in_tmpdir):
     d_u_o = pytest.importorskip("dials.util.options")
     tolerance = d_u_o.tolerance_phil_scope.extract().tolerance
 
-    diff = SequenceDiff(tolerance)
-    print("\n".join(diff(imageset, imageset2)))
+    print(sequence_diff(imageset, imageset2, tolerance=tolerance))
 
     assert BeamComparison()(imageset.get_beam(), imageset2.get_beam())
     assert DetectorComparison(origin_tolerance=tolerance.detector.origin)(

--- a/format/test_cbf_mini_as_file.py
+++ b/format/test_cbf_mini_as_file.py
@@ -11,7 +11,7 @@ from dxtbx.datablock import (
     GoniometerComparison,
 )
 from dxtbx.format.FormatCBFMini import FormatCBFMini
-from dxtbx.model.experiment_list import sequence_diff
+from dxtbx.model.compare import sequence_diff
 
 
 @pytest.mark.parametrize(

--- a/model/compare.py
+++ b/model/compare.py
@@ -1,0 +1,34 @@
+from dxtbx.datablock import BeamDiff, DetectorDiff, GoniometerDiff, ScanDiff
+
+
+def sequence_diff(sequence1, sequence2, tolerance=None) -> str:
+    if tolerance:
+        b_diff = BeamDiff(
+            wavelength_tolerance=tolerance.beam.wavelength,
+            direction_tolerance=tolerance.beam.direction,
+            polarization_normal_tolerance=tolerance.beam.polarization_normal,
+            polarization_fraction_tolerance=tolerance.beam.polarization_fraction,
+        )
+        d_diff = DetectorDiff(
+            fast_axis_tolerance=tolerance.detector.fast_axis,
+            slow_axis_tolerance=tolerance.detector.slow_axis,
+            origin_tolerance=tolerance.detector.origin,
+        )
+        g_diff = GoniometerDiff(
+            rotation_axis_tolerance=tolerance.goniometer.rotation_axis,
+            fixed_rotation_tolerance=tolerance.goniometer.fixed_rotation,
+            setting_rotation_tolerance=tolerance.goniometer.setting_rotation,
+        )
+        s_diff = ScanDiff(scan_tolerance=tolerance.scan.oscillation)
+    else:
+        b_diff = BeamDiff()
+        d_diff = DetectorDiff()
+        g_diff = GoniometerDiff()
+        s_diff = ScanDiff()
+
+    return "\n".join(
+        b_diff(sequence1.get_beam(), sequence2.get_beam())
+        + d_diff(sequence1.get_detector(), sequence2.get_detector())
+        + g_diff(sequence1.get_goniometer(), sequence2.get_goniometer())
+        + s_diff(sequence1.get_scan(), sequence2.get_scan())
+    )

--- a/model/compare.py
+++ b/model/compare.py
@@ -1,34 +1,173 @@
-from dxtbx.datablock import BeamDiff, DetectorDiff, GoniometerDiff, ScanDiff
+import functools
+import math
+
+from scitbx import matrix
+
+
+def _all_equal(a, b):
+    return all(x[0] == x[1] for x in zip(a, b))
+
+
+def _all_approx_equal(a, b, tolerance):
+    return all(abs(x[0] - x[1]) < tolerance for x in zip(a, b))
 
 
 def sequence_diff(sequence1, sequence2, tolerance=None) -> str:
+    b_diff = beam_diff
+    d_diff = detector_diff
+    g_diff = goniometer_diff
+    s_diff = scan_diff
     if tolerance:
-        b_diff = BeamDiff(
+        b_diff = functools.partial(
+            b_diff,
             wavelength_tolerance=tolerance.beam.wavelength,
             direction_tolerance=tolerance.beam.direction,
             polarization_normal_tolerance=tolerance.beam.polarization_normal,
             polarization_fraction_tolerance=tolerance.beam.polarization_fraction,
         )
-        d_diff = DetectorDiff(
+        d_diff = functools.partial(
+            d_diff,
             fast_axis_tolerance=tolerance.detector.fast_axis,
             slow_axis_tolerance=tolerance.detector.slow_axis,
             origin_tolerance=tolerance.detector.origin,
         )
-        g_diff = GoniometerDiff(
+        g_diff = functools.partial(
+            g_diff,
             rotation_axis_tolerance=tolerance.goniometer.rotation_axis,
             fixed_rotation_tolerance=tolerance.goniometer.fixed_rotation,
             setting_rotation_tolerance=tolerance.goniometer.setting_rotation,
         )
-        s_diff = ScanDiff(scan_tolerance=tolerance.scan.oscillation)
-    else:
-        b_diff = BeamDiff()
-        d_diff = DetectorDiff()
-        g_diff = GoniometerDiff()
-        s_diff = ScanDiff()
-
-    return "\n".join(
-        b_diff(sequence1.get_beam(), sequence2.get_beam())
-        + d_diff(sequence1.get_detector(), sequence2.get_detector())
-        + g_diff(sequence1.get_goniometer(), sequence2.get_goniometer())
-        + s_diff(sequence1.get_scan(), sequence2.get_scan())
+        s_diff = functools.partial(s_diff, scan_tolerance=tolerance.scan.oscillation)
+    output = (
+        b_diff(sequence1.get_beam(), sequence2.get_beam()),
+        d_diff(sequence1.get_detector(), sequence2.get_detector()),
+        g_diff(sequence1.get_goniometer(), sequence2.get_goniometer()),
+        s_diff(sequence1.get_scan(), sequence2.get_scan()),
     )
+
+    return "\n".join(block for block in output if block)
+
+
+def beam_diff(
+    beam1,
+    beam2,
+    wavelength_tolerance=1e-6,
+    direction_tolerance=1e-6,
+    polarization_normal_tolerance=1e-6,
+    polarization_fraction_tolerance=1e-6,
+) -> str:
+    aw = beam1.get_wavelength()
+    bw = beam2.get_wavelength()
+    ad = matrix.col(beam1.get_sample_to_source_direction())
+    bd = matrix.col(beam2.get_sample_to_source_direction())
+    an = matrix.col(beam1.get_polarization_normal())
+    bn = matrix.col(beam2.get_polarization_normal())
+    af = beam1.get_polarization_fraction()
+    bf = beam2.get_polarization_fraction()
+    text = []
+    if abs(aw - bw) > wavelength_tolerance:
+        text.append(f" Wavelength: {aw:f}, {bw:f}")
+    if abs(ad.angle(bd)) > direction_tolerance:
+        text.append(" Direction: {}, {}".format(tuple(ad), tuple(bd)))
+    if abs(an.angle(bn)) > polarization_normal_tolerance:
+        text.append(" Polarization Normal: {}, {}".format(tuple(an), tuple(bn)))
+    if abs(af - bf) > polarization_fraction_tolerance:
+        text.append(f" Polarization Fraction: {af}, {bf}")
+    if len(text) > 0:
+        text = ["Beam:"] + text
+    return "\n".join(text)
+
+
+def detector_diff(
+    detector1,
+    detector2,
+    fast_axis_tolerance=1e-6,
+    slow_axis_tolerance=1e-6,
+    origin_tolerance=1e-6,
+) -> str:
+    text = []
+    if len(detector1) != len(detector2):
+        text.append("Num Panels: %d, %d" % (len(detector1), len(detector2)))
+    for i, (aa, bb) in enumerate(zip(detector1, detector2)):
+        a_image_size = aa.get_image_size()
+        b_image_size = bb.get_image_size()
+        a_pixel_size = aa.get_pixel_size()
+        b_pixel_size = bb.get_pixel_size()
+        a_trusted_range = aa.get_trusted_range()
+        b_trusted_range = bb.get_trusted_range()
+        a_fast = aa.get_fast_axis()
+        b_fast = bb.get_fast_axis()
+        a_slow = aa.get_slow_axis()
+        b_slow = bb.get_slow_axis()
+        a_origin = aa.get_origin()
+        b_origin = bb.get_origin()
+        temp_text = []
+        if not _all_equal(a_image_size, b_image_size):
+            temp_text.append(f"  Image size: {a_image_size}, {b_image_size}")
+        if not _all_approx_equal(a_pixel_size, b_pixel_size, 1e-7):
+            temp_text.append(f"  Pixel size: {a_pixel_size}, {b_pixel_size}")
+        if not _all_approx_equal(a_trusted_range, b_trusted_range, 1e-7):
+            temp_text.append(f"  Trusted Range: {a_trusted_range}, {b_trusted_range}")
+        if not _all_approx_equal(a_fast, b_fast, fast_axis_tolerance):
+            temp_text.append(f"  Fast axis: {a_fast}, {b_fast}")
+        if not _all_approx_equal(a_slow, b_slow, slow_axis_tolerance):
+            temp_text.append(f"  Slow axis: {a_slow}, {b_slow}")
+        if not _all_approx_equal(a_origin, b_origin, origin_tolerance):
+            temp_text.append(f"  Origin: {a_origin}, {b_origin}")
+        if len(temp_text) > 0:
+            text.append(" panel %d:" % i)
+            text.extend(temp_text)
+    if len(text) > 0:
+        text = ["Detector:"] + text
+    return "\n".join(text)
+
+
+def goniometer_diff(
+    goniometer1,
+    goniometer2,
+    rotation_axis_tolerance=1e-6,
+    fixed_rotation_tolerance=1e-6,
+    setting_rotation_tolerance=1e-6,
+) -> str:
+    a_axis = matrix.col(goniometer1.get_rotation_axis())
+    b_axis = matrix.col(goniometer2.get_rotation_axis())
+    a_fixed = goniometer1.get_fixed_rotation()
+    b_fixed = goniometer2.get_fixed_rotation()
+    a_setting = goniometer1.get_setting_rotation()
+    b_setting = goniometer2.get_setting_rotation()
+    text = []
+    if abs(a_axis.angle(b_axis)) > rotation_axis_tolerance:
+        text.append(" Rotation axis: {}, {}".format(tuple(a_axis), tuple(b_axis)))
+    if not _all_approx_equal(a_fixed, b_fixed, fixed_rotation_tolerance):
+        text.append(f" Fixed rotation: {a_fixed}, {b_fixed}")
+    if not _all_approx_equal(a_setting, b_setting, setting_rotation_tolerance):
+        text.append(f" Setting rotation: {a_setting}, {b_setting}")
+    if len(text) > 0:
+        text = ["Goniometer:"] + text
+    return "\n".join(text)
+
+
+def scan_diff(scan1, scan2, scan_tolerance=0.03) -> str:
+    eps = scan_tolerance * abs(scan1.get_oscillation()[1])
+    a_image_range = scan1.get_image_range()
+    b_image_range = scan2.get_image_range()
+    a_oscillation = scan1.get_oscillation()
+    b_oscillation = scan2.get_oscillation()
+    a_osc_range = scan1.get_oscillation_range()
+    b_osc_range = scan2.get_oscillation_range()
+
+    def mod_2pi(x):
+        return x - 2 * math.pi * math.floor(x / (2 * math.pi))
+
+    diff_2pi = abs(mod_2pi(a_osc_range[1]) - mod_2pi(b_osc_range[0]))
+    diff_abs = abs(a_osc_range[1] - b_osc_range[0])
+    text = []
+    if not (a_image_range[1] + 1 == b_image_range[0]):
+        text.append(f" Incompatible image range: {a_image_range}, {b_image_range}")
+    if abs(a_oscillation[1] - b_oscillation[1]) > eps:
+        text.append(f" Incompatible Oscillation: {a_oscillation}, {b_oscillation}")
+    if min(diff_2pi, diff_abs) > eps * scan1.get_num_images():
+        text.append(f" Incompatible Oscillation Range: {a_osc_range}, {b_osc_range}")
+    if len(text) > 0:
+        text = ["Scan:"] + text
+    return "\n".join(text)

--- a/model/experiment_list.py
+++ b/model/experiment_list.py
@@ -12,14 +12,10 @@ import six.moves.cPickle as pickle
 
 from dxtbx.datablock import (
     BeamComparison,
-    BeamDiff,
     DataBlockFactory,
     DataBlockTemplateImporter,
     DetectorComparison,
-    DetectorDiff,
     GoniometerComparison,
-    GoniometerDiff,
-    ScanDiff,
     SequenceDiff,
 )
 from dxtbx.format.FormatMultiImage import FormatMultiImage
@@ -762,36 +758,3 @@ class ExperimentListTemplateImporter(object):
             self.experiments.extend(
                 ExperimentListFactory.from_datablock_and_crystal(db, None)
             )
-
-
-def sequence_diff(sequence1, sequence2, tolerance=None) -> str:
-    if tolerance:
-        b_diff = BeamDiff(
-            wavelength_tolerance=tolerance.beam.wavelength,
-            direction_tolerance=tolerance.beam.direction,
-            polarization_normal_tolerance=tolerance.beam.polarization_normal,
-            polarization_fraction_tolerance=tolerance.beam.polarization_fraction,
-        )
-        d_diff = DetectorDiff(
-            fast_axis_tolerance=tolerance.detector.fast_axis,
-            slow_axis_tolerance=tolerance.detector.slow_axis,
-            origin_tolerance=tolerance.detector.origin,
-        )
-        g_diff = GoniometerDiff(
-            rotation_axis_tolerance=tolerance.goniometer.rotation_axis,
-            fixed_rotation_tolerance=tolerance.goniometer.fixed_rotation,
-            setting_rotation_tolerance=tolerance.goniometer.setting_rotation,
-        )
-        s_diff = ScanDiff(scan_tolerance=tolerance.scan.oscillation)
-    else:
-        b_diff = BeamDiff()
-        d_diff = DetectorDiff()
-        g_diff = GoniometerDiff()
-        s_diff = ScanDiff()
-
-    return "\n".join(
-        b_diff(sequence1.get_beam(), sequence2.get_beam())
-        + d_diff(sequence1.get_detector(), sequence2.get_detector())
-        + g_diff(sequence1.get_goniometer(), sequence2.get_goniometer())
-        + s_diff(sequence1.get_scan(), sequence2.get_scan())
-    )

--- a/model/experiment_list.py
+++ b/model/experiment_list.py
@@ -12,10 +12,14 @@ import six.moves.cPickle as pickle
 
 from dxtbx.datablock import (
     BeamComparison,
+    BeamDiff,
     DataBlockFactory,
     DataBlockTemplateImporter,
     DetectorComparison,
+    DetectorDiff,
     GoniometerComparison,
+    GoniometerDiff,
+    ScanDiff,
     SequenceDiff,
 )
 from dxtbx.format.FormatMultiImage import FormatMultiImage
@@ -758,3 +762,36 @@ class ExperimentListTemplateImporter(object):
             self.experiments.extend(
                 ExperimentListFactory.from_datablock_and_crystal(db, None)
             )
+
+
+def sequence_diff(sequence1, sequence2, tolerance=None) -> str:
+    if tolerance:
+        b_diff = BeamDiff(
+            wavelength_tolerance=tolerance.beam.wavelength,
+            direction_tolerance=tolerance.beam.direction,
+            polarization_normal_tolerance=tolerance.beam.polarization_normal,
+            polarization_fraction_tolerance=tolerance.beam.polarization_fraction,
+        )
+        d_diff = DetectorDiff(
+            fast_axis_tolerance=tolerance.detector.fast_axis,
+            slow_axis_tolerance=tolerance.detector.slow_axis,
+            origin_tolerance=tolerance.detector.origin,
+        )
+        g_diff = GoniometerDiff(
+            rotation_axis_tolerance=tolerance.goniometer.rotation_axis,
+            fixed_rotation_tolerance=tolerance.goniometer.fixed_rotation,
+            setting_rotation_tolerance=tolerance.goniometer.setting_rotation,
+        )
+        s_diff = ScanDiff(scan_tolerance=tolerance.scan.oscillation)
+    else:
+        b_diff = BeamDiff()
+        d_diff = DetectorDiff()
+        g_diff = GoniometerDiff()
+        s_diff = ScanDiff()
+
+    return "\n".join(
+        b_diff(sequence1.get_beam(), sequence2.get_beam())
+        + d_diff(sequence1.get_detector(), sequence2.get_detector())
+        + g_diff(sequence1.get_goniometer(), sequence2.get_goniometer())
+        + s_diff(sequence1.get_scan(), sequence2.get_scan())
+    )

--- a/newsfragments/302.misc
+++ b/newsfragments/302.misc
@@ -1,1 +1,1 @@
-Deprecate datablock.SequenceDiff in favour of model.experiment_list.sequence_diff()
+Deprecate datablock.SequenceDiff in favour of model.compare.sequence_diff()

--- a/newsfragments/302.misc
+++ b/newsfragments/302.misc
@@ -1,1 +1,1 @@
-Deprecate datablock.SequenceDiff in favour of model.compare.sequence_diff()
+Deprecate datablock.*Diff classes in favour of model.compare.*_diff() functions

--- a/newsfragments/302.misc
+++ b/newsfragments/302.misc
@@ -1,0 +1,1 @@
+Deprecate datablock.SequenceDiff in favour of model.experiment_list.sequence_diff()


### PR DESCRIPTION
`BeamDiff`, `ScanDiff`, `GoniometerDiff`, `DetectorDiff`, `SequenceDiff` in `dxtbx.datablock` are replaced by functions in `dxtbx.model.compare` (`beam_diff`, etc.)

They don't really have anything to do with datablocks or experiment lists.