### PR TITLE
flumpy: Explicitly fail for non-contiguous numpy arrays

### DIFF
--- a/newsfragments/405.bugfix
+++ b/newsfragments/405.bugfix
@@ -1,0 +1,1 @@
+``flumpy``: Fail with an explicit error trying to convert non-contiguous numpy arrays

--- a/src/dxtbx/boost_python/flumpy.cc
+++ b/src/dxtbx/boost_python/flumpy.cc
@@ -369,6 +369,13 @@ py::object from_numpy(py::object array) {
       "Cannot currently convert from non-numpy array format to flex");
   }
   auto np_array = py::array(array);
+
+  // Check that this array is contiguous
+  if (!np_array.attr("flags")["C_CONTIGUOUS"].cast<bool>()) {
+    throw std::invalid_argument(
+      "numpy array is non-contiguous - flex arrays must be contiguous");
+  }
+
   // Now, see if this is a numpy object we created to wrap a flex
   if (np_array.base()) {
     if (py::isinstance<Scuffer>(np_array.base().attr("obj"))) {
@@ -441,6 +448,13 @@ py::object vec_from_numpy(py::array np_array) {
     throw std::invalid_argument("Input array last dimension is not size "
                                 + std::to_string(VecType<int>::fixed_size));
   }
+
+  // Check that this array is contiguous
+  if (!np_array.attr("flags")["C_CONTIGUOUS"].cast<bool>()) {
+    throw std::invalid_argument(
+      "numpy array is non-contiguous - flex arrays must be contiguous");
+  }
+
   auto dtype = np_array.attr("dtype").attr("char").cast<char>();
 
   std::string accepted_types = VecType<int>::fixed_size == 2 ? "dQ" : "di";
@@ -473,6 +487,11 @@ py::object vec_from_numpy(py::array np_array) {
 /// Decide which sized vector we want to convert to, and hand off to the
 /// specialization
 py::object vecs_from_numpy(py::array np_array) {
+  // Check that this array is contiguous
+  if (!np_array.attr("flags")["C_CONTIGUOUS"].cast<bool>()) {
+    throw std::invalid_argument(
+      "numpy array is non-contiguous - flex arrays must be contiguous");
+  }
   if (np_array.shape(np_array.ndim() - 1) == 3) {
     return vec_from_numpy<scitbx::vec3>(np_array);
   } else if (np_array.shape(np_array.ndim() - 1) == 2) {
@@ -483,6 +502,12 @@ py::object vecs_from_numpy(py::array np_array) {
 }
 
 py::object mat3_from_numpy(py::array np_array) {
+  // Check that this array is contiguous
+  if (!np_array.attr("flags")["C_CONTIGUOUS"].cast<bool>()) {
+    throw std::invalid_argument(
+      "numpy array is non-contiguous - flex arrays must be contiguous");
+  }
+
   auto nd = np_array.ndim();
   // Check our last dimension(s) are either x9 or x3x3
   bool last_is_9 = np_array.shape(nd - 1) == 9;

--- a/src/dxtbx/boost_python/flumpy.cc
+++ b/src/dxtbx/boost_python/flumpy.cc
@@ -48,6 +48,13 @@ using grid = af::versa<T, af::flex_grid<>>;
 // void wrap_flex_std_string(); - differently sized per element
 // void wrap_flex_sym_mat3_double(); - nonlinear memory layout
 
+const std::invalid_argument ERR_NON_CONTIGUOUS{
+  "numpy array is non-c-contiguous - flex arrays must be c-contiguous"};
+
+bool is_array_c_contiguous(py::array array) {
+  return array.attr("flags")["C_CONTIGUOUS"].cast<bool>();
+}
+
 template <typename T>
 py::buffer_info get_buffer_specific(grid<T> flex) {
   // Build the strides for each dimension by iterating over the sub-dimensions
@@ -371,9 +378,8 @@ py::object from_numpy(py::object array) {
   auto np_array = py::array(array);
 
   // Check that this array is contiguous
-  if (!np_array.attr("flags")["C_CONTIGUOUS"].cast<bool>()) {
-    throw std::invalid_argument(
-      "numpy array is non-contiguous - flex arrays must be contiguous");
+  if (!is_array_c_contiguous(np_array)) {
+    throw ERR_NON_CONTIGUOUS;
   }
 
   // Now, see if this is a numpy object we created to wrap a flex
@@ -449,12 +455,6 @@ py::object vec_from_numpy(py::array np_array) {
                                 + std::to_string(VecType<int>::fixed_size));
   }
 
-  // Check that this array is contiguous
-  if (!np_array.attr("flags")["C_CONTIGUOUS"].cast<bool>()) {
-    throw std::invalid_argument(
-      "numpy array is non-contiguous - flex arrays must be contiguous");
-  }
-
   auto dtype = np_array.attr("dtype").attr("char").cast<char>();
 
   std::string accepted_types = VecType<int>::fixed_size == 2 ? "dQ" : "di";
@@ -488,10 +488,10 @@ py::object vec_from_numpy(py::array np_array) {
 /// specialization
 py::object vecs_from_numpy(py::array np_array) {
   // Check that this array is contiguous
-  if (!np_array.attr("flags")["C_CONTIGUOUS"].cast<bool>()) {
-    throw std::invalid_argument(
-      "numpy array is non-contiguous - flex arrays must be contiguous");
+  if (!is_array_c_contiguous(np_array)) {
+    throw ERR_NON_CONTIGUOUS;
   }
+
   if (np_array.shape(np_array.ndim() - 1) == 3) {
     return vec_from_numpy<scitbx::vec3>(np_array);
   } else if (np_array.shape(np_array.ndim() - 1) == 2) {
@@ -503,9 +503,8 @@ py::object vecs_from_numpy(py::array np_array) {
 
 py::object mat3_from_numpy(py::array np_array) {
   // Check that this array is contiguous
-  if (!np_array.attr("flags")["C_CONTIGUOUS"].cast<bool>()) {
-    throw std::invalid_argument(
-      "numpy array is non-contiguous - flex arrays must be contiguous");
+  if (!is_array_c_contiguous(np_array)) {
+    throw ERR_NON_CONTIGUOUS;
   }
 
   auto nd = np_array.ndim();

--- a/tests/test_flumpy.py
+++ b/tests/test_flumpy.py
@@ -122,6 +122,11 @@ def test_reverse_numeric_2d(flex_numeric):
     fo[0, 1] = 2
     assert npo[0, 1] == 2
 
+    # Test zero-dimensional arrays
+    npo_zero = np.zeros((0, 3))
+    assert list(flumpy.from_numpy(npo_zero).all()) == [0, 3]
+    assert flumpy.from_numpy(npo_zero).size() == 0
+
 
 def test_numeric_4d(flex_numeric):
     #  Check that we can think fourth-dimnesionally

--- a/tests/test_flumpy.py
+++ b/tests/test_flumpy.py
@@ -311,6 +311,7 @@ def test_numpy_loop_nesting():
 def test_noncontiguous():
     npo = np.zeros((10, 4, 3))
     flumpy.from_numpy(npo)
+
     with pytest.raises(ValueError):
         flumpy.from_numpy(npo[:, 1:])
 
@@ -319,3 +320,15 @@ def test_noncontiguous():
 
     with pytest.raises(ValueError):
         flumpy.mat3_from_numpy(npo[:, 1:])
+
+    # Test fortran order
+    npo_f = np.zeros((10, 4, 3), order="F")
+
+    with pytest.raises(ValueError):
+        flumpy.from_numpy(npo_f)
+
+    with pytest.raises(ValueError):
+        flumpy.vec_from_numpy(npo_f)
+
+    with pytest.raises(ValueError):
+        flumpy.mat3_from_numpy(npo_f)

--- a/tests/test_flumpy.py
+++ b/tests/test_flumpy.py
@@ -306,3 +306,16 @@ def test_numpy_loop_nesting():
     fo = flumpy.from_numpy(no)
     no_2 = flumpy.to_numpy(fo)
     assert no_2 is no
+
+
+def test_noncontiguous():
+    npo = np.zeros((10, 4, 3))
+    flumpy.from_numpy(npo)
+    with pytest.raises(ValueError):
+        flumpy.from_numpy(npo[:, 1:])
+
+    with pytest.raises(ValueError):
+        flumpy.vec_from_numpy(npo[:, 1:])
+
+    with pytest.raises(ValueError):
+        flumpy.mat3_from_numpy(npo[:, 1:])


### PR DESCRIPTION
As per https://github.com/cctbx/dxtbx/issues/405, passing non-contiguous arrays into flumpy comes up with an obscure and unhelpful exception:
```
>>> flumpy.from_numpy(np.zeros((256,256,256))[0:1,1:255,1:255])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'numpy.ndarray' object has no attribute 'obj'
```

Unfortunately, there seems to be no way to use the scitbx flex array bindings in a way that allows this conversion, so with this patch it is explicitly failed with a more helpful message:
```
>>> flumpy.from_numpy(np.zeros((256,256,256))[0:1,1:255,1:255])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ValueError: numpy array is non-contiguous - flex arrays must be contiguous
```