### PR TITLE
Contiguous NeXus

### DIFF
--- a/format/nexus.py
+++ b/format/nexus.py
@@ -1325,6 +1325,7 @@ class MultiPanelDataList(object):
         data_as_flex = dataset_as_flex(self._datasets[d], tuple(full_slices))
 
         for slices in all_slices:
+            # need to adjust the origin of all the slices
             slices = [slice(0, 1, 1)] + slices[1:]
             subset = data_as_flex[slices]
             subset.reshape(flex.grid(subset.all()[-2:]))
@@ -1500,10 +1501,10 @@ class MaskFactory(object):
             total_slices = []
             for module_slices in all_slices:
                 assert len(dset.shape) in [len(module_slices), len(module_slices) + 1]
-                if len(dset.shape) == len(module_slices):
-                    slices = []  # single image mask
-                else:
+                if len(dset.shape) != len(module_slices):
                     slices = [slice(i, i + 1, 1)]  # multi-image mask
+                else:
+                    slices = []  # single image mask
                 slices.extend(module_slices)
                 total_slices.append(slices)
 


### PR DESCRIPTION
Rewrite of nexus.py to read all panels at once in a multi panel dataset.  Draft PR.

In the recent EuXFEL beam time we were processing data at 2 kHz and we had problems scaling up to many cores so we could keep up with data collection.  After profiling dials.stills_process, we saw that massive amounts of time were spent in dataset_as_flex in nexus.py when using many cores.  This is the function that reads the HDF5 data in C++ directly into flex arrays, bypassing the numpy array.  More specifically, the percentage of time spent in dataset_as_flex increased as the number of MPI cores went up, indicating a problem in scaling up.

We still don't know the source of the scaling problem.  We speculated dataset_as_flex itself might not be optimized, hence this PR, but the changeset here didn't solve the problem on its own.  During the beamtime we solved it by operating on many smaller hdf5 files instead of one big hdf5 file.  This let us keep up with data collection. However, I do think the code here helps.

In nexus.py, for multi-panel data (such as the AGIPD detector which has 256 panels), for each image, a call to dataset_as_flex is made for each panel.  This invokes an HDF5 read for each panel, which may be inefficient as the disc is hit for each panel.  Instead, in this PR I tried reading the data all at once, e.g. all the panels in at the same time in a single HDF5 read, then split the data in memory.

This PR has several problems:

1. It needs more review.  I'm particularly hoping someone can look at the masking code and make sure I didn't break single-panel images :)
2. It relies on the slices comprising data that is contiguous on disc.  There is a [fake assert](https://github.com/cctbx/dxtbx/compare/main...cctbx:contiguous_nexus?expand=1#diff-561673f296e5629bbe2e783ce83757f59f54ffe3bc8151f5767a885f78d58ddeR1323-R1324) in there, but one can imagine code that checks through all the slices, and reverts to old behavior if there are substantial gaps.
3. It's only actually faster if you are using many cores!  Otherwise it's slower!

More on that last point.  Here's an example script to test timing, using the [SwissFEL JF16M dataset](https://doi.org/10.5281/zenodo.3352357), which shares the 256 panel configuration of the AGIPD.

```
import dxtbx
from dials.array_family import flex
img = dxtbx.load('lyso009a_0087.JF07T32V01_master.h5')

for i in range(img.get_num_images()):
  print (i, flex.sum(img.get_raw_data(i)[0]))
```

On master, 1 process: ~13s
On this PR branch, 1 process: ~20s

On master, 64 processes (mpirun libtbx.python script.py): ~1min50s
On this PR branch, 64 processes: ~1min8s

It's a big difference, one that should only get more substantial as the number of cores increases.  Profiling the code in the 1 process case, the added time is spent in splitting the data in memory:
```
for slices in all_slices:
    subset = data[slices]
```
Pretty sure that invokes a copy.  However, I believe that time is made up for when using 64 processes, because less time is spent in I/O.

Ideal solution?  Probably splitting the data in c++ instead of python, hopefully during the read step by using a magic HDF5 command.  I bet there's a way to create a view onto a dataset that gives us what we want so we can get pre-split data reads without need to do any copies.  Research!
