### PR TITLE
Fix scan factory from dict inconsistency

### DIFF
--- a/newsfragments/XXX.bugfix
+++ b/newsfragments/XXX.bugfix
@@ -1,0 +1,1 @@
+Fixed inconsistency in Scan default constructor that gave different results when loading from Python dictionary.

--- a/src/dxtbx/model/scan.h
+++ b/src/dxtbx/model/scan.h
@@ -39,7 +39,9 @@ namespace dxtbx { namespace model {
     Scan()
         : image_range_(0, 0),
           oscillation_(0.0, 0.0),
-          num_images_(0),
+          num_images_(1),
+          exposure_times_(1, 0.0),
+          epochs_(1, 0.0),
           batch_offset_(0),
           is_still_(false) {}
 

--- a/tests/model/test_scan_data.py
+++ b/tests/model/test_scan_data.py
@@ -174,3 +174,15 @@ def test_from_phil():
     for i in range(ir1, ir2):
         assert s2.get_batch_for_image_index(i) == i + s2.get_batch_offset()
         assert s2.is_batch_valid(s2.get_batch_for_image_index(i))
+
+
+def test_scan_factory_from_dict(scan):
+
+    empty_scan = Scan()
+    empty_scan_from_dict = ScanFactory.from_dict(empty_scan.to_dict())
+
+    assert empty_scan_from_dict == empty_scan
+
+    scan_from_dict = ScanFactory.from_dict(scan.to_dict())
+
+    assert scan_from_dict == scan


### PR DESCRIPTION
This fixes this bug and adds a test for it:

```
from dxtbx.model import Scan, ScanFactory

Scan().get_num_images() # 0
ScanFactory.from_dict(Scan().to_dict()).get_num_images() # 1

Scan().get_exposure_times() # []
ScanFactory.from_dict(Scan().to_dict()).get_exposure_times() # [0.0]

Scan().get_epochs() # []
ScanFactory.from_dict(Scan().to_dict()).get_epochs() # [0.0]
```

This is fixed by updating the `Scan` default constructor because the current default `image_range` implies a single image (even though it's indexed at 0 which is invalid for `image_range`...), so the other parameters are updated to reflect that. The alternative would be specific branching in either `ScanFactory` or the `Scan` constructor it calls, which did not feel as clean.
