### PR TITLE
Fix 64-bit integer flumpy bindings on Windows

### DIFF
--- a/SConscript
+++ b/SConscript
@@ -182,13 +182,18 @@ if not env_etc.no_boost_python and hasattr(env_etc, "boost_adaptbx_include"):
         LIBS=env_etc.libs_python + env_etc.libm + env_etc.dxtbx_libs + env["LIBS"],
     )
 
+    flumpy_flags = []
+    # cl.exe treats symbols this way by default
+    if env_etc.compiler != "win32_cl":
+        flumpy_flags = ["-fvisibility=hidden"]
+
     env.SharedLibrary(
         target="#/lib/dxtbx_flumpy",
         source=[
             "src/dxtbx/boost_python/flumpy.cc",
         ],
         LIBS=env_etc.libs_python + env_etc.libm + env_etc.dxtbx_libs + env["LIBS"],
-        CPPFLAGS=["-fvisibility=hidden"],
+        CPPFLAGS=flumpy_flags,
     )
 
     env.SConscript("src/dxtbx/masking/SConscript", exports={"env": env})

--- a/newsfragments/392.bugfix
+++ b/newsfragments/392.bugfix
@@ -1,0 +1,1 @@
+Fix 64-bit integer binding for ``dxtbx.flumpy`` on Windows

--- a/src/dxtbx/boost_python/flumpy.cc
+++ b/src/dxtbx/boost_python/flumpy.cc
@@ -390,8 +390,13 @@ py::object from_numpy(py::object array) {
     if (sizeof(long) == sizeof(long long)) {
       dtype = 'l';
     } else {
+      // flex doesn't bind long long on windows, but does bind 64-bit
+      // integers separately, which we can use for that. Other platforms
+      // don't have this bound as a separate type.
+#ifndef _MSC_VER
       throw std::invalid_argument(
         "Numpy array is type 'q' but long long is unbound by flex");
+#endif
     }
   }
 
@@ -412,7 +417,7 @@ py::object from_numpy(py::object array) {
   } else if (dtype == 'l') {
     return numpy_to_array_family<af::versa<long, af::flex_grid<>>>(np_array);
   } else if (dtype == 'q') {
-    return numpy_to_array_family<af::versa<long long, af::flex_grid<>>>(np_array);
+    return numpy_to_array_family<af::versa<int64_t, af::flex_grid<>>>(np_array);
   } else if (dtype == 'f') {
     return numpy_to_array_family<af::versa<float, af::flex_grid<>>>(np_array);
   } else if (dtype == 'd') {

--- a/tests/test_flumpy.py
+++ b/tests/test_flumpy.py
@@ -16,7 +16,6 @@ lookup_flex_type_to_numpy = {
     "int8": "b",
     "int16": "h",
     "int": "i",
-    "long": "q",
     "int32": "i",
     "int64": "q",
     "float": "f",
@@ -28,6 +27,13 @@ lookup_flex_type_to_numpy = {
     "vec2_double": "d",
     "tiny_size_t_2": "Q",
 }
+
+# On POSIX platforms, long and q are the same and numpy tends to give q's
+# On Windows, defer to numpy long binding directly
+if np.dtype("l").itemsize == np.dtype("q").itemsize:
+    lookup_flex_type_to_numpy["long"] = "q"
+else:
+    lookup_flex_type_to_numpy["long"] = "l"
 
 
 def test_basics():


### PR DESCRIPTION
Flex still doesn't bind `long long` on Windows, but does bind `int64_t` as a separate flex instance. This binds to it.