### PR TITLE
Remove useless assert

### DIFF
--- a/boost_python/compression.cc
+++ b/boost_python/compression.cc
@@ -88,7 +88,7 @@ std::vector<char> dxtbx::boost_python::cbf_compress(const int *values,
     packed.push_back(b[0]);
     packed.push_back(b[1]);
 
-    assert((-0x7fffffff <= delta) && (delta < 0x80000000));
+    assert(delta != -0x8000000);
 
     i = delta;
     b = ((union_int *)&i)[0].b;

--- a/newsfragments/352.bugfix
+++ b/newsfragments/352.bugfix
@@ -1,1 +1,1 @@
-CBF compression assertion error: changed assert to be more correct.
+Fix rare error during CBF compression

--- a/newsfragments/352.bugfix
+++ b/newsfragments/352.bugfix
@@ -1,0 +1,1 @@
+CBF compression assertion error: changed assert to be more correct.


### PR DESCRIPTION
This fixes the assertion error raised in the azure build (See #351)

Presumably the comparison is made against a 32 bit signed int as the static value, and 0x80000000 is _not_ a valid signed 32 bit integer value