### PR TITLE
Restrict conda-forge compilers for CI jobs

### DIFF
--- a/.azure-pipelines/ci-conda-env.txt
+++ b/.azure-pipelines/ci-conda-env.txt
@@ -1,10 +1,10 @@
 conda-forge::boost
 conda-forge::boost-cpp
 conda-forge::bzip2
-conda-forge::c-compiler
+conda-forge::c-compiler<1.5
 conda-forge::cctbx-base==2022.2
 conda-forge::conda
-conda-forge::cxx-compiler
+conda-forge::cxx-compiler<1.5
 conda-forge::python-dateutil
 conda-forge::dials-data
 conda-forge::docutils
@@ -12,7 +12,7 @@ conda-forge::eigen
 conda-forge::future
 conda-forge::h5py>=3.1
 conda-forge::hdf5plugin
-conda-forge::hdf5=1.12
+conda-forge::hdf5>=1.12,<1.13
 conda-forge::jpeg
 conda-forge::matplotlib-base
 conda-forge::mrcfile


### PR DESCRIPTION
The generation on Clang 14 appears to be incorrect for this combination of boost, python. In particular, in https://github.com/cctbx/dxtbx/blob/23f28fffb8f78321fa89e786b6c8e9aaefec4ea0/src/dxtbx/boost_python/ext.cpp#L196-L198, the generated assembly appears to early-call `_Py_Dealloc` near the top of the function without any kind of zero protections or checks:

```
    0x101c03be8 <+40>:   lea    rbx, [rip + 0x7d78]       ; "file"
    0x101c03bef <+47>:   mov    qword ptr [rbp - 0x88], rbx
    0x101c03bf6 <+54>:   mov    qword ptr [rbp - 0x30], 0x0
    0x101c03bfe <+62>:   lea    r12, [rip + 0x7d67]       ; "count"
    0x101c03c05 <+69>:   mov    qword ptr [rbp - 0x38], r12
    0x101c03c09 <+73>:   xorps  xmm0, xmm0
    0x101c03c0c <+76>:   movups xmmword ptr [rbp - 0x60], xmm0
    0x101c03c10 <+80>:   mov    qword ptr [rbp - 0x50], 0x0
    0x101c03c18 <+88>:   mov    qword ptr [rbp - 0x68], rbx
    0x101c03c1c <+92>:   call   0x101c0a63c               ; symbol stub for: _Py_Dealloc
    0x101c03c21 <+97>:   mov    qword ptr [rbp - 0x60], 0x0
    0x101c03c29 <+105>:  mov    qword ptr [rbp - 0x58], r12
    0x101c03c2d <+109>:  call   0x101c0a63c               ; symbol stub for: _Py_Dealloc
```
Whereas on clang 13 the calls to Dealloc are later, and include zero-protection around the calls (to _Py_Dealloc and the class destructors):
```
    0x101c03e85 <+197>:  mov    rdi, qword ptr [rbp - 0x50]
    0x101c03e89 <+201>:  test   rdi, rdi
    0x101c03e8c <+204>:  je     0x101c03e98               ; <+216> [inlined] boost::python::handle<_object>::~handle() + 19 at handle.hpp:183
    0x101c03e8e <+206>:  dec    qword ptr [rdi]
    0x101c03e91 <+209>:  jne    0x101c03e98               ; <+216> [inlined] boost::python::handle<_object>::~handle() + 19 at handle.hpp:183
    0x101c03e93 <+211>:  call   0x101c0a6bc               ; symbol stub for: _Py_Dealloc
    0x101c03e98 <+216>
```
I am unsure if this difference is coming from the compiler, or from the newer build of python associated with this compiler that conda-forge selects when constraining the compiler. In any case, constraining the compiler works for now and hopefully the problem will be fixed before this becomes a problem.