### PR TITLE
Avoid crashes on Windows when printing unicode

### DIFF
--- a/command_line/debug_memory.py
+++ b/command_line/debug_memory.py
@@ -2,12 +2,13 @@
 
 import argparse
 import resource
-from builtins import range
 
 import dxtbx
+import dxtbx.util
 
 
 def run(args=None):
+    dxtbx.util.encode_output_as_utf8()
     parser = argparse.ArgumentParser(
         description="Test memory usage by repeatedly loading an image"
     )

--- a/command_line/depends_on.py
+++ b/command_line/depends_on.py
@@ -2,6 +2,8 @@ import argparse
 
 import h5py
 
+import dxtbx.util
+
 sample = None
 
 
@@ -70,6 +72,7 @@ def depends_on(in_name):
 
 
 def run(args=None):
+    dxtbx.util.encode_output_as_utf8()
     parser = argparse.ArgumentParser(
         description="Print depends_on hierarchy for Nexus files"
     )

--- a/command_line/detector_superpose.py
+++ b/command_line/detector_superpose.py
@@ -1,8 +1,5 @@
-from __future__ import absolute_import, division, print_function
-
 import math
 import sys
-from builtins import range
 
 from libtbx.phil import parse
 from libtbx.test_utils import approx_equal
@@ -14,6 +11,7 @@ from xfel.command_line.cspad_detector_congruence import iterate_detector_at_leve
 import dials.util
 from dials.util.options import OptionParser
 
+import dxtbx.util
 from dxtbx.model.experiment_list import ExperimentListFactory
 
 help_message = """
@@ -56,6 +54,7 @@ repeat_until_converged = True
 
 @dials.util.show_mail_handle_errors()
 def run(args=None):
+    dxtbx.util.encode_output_as_utf8()
     usage = "usage: dxtbx.detector_superpose reference.json moving.json "
     parser = OptionParser(
         usage=usage,

--- a/command_line/display_parallax_correction.py
+++ b/command_line/display_parallax_correction.py
@@ -1,17 +1,16 @@
-from __future__ import absolute_import, division, print_function
-
 import sys
-from builtins import range
 
 from matplotlib import pylab
 
 from scitbx.array_family import flex
 
+import dxtbx.util
 from dxtbx.datablock import DataBlockFactory
 from dxtbx.model import ParallaxCorrectedPxMmStrategy
 
 
 def run(args=None):
+    dxtbx.util.encode_output_as_utf8()
     datablocks = DataBlockFactory.from_args(args or sys.argv[1:])
     assert len(datablocks) == 1
     detectors = datablocks[0].unique_detectors()

--- a/command_line/dlsnxs2cbf.py
+++ b/command_line/dlsnxs2cbf.py
@@ -4,6 +4,7 @@ import dxtbx.util.dlsnxs2cbf
 
 
 def run(args=None):
+    dxtbx.util.encode_output_as_utf8()
     parser = argparse.ArgumentParser(description="Convert an nxs file to multiple cbfs")
     parser.add_argument("nexus_file", help="Input nexus file")
     parser.add_argument(

--- a/command_line/image2pickle.py
+++ b/command_line/image2pickle.py
@@ -5,12 +5,9 @@ Convert images of any extant format to pickle files suitable for processing with
 cxi.index.  Note, oscillation values are not preserved.
 """
 
-from __future__ import absolute_import, division, print_function
-
 import math
 import os
 import sys
-from builtins import range
 
 import numpy as np
 
@@ -20,7 +17,7 @@ from libtbx.utils import Usage
 from scitbx.array_family import flex
 from xfel.cxi.cspad_ana.cspad_tbx import dpack, evt_timestamp
 
