### PR TITLE
Add Windows build job to Azure CI

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -117,6 +117,17 @@ stages:
       steps:
       - template: unix-build.yml
 
+    - job: windows
+      pool:
+        vmImage: windows-latest
+      strategy:
+        matrix:
+          python37:
+            PYTHON_VERSION: 3.7
+      timeoutInMinutes: 20
+      steps:
+      - template: windows-build.yml
+
     - ${{ if startsWith(variables['Build.SourceBranch'], 'refs/pull/') }}:
       - job: pr
         displayName: ready to merge

--- a/.azure-pipelines/unix-build.yml
+++ b/.azure-pipelines/unix-build.yml
@@ -27,6 +27,7 @@ steps:
   workingDirectory: $(Pipeline.Workspace)
 
 # Download additional source repositories required by cctbx-base (but not dxtbx)
+# cf. https://github.com/conda-forge/cctbx-base-feedstock/issues/12
 - bash: |
     set -eux
     git clone https://github.com/dials/annlib.git modules/annlib
@@ -36,7 +37,7 @@ steps:
 
 # Create a new conda environment using the bootstrap script
 # Extract the dials-data version so we can correctly cache regression data.
-- script: |
+- bash: |
     set -eux
     python3 modules/dxtbx/.azure-pipelines/bootstrap.py base --clean --python $(PYTHON_VERSION)
 
@@ -46,8 +47,7 @@ steps:
 
     dials.data info -v
     echo "##vso[task.setvariable variable=DIALS_DATA_VERSION_FULL]$(dials.data info -v | grep version.full)"
-    echo "##vso[task.setvariable variable=DIALS_DATA_VERSION]$(dials.data info -v | grep version.major)"
-    #                                                                this is a bug in dials-data ^^^^^
+    echo "##vso[task.setvariable variable=DIALS_DATA_VERSION]$(dials.data info -v | grep version.major_minor)"
     mkdir -p data
   displayName: Create python $(PYTHON_VERSION) environment
   workingDirectory: $(Pipeline.Workspace)

--- a/.azure-pipelines/windows-build.yml
+++ b/.azure-pipelines/windows-build.yml
@@ -1,0 +1,73 @@
+# This is work in progress.
+# Currently the windows build only proceeds up to the base installation stage.
+
+# Variables:
+#   CACHE_VERSION: unique cache identifier
+#   CURRENT_WEEK: weekly changing cache identifier
+#   PYTHON_VERSION: string in the form of "3.x"
+#   TODAY_ISO: today's date in ISO format, eg. "20200531"
+
+steps:
+
+# Obtain a shallow clone of the DXTBX repository.
+# DXTBX will not be able to report proper version numbers
+- checkout: self
+  path: ./modules/dxtbx
+  fetchDepth: 1
+  displayName: Checkout $(Build.SourceBranch)
+
+# Download other source repositories
+- bash: |
+    set -eux
+
+    # Extract the version of cctbx-base from the conda environment file
+    [[ "$(cat modules/dxtbx/.azure-pipelines/ci-conda-env.txt)" =~ cctbx-base==([^:space:]+) ]]
+    cctbx_version="$(echo "${BASH_REMATCH[1]}" | xargs)"
+    echo "Using cctbx conda release ${cctbx_version}"
+
+    python3 modules/dxtbx/.azure-pipelines/bootstrap.py update --branch cctbx_project@"v${cctbx_version}"
+  displayName: Repository checkout
+  workingDirectory: $(Pipeline.Workspace)
+
+# Download additional source repositories required by cctbx-base (but not dxtbx)
+# cf. https://github.com/conda-forge/cctbx-base-feedstock/issues/12
+- bash: |
+    set -eux
+    git clone https://github.com/dials/annlib.git modules/annlib
+    git clone https://github.com/dials/annlib_adaptbx.git modules/annlib_adaptbx
+  displayName: Repository checkout (additional cctbx)
+  workingDirectory: $(Pipeline.Workspace)
+
+# Create a new conda environment using the bootstrap script
+- script: |
+    set PYTHONUNBUFFERED=TRUE
+    python3 modules/dxtbx/.azure-pipelines/bootstrap.py base --clean --python $(PYTHON_VERSION)
+  displayName: Create python $(PYTHON_VERSION) environment
+  workingDirectory: $(Pipeline.Workspace)
+
+# Next steps are currently disabled due to
+# https://github.com/conda-forge/cctbx-base-feedstock/issues/28
+#
+#
+## Build dxtbx using the bootstrap script
+#- script: |
+#    pushd "C:\Program Files (x86)\Microsoft Visual Studio\Installer\"
+#    for /f "delims=" %%x in ('.\vswhere.exe -latest -property InstallationPath') do set VSPATH=%%x
+#    popd
+#    call "%VSPATH%\VC\Auxiliary\Build\vcvarsall.bat" x64
+#
+#    python3 modules/dxtbx/.azure-pipelines/bootstrap.py build
+#  displayName: dxtbx build
+#  workingDirectory: $(Pipeline.Workspace)
+#
+## Ensure we are using up-to-date testing packages.
+## Extract the dials-data version so we can correctly cache regression data.
+#- script: |
+#    call conda_base/Scripts/activate
+#    conda install -y dials-data pytest-azurepipelines pytest-timeout
+#    dials.data info -v
+#    echo "##vso[task.setvariable variable=DIALS_DATA_VERSION_FULL]$(dials.data info -v | grep version.full)"
+#    echo "##vso[task.setvariable variable=DIALS_DATA_VERSION]$(dials.data info -v | grep version.major_minor)"
+#    mkdir -p data
+#  displayName: Install additional packages
+#  workingDirectory: $(Pipeline.Workspace)

--- a/newsfragments/396.misc
+++ b/newsfragments/396.misc
@@ -1,0 +1,1 @@
+Add Windows build job to Azure CI that runs up to the 'base' installation stage.


### PR DESCRIPTION
that runs up to the 'base' installation stage, at which point it is blocked by conda-forge/cctbx-base-feedstock#28.

First steps for #396