### PR TITLE
Accept a missing χ or φ axis in dlsnxs2cbf

### DIFF
--- a/newsfragments/387.bugfix
+++ b/newsfragments/387.bugfix
@@ -1,0 +1,1 @@
+``dxtbx.dlsnxs2cbf``: Handle missing chi/phi axis entries.

--- a/util/dlsnxs2cbf.py
+++ b/util/dlsnxs2cbf.py
@@ -74,10 +74,8 @@ def compute_cbf_header(f, nn=0):
     timestamp = f["/entry/start_time"][()].decode()[:19]
     omega = f["/entry/sample/transformations/omega"][()]
     omega_increment = f["/entry/sample/transformations/omega_increment_set"][()]
-    chi_key = "/entry/sample/transformations/chi"
-    chi = f[chi_key][()] if chi_key in f else None
-    phi_key = "/entry/sample/transformations/phi"
-    phi = f[phi_key][()] if phi_key in f else None
+    chi = "/entry/sample/transformations/chi"
+    phi = "/entry/sample/transformations/phi"
 
     if "/entry/instrument/detector/beam_centre_x" in f:
         Bx = instrument["detector/beam_centre_x"][()]
@@ -119,13 +117,13 @@ _array_data.header_contents
     result.append("# Polarization 0.990")
     result.append("# Alpha 0.0000 deg.")
     result.append("# Kappa 0.0000 deg.")
-    if phi:
-        result.append(f"# Phi {phi:.4f} deg.")
+    if phi in f:
+        result.append(f"# Phi {f[phi][()]:.4f} deg.")
         result.append("# Phi_increment 0.0000 deg.")
     result.append("# Omega %.4f deg." % omega[nn])
     result.append("# Omega_increment %.4f deg." % omega_increment[nn])
-    if chi:
-        result.append(f"# Chi {chi:.4f} deg.")
+    if chi in f:
+        result.append(f"# Chi {f[chi][()]:.4f} deg.")
         result.append("# Chi_increment 0.0000 deg.")
     result.append("# Oscillation_axis X.CW")
     result.append("# N_oscillations 1")

--- a/util/dlsnxs2cbf.py
+++ b/util/dlsnxs2cbf.py
@@ -74,8 +74,10 @@ def compute_cbf_header(f, nn=0):
     timestamp = f["/entry/start_time"][()].decode()[:19]
     omega = f["/entry/sample/transformations/omega"][()]
     omega_increment = f["/entry/sample/transformations/omega_increment_set"][()]
-    chi = f["/entry/sample/transformations/chi"][()]
-    phi = f["/entry/sample/transformations/phi"][()]
+    chi_key = "/entry/sample/transformations/chi"
+    chi = f[chi_key][()] if chi_key in f else None
+    phi_key = "/entry/sample/transformations/phi"
+    phi = f[phi_key][()] if phi_key in f else None
 
     if "/entry/instrument/detector/beam_centre_x" in f:
         Bx = instrument["detector/beam_centre_x"][()]
@@ -117,12 +119,14 @@ _array_data.header_contents
     result.append("# Polarization 0.990")
     result.append("# Alpha 0.0000 deg.")
     result.append("# Kappa 0.0000 deg.")
-    result.append("# Phi %.4f deg." % phi)
-    result.append("# Phi_increment 0.0000 deg.")
+    if phi:
+        result.append(f"# Phi {phi:.4f} deg.")
+        result.append("# Phi_increment 0.0000 deg.")
     result.append("# Omega %.4f deg." % omega[nn])
     result.append("# Omega_increment %.4f deg." % omega_increment[nn])
-    result.append("# Chi %.4f deg." % chi)
-    result.append("# Chi_increment 0.0000 deg.")
+    if chi:
+        result.append(f"# Chi {chi:.4f} deg.")
+        result.append("# Chi_increment 0.0000 deg.")
     result.append("# Oscillation_axis X.CW")
     result.append("# N_oscillations 1")
     result.append(";")

--- a/util/dlsnxs2cbf.py
+++ b/util/dlsnxs2cbf.py
@@ -118,12 +118,12 @@ _array_data.header_contents
     result.append("# Alpha 0.0000 deg.")
     result.append("# Kappa 0.0000 deg.")
     if phi_key in f:
-        result.append(f"# Phi {f[phi_key][()]:.4f} deg.")
+        result.append(f"# Phi {np.squeeze(f[phi_key][()]):.4f} deg.")
         result.append("# Phi_increment 0.0000 deg.")
     result.append("# Omega %.4f deg." % omega[nn])
     result.append("# Omega_increment %.4f deg." % omega_increment[nn])
     if chi_key in f:
-        result.append(f"# Chi {f[chi_key][()]:.4f} deg.")
+        result.append(f"# Chi {np.squeeze(f[chi_key][()]):.4f} deg.")
         result.append("# Chi_increment 0.0000 deg.")
     result.append("# Oscillation_axis X.CW")
     result.append("# N_oscillations 1")

--- a/util/dlsnxs2cbf.py
+++ b/util/dlsnxs2cbf.py
@@ -74,8 +74,8 @@ def compute_cbf_header(f, nn=0):
     timestamp = f["/entry/start_time"][()].decode()[:19]
     omega = f["/entry/sample/transformations/omega"][()]
     omega_increment = f["/entry/sample/transformations/omega_increment_set"][()]
-    chi = "/entry/sample/transformations/chi"
-    phi = "/entry/sample/transformations/phi"
+    chi_key = "/entry/sample/transformations/chi"
+    phi_key = "/entry/sample/transformations/phi"
 
     if "/entry/instrument/detector/beam_centre_x" in f:
         Bx = instrument["detector/beam_centre_x"][()]
@@ -117,13 +117,13 @@ _array_data.header_contents
     result.append("# Polarization 0.990")
     result.append("# Alpha 0.0000 deg.")
     result.append("# Kappa 0.0000 deg.")
-    if phi in f:
-        result.append(f"# Phi {f[phi][()]:.4f} deg.")
+    if phi_key in f:
+        result.append(f"# Phi {f[phi_key][()]:.4f} deg.")
         result.append("# Phi_increment 0.0000 deg.")
     result.append("# Omega %.4f deg." % omega[nn])
     result.append("# Omega_increment %.4f deg." % omega_increment[nn])
-    if chi in f:
-        result.append(f"# Chi {f[chi][()]:.4f} deg.")
+    if chi_key in f:
+        result.append(f"# Chi {f[chi_key][()]:.4f} deg.")
         result.append("# Chi_increment 0.0000 deg.")
     result.append("# Oscillation_axis X.CW")
     result.append("# N_oscillations 1")


### PR DESCRIPTION
At present, `dlsnxs2cbf` expects the goniometer to have a φ and a χ axis.  Relax that assumption and only add φ and χ details to the CBF header if they are present in the NeXus file.