### PR TITLE
Fix ExperimentList N² complexity appending experiments

### DIFF
--- a/newsfragments/XXX.bugfix
+++ b/newsfragments/XXX.bugfix
@@ -1,0 +1,1 @@
+``ExperimentList.append()``: No longer O(N²) with experiment identifiers.


### PR DESCRIPTION
Appending is always used when constructing an `ExperimentList` from python.

In cases where every `Experiment` being inserted had an identifier, every other experiment was scanned on every insertion. This switches to using an `std::unordered_set` to do the check instead.

In profiling, for a collection of 50k still experiments, this reduced the execution time of `ExperimentList.from_file(...)` from ~90s to ~4s.