### PR TITLE
remove ExperimentListTemplateImporter

### DIFF
--- a/model/experiment_list.py
+++ b/model/experiment_list.py
@@ -7,7 +7,6 @@ import logging
 import operator
 import os
 import pickle
-import warnings
 
 import pkg_resources
 
@@ -1252,18 +1251,3 @@ def _create_imagesequence(record, format_class, format_kwargs=None):
         # check_format=False,
     )
     return sequence
-
-
-class ExperimentListTemplateImporter:
-    """[DEPRECATED] Import an experiment list from a template.
-
-    To be removed after DIALS v3.5 release branch is made; 3.5 v3.5.0"""
-
-    def __init__(self, templates, **kwargs):
-        warnings.warn(
-            "ExperimentListTemplateImporter is deprecated; Please use ExperimentList.from_templates.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        kwargs.pop("verbose", None)
-        self.experiments = ExperimentListFactory.from_templates(templates, **kwargs)

--- a/newsfragments/333.removal
+++ b/newsfragments/333.removal
@@ -1,0 +1,1 @@
+The previously deprecated ``ExperimentListTemplateImporter`` has been removed. Please use ``ExperimentList.from_templates`` instead.


### PR DESCRIPTION
previously deprecated in #333 (March 2021)