### PR TITLE
Fix dxtbx.dlsnxs2cbf help message

### DIFF
--- a/command_line/dlsnxs2cbf.py
+++ b/command_line/dlsnxs2cbf.py
@@ -2,14 +2,13 @@ import argparse
 
 import dxtbx.util.dlsnxs2cbf
 
+parser = argparse.ArgumentParser(description="Convert an nxs file to multiple cbfs")
+parser.add_argument("nexus_file", help="Input nexus file")
+parser.add_argument("template", help="Template cbf output name e.g. 'image_%%04d.cbf'")
+
 
 def run(args=None):
     dxtbx.util.encode_output_as_utf8()
-    parser = argparse.ArgumentParser(description="Convert an nxs file to multiple cbfs")
-    parser.add_argument("nexus_file", help="Input nexus file")
-    parser.add_argument(
-        "template", help="Template cbf output name e.g. 'image_%04d.cbf'"
-    )
     options = parser.parse_args(args)
     dxtbx.util.dlsnxs2cbf.make_cbf(options.nexus_file, options.template)
 

--- a/newsfragments/309.bugfix
+++ b/newsfragments/309.bugfix
@@ -1,0 +1,1 @@
+``dxtbx.dlsnxs2cbf``: Properly display help message when passed ``-h``

--- a/newsfragments/309.doc
+++ b/newsfragments/309.doc
@@ -1,1 +1,0 @@
-The help message that ought to be displayed when calling ``dxtbx.dlsnxs2cbf -h`` was formerly broken and is now fixed.

--- a/newsfragments/309.doc
+++ b/newsfragments/309.doc
@@ -1,0 +1,1 @@
+The help message that ought to be displayed when calling ``dxtbx.dlsnxs2cbf -h`` was formerly broken and is now fixed.

--- a/tests/command_line/test_dlsnxs2cbf.py
+++ b/tests/command_line/test_dlsnxs2cbf.py
@@ -3,6 +3,7 @@ import numpy as np
 import procrunner
 import pytest
 
+from dxtbx.command_line.dlsnxs2cbf import parser
 from dxtbx.format.FormatCBFMiniEigerDLS16MSN160 import FormatCBFMiniEigerDLS16MSN160
 from dxtbx.model.experiment_list import ExperimentListFactory
 
@@ -39,3 +40,12 @@ def test_dlsnxs2cbf(dials_data, tmp_path):
                 fh["/entry/data/data_000001"][i][sel],
                 imgset.get_raw_data(0)[0].as_numpy_array()[sel],
             )
+
+
+def test_dlsnxs2cbf_help():
+    result = procrunner.run(["dxtbx.dlsnxs2cbf", "-h"])
+    assert not result.returncode and not result.stderr
+
+    stdout = str(result.stdout)
+    assert parser.description in stdout
+    assert "Template cbf output name e.g. 'image_%04d.cbf'" in stdout


### PR DESCRIPTION
It seems you should be able to get a help message by calling `dxtbx.dlsnxs2cbf -h`:
```
$ dxtbx.dlsnxs2cbf
usage: dlsnxs2cbf.py [-h] nexus_file template
dlsnxs2cbf.py: error: the following arguments are required: nexus_file, template
```
but instead I get a traceback:
```
$ dxtbx.dlsnxs2cbf -h
Traceback (most recent call last):
  File "/dls_sw/apps/dials/dials-v3-3-3/build/../modules/dxtbx/command_line/dlsnxs2cbf.py", line 17, in <module>
    run()
  File "/dls_sw/apps/dials/dials-v3-3-3/build/../modules/dxtbx/command_line/dlsnxs2cbf.py", line 12, in run
    options = parser.parse_args(args)
  File "/dls_sw/apps/dials/dials-v3-3-3/conda_base/lib/python3.8/argparse.py", line 1768, in parse_args
    args, argv = self.parse_known_args(args, namespace)
  File "/dls_sw/apps/dials/dials-v3-3-3/conda_base/lib/python3.8/argparse.py", line 1800, in parse_known_args
    namespace, args = self._parse_known_args(args, namespace)
  File "/dls_sw/apps/dials/dials-v3-3-3/conda_base/lib/python3.8/argparse.py", line 2006, in _parse_known_args
    start_index = consume_optional(start_index)
  File "/dls_sw/apps/dials/dials-v3-3-3/conda_base/lib/python3.8/argparse.py", line 1946, in consume_optional
    take_action(action, args, option_string)
  File "/dls_sw/apps/dials/dials-v3-3-3/conda_base/lib/python3.8/argparse.py", line 1874, in take_action
    action(self, namespace, argument_values, option_string)
  File "/dls_sw/apps/dials/dials-v3-3-3/conda_base/lib/python3.8/argparse.py", line 1044, in __call__
    parser.print_help()
  File "/dls_sw/apps/dials/dials-v3-3-3/conda_base/lib/python3.8/argparse.py", line 2494, in print_help
    self._print_message(self.format_help(), file)
  File "/dls_sw/apps/dials/dials-v3-3-3/conda_base/lib/python3.8/argparse.py", line 2478, in format_help
    return formatter.format_help()
  File "/dls_sw/apps/dials/dials-v3-3-3/conda_base/lib/python3.8/argparse.py", line 282, in format_help
    help = self._root_section.format_help()
  File "/dls_sw/apps/dials/dials-v3-3-3/conda_base/lib/python3.8/argparse.py", line 213, in format_help
    item_help = join([func(*args) for func, args in self.items])
  File "/dls_sw/apps/dials/dials-v3-3-3/conda_base/lib/python3.8/argparse.py", line 213, in <listcomp>
    item_help = join([func(*args) for func, args in self.items])
  File "/dls_sw/apps/dials/dials-v3-3-3/conda_base/lib/python3.8/argparse.py", line 213, in format_help
    item_help = join([func(*args) for func, args in self.items])
  File "/dls_sw/apps/dials/dials-v3-3-3/conda_base/lib/python3.8/argparse.py", line 213, in <listcomp>
    item_help = join([func(*args) for func, args in self.items])
  File "/dls_sw/apps/dials/dials-v3-3-3/conda_base/lib/python3.8/argparse.py", line 529, in _format_action
    help_text = self._expand_help(action)
  File "/dls_sw/apps/dials/dials-v3-3-3/conda_base/lib/python3.8/argparse.py", line 621, in _expand_help
    return self._get_help_string(action) % params
TypeError: %d format: a number is required, not dict
```

Clearly, some part of `argparse` still uses old-style string formatting, which
means that it tries to substitute something for the `%04d` in the help
message of the `template` argument, which ought to be printed verbatim
when `dxtbx.dlsnxs2cbf -h` is invoked.  Escaping this with `%%04d` is a
temporary workaround and will break if/when `argparse` moves to new-style
string formatting, at which point we should revert to `%04d`.