### PR TITLE
Work around detector distance sign error

### DIFF
--- a/newsfragments/XXX.bugfix
+++ b/newsfragments/XXX.bugfix
@@ -1,0 +1,1 @@
+NXmx: if the detector reads as between the sample and source invert the detector distance. Unfortunate side-effect of a feature of the dectris Eiger file writer.


### PR DESCRIPTION
If the detector appears to be between the sample and the source then invert the detector Z such that the detector is then downstream of the sample. Fixes

Recognise that there could be additional defensive measures around this