### PR TITLE
Allow offline configuration vis libtbx.refresh

### DIFF
--- a/libtbx_refresh.py
+++ b/libtbx_refresh.py
@@ -26,7 +26,16 @@ def _install_dxtbx_setup():
 
     # Call pip
     subprocess.run(
-        [sys.executable, "-m", "pip", "install", "--no-deps", "-e", dxtbx_root_path],
+        [
+            sys.executable,
+            "-m",
+            "pip",
+            "install",
+            "--no-build-isolation",
+            "--no-deps",
+            "-e",
+            dxtbx_root_path,
+        ],
         check=True,
     )
 

--- a/newsfragments/410.bugfix
+++ b/newsfragments/410.bugfix
@@ -1,0 +1,1 @@
+Restore offline-installation behaviour from ``src/`` restructuring


### PR DESCRIPTION
Fixes #410.

`--no-build-isolation` bypasses the PEP-517/PEP-518 system where pip installs the build-time requirements in an isolated environment: see https://pip.pypa.io/en/latest/cli/pip/#pep-517-and-518-support. This was causing network access even with `--no-deps`. Combining `--no-build-isolation` and `--no-deps` appears to avoids triggering my outgoing firewall, and works when network is disconnected.

This appears to fail installation if not all the required base packages are present (e.g. `wheel`), because it cannot go fetch them. But since the `libtbx_refresh` stage will always be run in a managed environment, this restriction should be acceptable.