### PR TITLE
Graceful fail

### DIFF
--- a/src/dxtbx/model/experiment_list.py
+++ b/src/dxtbx/model/experiment_list.py
@@ -846,7 +846,10 @@ class ExperimentListFactory:
                     f"Image file {filenames[0]} appears to be a '{type(format_class).__name__}', but this is an abstract Format"
                 )
             else:
-                index = slice(*template_string_number_index(template))
+                if "#" in template:
+                    index = slice(*template_string_number_index(template))
+                else:  # there is just one file
+                    index = 0
                 image_range = kwargs.get("image_range")
                 if image_range:
                     first, last = image_range

--- a/src/dxtbx/model/experiment_list.py
+++ b/src/dxtbx/model/experiment_list.py
@@ -846,29 +846,32 @@ class ExperimentListFactory:
                     f"Image file {filenames[0]} appears to be a '{type(format_class).__name__}', but this is an abstract Format"
                 )
             else:
-                if "#" in template:
-                    index = slice(*template_string_number_index(template))
-                else:  # there is just one file
-                    index = 0
+                index = slice(*template_string_number_index(template))
+
                 image_range = kwargs.get("image_range")
                 if image_range:
                     first, last = image_range
                 else:
-                    first = int(filenames[0][index])
-                    last = int(filenames[-1][index])
+                    first, last = template_image_range(template)
 
-                # Check all images in range are present - if allowed
                 if not kwargs.get("allow_incomplete_sequences", False):
-                    all_numbers = {int(f[index]) for f in filenames}
-                    missing = set(range(first, last + 1)) - all_numbers
-                    if missing:
-                        raise ValueError(
-                            "Missing image{} {} from imageset ({}-{})".format(
-                                "s" if len(missing) > 1 else "",
-                                ", ".join(str(x) for x in sorted(missing)),
-                                first,
-                                last,
+                    if "#" in template:
+                        # Check all images in range are present - if allowed
+                        all_numbers = {int(f[index]) for f in filenames}
+                        missing = set(range(first, last + 1)) - all_numbers
+                        if missing:
+                            raise ValueError(
+                                "Missing image{} {} from imageset ({}-{})".format(
+                                    "s" if len(missing) > 1 else "",
+                                    ", ".join(str(x) for x in sorted(missing)),
+                                    first,
+                                    last,
+                                )
                             )
+                    else:
+                        print(
+                            "Using only one template file: %s. \n "
+                            "`allow_incomplete_sequence` has no effect" % template
                         )
 
                 # Read the image

--- a/src/dxtbx/sequence_filenames.py
+++ b/src/dxtbx/sequence_filenames.py
@@ -179,9 +179,12 @@ def replace_template_format_with_hash(match):
 
 def template_string_to_glob_expr(template):
     """Convert the template to a glob expression."""
-    pfx = template.split("#")[0]
-    sfx = template.split("#")[-1]
-    return "%s%s%s" % (pfx, "[0-9]" * template.count("#"), sfx)
+    if "#" in template:
+        pfx = template.split("#")[0]
+        sfx = template.split("#")[-1]
+        return "%s%s%s" % (pfx, "[0-9]" * template.count("#"), sfx)
+    else:
+        return "%s" % (template)
 
 
 def template_string_number_index(template):

--- a/src/dxtbx/sequence_filenames.py
+++ b/src/dxtbx/sequence_filenames.py
@@ -179,12 +179,7 @@ def replace_template_format_with_hash(match):
 
 def template_string_to_glob_expr(template):
     """Convert the template to a glob expression."""
-    if "#" in template:
-        pfx = template.split("#")[0]
-        sfx = template.split("#")[-1]
-        return "%s%s%s" % (pfx, "[0-9]" * template.count("#"), sfx)
-    else:
-        return "%s" % (template)
+    return template.replace("#", "[0-9]")
 
 
 def template_string_number_index(template):

--- a/src/dxtbx/sequence_filenames.py
+++ b/src/dxtbx/sequence_filenames.py
@@ -183,9 +183,8 @@ def template_string_to_glob_expr(template):
 
 
 def template_string_number_index(template):
-    """Get the number idex of the template."""
-    pfx = template.split("#")[0]
-    return len(pfx), len(pfx) + template.count("#")
+    """Get the index slice ends for `##...#` in the template."""
+    return template.find("#"), template.rfind("#") + 1
 
 
 def locate_files_matching_template_string(template):
@@ -208,8 +207,11 @@ def template_image_range(template):
     index = slice(*template_string_number_index(template))
 
     # Get the first and last indices
-    first = int(filenames[0][index])
-    last = int(filenames[-1][index])
+    if "#" in template:
+        first = int(filenames[0][index])
+        last = int(filenames[-1][index])
+    else:  # template is one file
+        first, last = 0, 0
 
     # Return the image range
     return (first, last)


### PR DESCRIPTION
A way for `template_image_range` to deal with template having no `#`, ie. setting range limits to 0. 
Avoid using the notion of index in this case by not doing what would be a redundant check.