### PR TITLE
Timezone fix for FormatSMVADSCSN442

### DIFF
--- a/newsfragments/XXX.bugfix
+++ b/newsfragments/XXX.bugfix
@@ -1,0 +1,1 @@
+Better support for detector SMV ADSC SN442

--- a/src/dxtbx/format/FormatSMVADSCSN442.py
+++ b/src/dxtbx/format/FormatSMVADSCSN442.py
@@ -38,7 +38,15 @@ class FormatSMVADSCSN442(FormatSMVADSCSN):
             tm = time.strptime(date_str, format_string)
         except ValueError:
             format_string = "%a %b %d %H:%M:%S %Z %Y"
-            tm = time.strptime(date_str, format_string)
+            try:
+                tm = time.strptime(date_str, format_string)
+            except ValueError:
+                # Can happen if the time zone isn't matched by strptime,
+                # for example if running in EST but image header is PST.
+                # Try to drop out the time zone
+                format_string = "%a %b %d %H:%M:%S %Y"
+                date_str = " ".join(date_str.split()[0:4] + date_str.split()[5:6])
+                tm = time.strptime(date_str, format_string)
 
         als831 = True
         if tm.tm_year > 2006 or (tm.tm_year == 2006 and tm.tm_yday >= 134):


### PR DESCRIPTION
If the image header includes the timezone PST, but the computer is in EST, time.strptime will fail. Solve by trying to drop out the time zone.

See https://docs.python.org/3/library/datetime.html#strftime-and-strptime-behavior (look for the %Z section)

Found by a test in labelit_regression that is failing on a new Azure pipeline (presumably in an unknown timezone) but not on local PST computers.

Minimal reproducer:

```
import time
a = 'Tue Nov 20 16:42:16 DOG 2007'
b = '%a %b %d %H:%M:%S %Z %Y'
assert time.strptime(a, b)
```

Change DOG to your timezone (or `time.tzname[0]`) and the reproducer will pass.