### PR TITLE
Import flex when loading flumpy

### DIFF
--- a/newsfragments/398.bugfix
+++ b/newsfragments/398.bugfix
@@ -1,0 +1,1 @@
+``dxtbx.flumpy``: Don't fail to convert if scitbx hasn't been imported yet

--- a/src/dxtbx/boost_python/flumpy.cc
+++ b/src/dxtbx/boost_python/flumpy.cc
@@ -523,4 +523,7 @@ PYBIND11_MODULE(dxtbx_flumpy, m) {
         &vecs_from_numpy,
         "Convert a numpy object to a flex.vec2 or .vec3, depending on input array");
   m.def("mat3_from_numpy", &mat3_from_numpy, "Convert a numpy object to a flex.mat3");
+
+  // Make sure that we have imported flex - cannot do boost::python conversions otherwise
+  pybind11::module::import("scitbx.array_family.flex");
 }


### PR DESCRIPTION
This prevents errors when trying to convert to flex arrays, when scitbx
hasn't been loaded yet.

Fixes #398.