-import dxtbx
+import dxtbx.util
 
 
 def crop_image_pickle(
@@ -68,6 +65,7 @@ def crop_image_pickle(
 
 
 def run(args=None):
+    dxtbx.util.encode_output_as_utf8()
     args = args or sys.argv[1:]
 
     command_line = (

--- a/command_line/image_average.py
+++ b/command_line/image_average.py
@@ -5,11 +5,8 @@
 Average images of any dxtbx-supported format. Handles many individual images or single container files.
 """
 
-from __future__ import absolute_import, division, print_function
-
 import copy
 import sys
-from builtins import range
 
 import numpy as np
 
@@ -19,6 +16,7 @@ from libtbx.utils import Sorry, Usage
 from scitbx.array_family import flex
 
 import dxtbx.format.Registry
+import dxtbx.util
 from dxtbx.datablock import DataBlockFactory
 from dxtbx.format.cbf_writer import FullCBFWriter
 from dxtbx.format.FormatMultiImage import FormatMultiImage
@@ -169,6 +167,7 @@ def run(argv=None):
     """
     if argv is None:
         argv = sys.argv
+    dxtbx.util.encode_output_as_utf8()
     command_line = (
         option_parser.option_parser(
             usage="%s [-v] [-a PATH] [-m PATH] [-s PATH] "

--- a/command_line/install_format.py
+++ b/command_line/install_format.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, division, print_function
-
 import ast
 import optparse
 import os
@@ -8,6 +6,8 @@ import sys
 import procrunner
 import py
 from six.moves.urllib import request
+
+import dxtbx.util
 
 
 def find_format_classes(directory, base_python_path="dxtbx.format"):
@@ -80,6 +80,7 @@ setup(
 
 
 def run(args=None):
+    dxtbx.util.encode_output_as_utf8()
     parser = optparse.OptionParser(
         usage="dxtbx.install_format (--user | --global) [/path/to/format/class.py] [URL]",
         description=(

--- a/command_line/install_format.py
+++ b/command_line/install_format.py
@@ -2,10 +2,10 @@ import ast
 import optparse
 import os
 import sys
+from urllib.request import urlretrieve
 
 import procrunner
 import py
-from six.moves.urllib import request
 
 import dxtbx.util
 
@@ -145,7 +145,7 @@ def run(args=None):
             if local_file.ext != ".py":
                 local_file = local_file.new(basename=local_file.basename + ".py")
             try:
-                request.urlretrieve(fc, local_file.strpath)
+                urlretrieve(fc, local_file.strpath)
             except Exception:
                 local_file = False
             if local_file and local_file.check(file=1):

--- a/command_line/overload.py
+++ b/command_line/overload.py
@@ -1,5 +1,6 @@
 import argparse
 
+import dxtbx.util
 from dxtbx import load
 
 
@@ -16,6 +17,7 @@ def overload(image_file):
 
 
 def run(args=None):
+    dxtbx.util.encode_output_as_utf8()
     parser = argparse.ArgumentParser()
     parser.add_argument("image_file", nargs="+")
     options = parser.parse_args(args)

--- a/command_line/plot_detector_models.py
+++ b/command_line/plot_detector_models.py
@@ -1,5 +1,4 @@
 # LIBTBX_PRE_DISPATCHER_INCLUDE_SH export PHENIX_GUI_ENVIRONMENT=1
-from __future__ import absolute_import, division, print_function
 
 import os
 import sys
@@ -14,6 +13,7 @@ from libtbx.phil import parse
 from libtbx.utils import Sorry
 from scitbx.matrix import col
 
+import dxtbx.util
 from dxtbx.datablock import DataBlockFactory
 from dxtbx.model.detector_helpers import project_2d
 from dxtbx.model.experiment_list import ExperimentListFactory
@@ -139,6 +139,7 @@ def plot_image_plane_projection(detector, color, ax, panel_numbers=True):
 
 
 def run(args=None):
+    dxtbx.util.encode_output_as_utf8()
     args = args or sys.argv[1:]
     user_phil = []
     files = []

--- a/command_line/print_header.py
+++ b/command_line/print_header.py
@@ -3,6 +3,7 @@ import argparse
 from scitbx.array_family import flex
 
 import dxtbx.format.Registry
+import dxtbx.util
 from dxtbx.format.FormatMultiImage import FormatMultiImage
 
 
@@ -50,6 +51,7 @@ def print_header(filenames):
 
 
 def run(args=None):
+    dxtbx.util.encode_output_as_utf8()
     parser = argparse.ArgumentParser(description="Print headers for images")
     parser.add_argument("image_files", nargs="+", metavar="FILE", help="Image files")
     options = parser.parse_args(args)

--- a/command_line/print_matching_images.py
+++ b/command_line/print_matching_images.py
@@ -1,9 +1,11 @@
 import argparse
 
+import dxtbx.util
 from dxtbx.sequence_filenames import find_matching_images
 
 
 def run(args=None):
+    dxtbx.util.encode_output_as_utf8()
     parser = argparse.ArgumentParser(
         description="Find images that match a template specification"
     )

--- a/command_line/radial_average.py
+++ b/command_line/radial_average.py
@@ -1,8 +1,6 @@
 # LIBTBX_SET_DISPATCHER_NAME dxtbx.radial_average
 # LIBTBX_PRE_DISPATCHER_INCLUDE_SH export PHENIX_GUI_ENVIRONMENT=1
 
-from __future__ import absolute_import, division, print_function
-
 import math
 import os
 import sys
@@ -20,6 +18,7 @@ from scitbx.matrix import col
 from xfel import radial_average
 
 import dxtbx.datablock
+import dxtbx.util
 from dxtbx.model.experiment_list import ExperimentListFactory
 
 master_phil = iotbx.phil.parse(
@@ -93,6 +92,7 @@ master_phil = iotbx.phil.parse(
 
 
 def run(args=None, imageset=None):
+    dxtbx.util.encode_output_as_utf8()
     args = sys.argv[1:] if args is None else args
 
     # Parse input

--- a/command_line/read_sequence.py
+++ b/command_line/read_sequence.py
@@ -6,6 +6,7 @@ import argparse
 import time
 from typing import List
 
+import dxtbx.util
 from dxtbx.imageset import ImageSetFactory
 
 
@@ -28,6 +29,7 @@ def read_sequence(images: List[str]):
 
 
 def run(args=None):
+    dxtbx.util.encode_output_as_utf8()
     parser = argparse.ArgumentParser(
         description="Benchmark the time to read a set of images"
     )

--- a/command_line/saturation.py
+++ b/command_line/saturation.py
@@ -1,5 +1,6 @@
 import argparse
 
+import dxtbx.util
 from dxtbx import load
 
 
@@ -28,6 +29,7 @@ def saturation(image_file):
 
 
 def run(args=None):
+    dxtbx.util.encode_output_as_utf8()
     parser = argparse.ArgumentParser()
     parser.add_argument("images", metavar="IMAGE", help="Image files", nargs="+")
     options = parser.parse_args(args)

--- a/command_line/show_mask_info.py
+++ b/command_line/show_mask_info.py
@@ -3,11 +3,12 @@
 import argparse
 import sys
 
+import dxtbx.util
 from dxtbx.model.experiment_list import ExperimentListFactory
-from dxtbx.util import show_mask_info
 
 
 def run(args=None):
+    dxtbx.util.encode_output_as_utf8()
     parser = argparse.ArgumentParser()
     parser.add_argument("filenames", metavar="IMAGE", nargs="+")
     options = parser.parse_args(args)
@@ -16,7 +17,7 @@ def run(args=None):
     except FileNotFoundError as e:
         sys.exit(str(e))
 
-    show_mask_info(el)
+    dxtbx.util.show_mask_info(el)
 
 
 if __name__ == "__main__":

--- a/command_line/show_matching_formats.py
+++ b/command_line/show_matching_formats.py
@@ -2,6 +2,7 @@ import argparse
 import os
 
 import dxtbx.format.Registry
+import dxtbx.util
 
 dag = dxtbx.format.Registry.get_format_class_dag()
 
@@ -26,6 +27,7 @@ def show_matching_formats(files):
 
 
 def run(args=None):
+    dxtbx.util.encode_output_as_utf8()
     parser = argparse.ArgumentParser()
     parser.add_argument("filenames", metavar="IMAGE", nargs="+")
     options = parser.parse_args(args)

--- a/command_line/show_registry.py
+++ b/command_line/show_registry.py
@@ -1,5 +1,6 @@
 import argparse
 
+import dxtbx.util
 from dxtbx.format import Registry
 
 dag = Registry.get_format_class_dag()
@@ -32,6 +33,7 @@ def show_registry(filename: str = None):
 
 
 def run(args=None):
+    dxtbx.util.encode_output_as_utf8()
     parser = argparse.ArgumentParser(
         description="Show hierarchy of dxtbx format classes"
     )

--- a/newsfragments/306.bugfix
+++ b/newsfragments/306.bugfix
@@ -1,0 +1,1 @@
+Fix ``dxtbx.`` commands crashing on Windows when unicode output is directed to a file

--- a/util/__init__.py
+++ b/util/__init__.py
@@ -1,13 +1,27 @@
-from __future__ import absolute_import, division, print_function
-
 import math
+import sys
 from urllib.parse import urlparse
 
-import six
 
-# we want a round function which does the same on Python 2.7 and 3.x
-if six.PY2:
-    from numpy import around as round
+def encode_output_as_utf8() -> None:
+    """
+    Ensures stdout and stderr are UTF-8 encoded.
+    This avoids crashes on Windows when printing unicode where the output is
+    redirected away from the console into a pipe or file
+    """
+    if hasattr(encode_output_as_utf8, "done"):
+        return
+
+    if sys.stdout.encoding.lower() != "utf-8":
+        try:
+            sys.stdout.reconfigure(encoding="utf-8")
+            sys.stderr.reconfigure(encoding="utf-8")
+        except AttributeError:  # Python 3.1-3.6 compatibility
+            import codecs
+
+            sys.stdout = codecs.getwriter("utf-8")(sys.stdout.detach())
+            sys.stderr = codecs.getwriter("utf-8")(sys.stderr.detach())
+    encode_output_as_utf8.done = True
 
 
 def format_float_with_standard_uncertainty(value, standard_uncertainty, minimum=1e-12):


### PR DESCRIPTION
where the output is redirected away from the console into a pipe or file. For this we need to ensure that stdout/stderr are UTF-8 encoded.

Closes DiamondLightSource/python-procrunner#88