### PR TITLE
Allow `Beam.rotate_around_origin` to work with old files

### DIFF
--- a/newsfragments/xxx.bugfix
+++ b/newsfragments/xxx.bugfix
@@ -1,0 +1,1 @@
+Relax an assert that stopped ``Beam.rotate_around_origin`` working in some cases.

--- a/src/dxtbx/model/beam.h
+++ b/src/dxtbx/model/beam.h
@@ -369,8 +369,6 @@ namespace dxtbx { namespace model {
     }
 
     void rotate_around_origin(vec3<double> axis, double angle) {
-      const double EPS = 1e-7;
-      DXTBX_ASSERT(std::abs(direction_ * polarization_normal_) < EPS);
       direction_ = direction_.rotate_around_origin(axis, angle);
       polarization_normal_ = polarization_normal_.rotate_around_origin(axis, angle);
     }


### PR DESCRIPTION
`Beam.rotate_around_origin` asserts that the beam direction and polarization vector are orthogonal. While this sounds physically reasonable, dxtbx has separate setters for direction and polarization, so that as soon as one is changed without the other, the beam becomes inconsistent (https://github.com/cctbx/dxtbx/issues/454). Since https://github.com/dials/dials/issues/1939, `dials.refine` always updates both, but older results have non-orthogonal vectors, including `.expt` files used in tests. Currently, it is impossible to call `beam.rotate_around_origin` on these models.

This PR removes that assert. It is strange to have such an assert in this method in the first place, as `rotate_around_origin` is the one setter that actually _does_ preserve the angle between the direction and polarization.

It is, in general, impossible to update the either direction or polarization without updating the other. dxtbx should not have had separate setters for these in the first place, but that is a rather larger issue to deal with.