### PR TITLE
flumpy: Fix conversion of non-owning arrays

### DIFF
--- a/newsfragments/406.bugfix
+++ b/newsfragments/406.bugfix
@@ -1,0 +1,1 @@
+``flumpy``: Fix conversion of arrays that don't own their own data

--- a/src/dxtbx/boost_python/flumpy.cc
+++ b/src/dxtbx/boost_python/flumpy.cc
@@ -377,6 +377,11 @@ py::object from_numpy(py::object array) {
   }
   auto np_array = py::array(array);
 
+  // Check that this array is contiguous
+  if (!is_array_c_contiguous(np_array)) {
+    throw ERR_NON_CONTIGUOUS;
+  }
+
   // If this was directly converted from a flex array, give back the original
   // object; In any other case we want to wrap, because of slicing/metadata
   if (np_array.base()) {
@@ -387,11 +392,6 @@ py::object from_numpy(py::object array) {
         return scuffer.base();
       }
     }
-  }
-
-  // Check that this array is contiguous
-  if (!is_array_c_contiguous(np_array)) {
-    throw ERR_NON_CONTIGUOUS;
   }
 
   // Check that we recognise this type

--- a/src/dxtbx/boost_python/flumpy.cc
+++ b/src/dxtbx/boost_python/flumpy.cc
@@ -369,12 +369,16 @@ py::object from_numpy(py::object array) {
       "Cannot currently convert from non-numpy array format to flex");
   }
   auto np_array = py::array(array);
-  // Now, see if this is a numpy object we created to wrap a flex
+
+  // If this was directly converted from a flex array, give back the original object
+  // in any other case we want to wrap, because of slicing/metadata
   if (np_array.base()) {
-    if (py::isinstance<Scuffer>(np_array.base().attr("obj"))) {
-      // Ah, this came from flex originally
-      auto scuffer = np_array.base().attr("obj").cast<Scuffer &>();
-      return scuffer.base();
+    if (py::isinstance<py::memoryview>(np_array.base())) {
+      if (py::isinstance<Scuffer>(np_array.base().attr("obj"))) {
+        // Ah, this came from flex originally
+        auto scuffer = np_array.base().attr("obj").cast<Scuffer &>();
+        return scuffer.base();
+      }
     }
   }
 

--- a/src/dxtbx/boost_python/flumpy.cc
+++ b/src/dxtbx/boost_python/flumpy.cc
@@ -377,8 +377,8 @@ py::object from_numpy(py::object array) {
   }
   auto np_array = py::array(array);
 
-  // If this was directly converted from a flex array, give back the original object
-  // in any other case we want to wrap, because of slicing/metadata
+  // If this was directly converted from a flex array, give back the original
+  // object; In any other case we want to wrap, because of slicing/metadata
   if (np_array.base()) {
     if (py::isinstance<py::memoryview>(np_array.base())) {
       if (py::isinstance<Scuffer>(np_array.base().attr("obj"))) {

--- a/tests/test_flumpy.py
+++ b/tests/test_flumpy.py
@@ -306,3 +306,14 @@ def test_numpy_loop_nesting():
     fo = flumpy.from_numpy(no)
     no_2 = flumpy.to_numpy(fo)
     assert no_2 is no
+
+
+def test_nonowning():
+    f_a = flex.double([0, 1, 2, 3, 4])
+    n_b = flumpy.to_numpy(f_a)
+    f_c = flumpy.from_numpy(n_b[1:])
+    assert f_c[0] == 1
+    f_c[1] = 9
+    assert f_a[2] == 9
+    assert n_b[2] == 9
+    assert f_c[1] == 9


### PR DESCRIPTION
This could happen in cases where you are converting e.g. a contiguous slice of your original array - flumpy previously needlessly (and erroneously) assumed that if an array didn't own it's own data, that the array base came from flex.

Fixes #406

```
>>> data = numpy.zeros(100)
>>> flumpy.from_numpy(data[:])
<scitbx_array_family_flex_ext.double object at 0x7fe025c7abc0>
```