### PR TITLE
Check for incorrect SSL_CERT_FILE in dxtbx.install_format

### DIFF
--- a/newsfragments/XXX.bugfix
+++ b/newsfragments/XXX.bugfix
@@ -1,0 +1,1 @@
+``dxtbx.install_format``: Handle case on MacOS ``.pkg`` installations where URL-formats could not be installed.


### PR DESCRIPTION
This is normally correctly set by the libtbx dispatchers and rewritten upon
installation. However, on the MacOS .pkg installers, libtbx.refresh is not
run and so SSL_CERT_FILE points to a nonexistent directory.

This patch checks for this case explicitly when installing formats, and
rewrites it to the correct path before attempting to access the download URL.