### PR TITLE
`flumpy`: More comprehensively handle type conversions

### DIFF
--- a/newsfragments/415.bugfix
+++ b/newsfragments/415.bugfix
@@ -1,0 +1,1 @@
+``flumpy``: Fix occasionaly issue matching 64-bit integer types

--- a/src/dxtbx/boost_python/flumpy.cc
+++ b/src/dxtbx/boost_python/flumpy.cc
@@ -392,7 +392,7 @@ py::object from_numpy(py::object array) {
   }
 
   // Check that we recognise this type
-  std::string known_types = "BHIQLbhilqdDf?";
+  std::string known_types = "BHILQbhilqdDf?";
   auto dtype_obj = np_array.attr("dtype");
   auto dtype = dtype_obj.attr("char").cast<char>();
   if (known_types.find(dtype) == std::string::npos) {


### PR DESCRIPTION
Previously, types were manually mapped between numpy [types](https://numpy.org/doc/stable/reference/arrays.scalars.html) and the types bound by flex. However, this caused several issues to do with cross-platform behaviour e.g. differences between when numpy gives you `q` and `l` types, and windows/linux differences in type sizing; see e.g. #415, #392.

This changes flumpy to map binded integer types directly (bool, int, long), and all other integer types are matched by signed/unsigned and integer width. This should eliminate this class of problems.