### PR TITLE
Fix problems with image pedestal in FormatSMVJHSim

### DIFF
--- a/newsfragments/456.bugfix
+++ b/newsfragments/456.bugfix
@@ -1,0 +1,1 @@
+Correct pedestal handling for simulated images from ``simtbx``

--- a/src/dxtbx/format/FormatSMVJHSim.py
+++ b/src/dxtbx/format/FormatSMVJHSim.py
@@ -59,13 +59,9 @@ class FormatSMVJHSim(FormatSMV):
             float(self._header_dictionary["SIZE1"]),
             float(self._header_dictionary["SIZE2"]),
         )
-        image_pedestal = 1
-        try:
-            image_pedestal = float(self._header_dictionary["ADC_OFFSET"])
-        except (KeyError):
-            pass
+        image_pedestal = float(self._header_dictionary.get("ADC_OFFSET", 0))
         overload = 65535 - image_pedestal
-        underload = 1 - image_pedestal
+        underload = -1 - image_pedestal
 
         # interpret beam center conventions
         image_height_mm = pixel_size * image_size[1]
@@ -92,7 +88,7 @@ class FormatSMVJHSim(FormatSMV):
             image_size,
             (underload, overload),
             [],
-            pedestal=int(self._header_dictionary.get("ADC_OFFSET", 1)),
+            pedestal=image_pedestal,
         )
 
     def _beam(self):

--- a/src/dxtbx/format/FormatSMVJHSim.py
+++ b/src/dxtbx/format/FormatSMVJHSim.py
@@ -17,9 +17,9 @@ class FormatSMVJHSim(FormatSMV):
     # all ADSC detectors generate images with an ADC offset of 40
     # for Mar/Rayonix it is 10
     # Rigaku SMV uses 20, and 5 for image plate formats
-    # for one particular simulation, I used 1
+    # The images generated for https://bl831.als.lbl.gov/~jamesh/dose_slice/results.html
+    # use 1, so if a value is not provided in the header, default to 1
     ADC_OFFSET = 1
-    image_pedestal = 1
 
     @staticmethod
     def understand(image_file):
@@ -59,9 +59,11 @@ class FormatSMVJHSim(FormatSMV):
             float(self._header_dictionary["SIZE1"]),
             float(self._header_dictionary["SIZE2"]),
         )
-        image_pedestal = float(self._header_dictionary.get("ADC_OFFSET", 0))
+        image_pedestal = float(
+            self._header_dictionary.get("ADC_OFFSET", self.ADC_OFFSET)
+        )
         overload = 65535 - image_pedestal
-        underload = -1 - image_pedestal
+        underload = -1
 
         # interpret beam center conventions
         image_height_mm = pixel_size * image_size[1]


### PR DESCRIPTION
- default pedestal to 0 not 1
- trusted_range actually starts at the first untrusted value (#182)

With these changes, spots can be found on the attached zero noise image. Otherwise, the whole background is masked out and no spots are found.
[intimage_001.img.zip](https://github.com/dials/dxtbx/files/7661170/intimage_001.img.zip)
