### PR TITLE
Fix for DLS EIGER 16M name changes

### DIFF
--- a/format/FormatNexusEigerDLS16M.py
+++ b/format/FormatNexusEigerDLS16M.py
@@ -25,15 +25,8 @@ class FormatNexusEigerDLS16M(FormatNexusEigerDLS):
     def understand(image_file):
         # Get the file handle
         with h5py.File(image_file, "r") as handle:
-            name = FormatNexusEigerDLS.get_instrument_name(handle)
-            if name is None:
-                return False
-            if name.upper() in LEGACY_NAMES:
-                return True
-            if name in VALID_NAMES:
-                return True
-
-        return False
+            name = FormatNexusEigerDLS16M.get_instrument_name(handle)
+            return name and name.upper() in VALID_NAMES | LEGACY_NAMES
 
     def has_dynamic_shadowing(self, **kwargs):
         dynamic_shadowing = kwargs.get("dynamic_shadowing", False)

--- a/format/FormatNexusEigerDLS16M.py
+++ b/format/FormatNexusEigerDLS16M.py
@@ -5,19 +5,20 @@ import h5py
 import libtbx
 
 from dxtbx.format.FormatNexusEigerDLS import FormatNexusEigerDLS
+from dxtbx.format.nexus import h5str
 from dxtbx.masking import GoniometerMaskerFactory
 from dxtbx.model import MultiAxisGoniometer
 
 VALID_NAMES = {
     # "long" names
-    b"DIAMOND BEAMLINE I03",
-    b"DIAMOND BEAMLINE I04",
+    "DIAMOND BEAMLINE I03",
+    "DIAMOND BEAMLINE I04",
     # "short" names
-    b"DLS I03",
-    b"DLS I04",
+    "DLS I03",
+    "DLS I04",
 }
 
-LEGACY_NAMES = {b"I03", b"I04"}
+LEGACY_NAMES = {"I03", "I04"}
 
 
 class FormatNexusEigerDLS16M(FormatNexusEigerDLS):
@@ -25,7 +26,7 @@ class FormatNexusEigerDLS16M(FormatNexusEigerDLS):
     def understand(image_file):
         # Get the file handle
         with h5py.File(image_file, "r") as handle:
-            name = FormatNexusEigerDLS16M.get_instrument_name(handle)
+            name = h5str(FormatNexusEigerDLS16M.get_instrument_name(handle))
             return name and name.upper() in VALID_NAMES | LEGACY_NAMES
 
     def has_dynamic_shadowing(self, **kwargs):

--- a/format/FormatNexusEigerDLS16M.py
+++ b/format/FormatNexusEigerDLS16M.py
@@ -9,8 +9,12 @@ from dxtbx.masking import GoniometerMaskerFactory
 from dxtbx.model import MultiAxisGoniometer
 
 VALID_NAMES = {
+    # "long" names
     b"DIAMOND BEAMLINE I03",
     b"DIAMOND BEAMLINE I04",
+    # "short" names
+    b"DLS I03",
+    b"DLS I04",
 }
 
 LEGACY_NAMES = {b"I03", b"I04"}

--- a/newsfragments/xxx.misc
+++ b/newsfragments/xxx.misc
@@ -1,0 +1,1 @@
+Format suport for Eiger 16M XE at Diamond - recognise legacy and updated beamline names.

--- a/tests/format/test_FormatNexusEigerDLS16M.py
+++ b/tests/format/test_FormatNexusEigerDLS16M.py
@@ -219,3 +219,24 @@ def test_understand_legacy(beamline, tmp_path):
         name = instrument.create_dataset("name", data=np.string_(f"{beamline}"))
         name.attrs["short_name"] = np.string_(f"{beamline}")
     assert FormatNexusEigerDLS16M.understand(nxs)
+
+
+def test_do_not_understand_name_none(tmp_path):
+    nxs = tmp_path / "data.nxs"
+    with h5py.File(nxs, mode="w") as fh:
+        entry = fh.create_group("entry")
+        entry.create_group("instrument")
+    assert not FormatNexusEigerDLS16M.understand(nxs)
+
+
+def test_do_not_understand_i24(tmp_path):
+    nxs = tmp_path / "data.nxs"
+    with h5py.File(nxs, mode="w") as fh:
+        entry = fh.create_group("entry")
+        instrument = entry.create_group("instrument")
+        instrument.attrs["short_name"] = np.string_(f"DLS I24")
+        name = instrument.create_dataset(
+            "name", data=np.string_(f"DIAMOND BEAMLINE I24")
+        )
+        name.attrs["short_name"] = np.string_(f"DLS I24")
+    assert not FormatNexusEigerDLS16M.understand(nxs)


### PR DESCRIPTION
The changes introduced in #323 weren't entirely correct, as `get_instrument_name` preferentially returns the `short_name`, which according to [MXGDA-3624](https://jira.diamond.ac.uk/browse/MXGDA-3624) will be e.g. `"DLS I03"` rather than `"DIAMOND BEAMLINE I03"` (the long name):

https://github.com/dials/dxtbx/blob/91bc4631ab1e11ba3c4ea7735408e913977a8253/format/FormatNexus.py#L135-L146

* Add tests for `FormatNexusEigerDLS16M.understand()`
* Simplify `FormatNexusEigerDLS16M.understand()`
* Use `nexus.h5str` to avoid bytestrings