### PR TITLE
Run CMake CI build/tests on Windows

### DIFF
--- a/.azure-pipelines/azure-pipelines.yml
+++ b/.azure-pipelines/azure-pipelines.yml
@@ -111,7 +111,7 @@ stages:
 
     - job: windows
       pool:
-        vmImage: windows-latest
+        vmImage: windows-2019
       strategy:
         matrix:
           python38:

--- a/.azure-pipelines/ci-conda-env.txt
+++ b/.azure-pipelines/ci-conda-env.txt
@@ -2,7 +2,7 @@ conda-forge::boost
 conda-forge::boost-cpp
 conda-forge::bzip2
 conda-forge::c-compiler<1.5
-conda-forge::cctbx-base==2022.8
+conda-forge::cctbx-base==2022.12
 conda-forge::conda
 conda-forge::cxx-compiler<1.5
 conda-forge::python-dateutil

--- a/.azure-pipelines/windows-build.yml
+++ b/.azure-pipelines/windows-build.yml
@@ -16,58 +16,94 @@ steps:
   fetchDepth: 1
   displayName: Checkout $(Build.SourceBranch)
 
-# Download other source repositories
-- bash: |
-    set -eux
-
-    # Extract the version of cctbx-base from the conda environment file
-    [[ "$(cat modules/dxtbx/.azure-pipelines/ci-conda-env.txt)" =~ cctbx-base==([^:space:]+) ]]
-    cctbx_version="$(echo "${BASH_REMATCH[1]}" | xargs)"
-    echo "Using cctbx conda release ${cctbx_version}"
-
-    python3 modules/dxtbx/.azure-pipelines/bootstrap.py update --branch cctbx_project@"v${cctbx_version}"
-  displayName: Repository checkout
-  workingDirectory: $(Pipeline.Workspace)
-
-# Download additional source repositories required by cctbx-base (but not dxtbx)
-# cf. https://github.com/conda-forge/cctbx-base-feedstock/issues/12
-- bash: |
-    set -eux
-    git clone https://github.com/dials/annlib.git modules/annlib
-    git clone https://github.com/dials/annlib_adaptbx.git modules/annlib_adaptbx
-  displayName: Repository checkout (additional cctbx)
-  workingDirectory: $(Pipeline.Workspace)
+- powershell: Write-Host "##vso[task.prependpath]$env:CONDA\Scripts"
+  displayName: Add conda to PATH
 
 # Create a new conda environment using the bootstrap script
-- script: |
-    set PYTHONUNBUFFERED=TRUE
+- bash: |
+    set -eux
+    # Remove compilers from conda-env, as prebuilt cctbx appears to use
+    # the system configured compilers and so the conda-forge settings conflict
+    grep -v compiler modules/dxtbx/.azure-pipelines/ci-conda-env.txt > ci-conda-env.txt
+    echo pycbf >> ci-conda-env.txt
+    echo cmake >> ci-conda-env.txt
+    mv ci-conda-env.txt modules/dxtbx/.azure-pipelines/ci-conda-env.txt
+
     python3 modules/dxtbx/.azure-pipelines/bootstrap.py base --clean --python $(PYTHON_VERSION)
+
   displayName: Create python $(PYTHON_VERSION) environment
   workingDirectory: $(Pipeline.Workspace)
 
-# Next steps are currently disabled due to
-# https://github.com/conda-forge/cctbx-base-feedstock/issues/28
-#
-#
-## Build dxtbx using the bootstrap script
-#- script: |
-#    pushd "C:\Program Files (x86)\Microsoft Visual Studio\Installer\"
-#    for /f "delims=" %%x in ('.\vswhere.exe -latest -property InstallationPath') do set VSPATH=%%x
-#    popd
-#    call "%VSPATH%\VC\Auxiliary\Build\vcvarsall.bat" x64
-#
-#    python3 modules/dxtbx/.azure-pipelines/bootstrap.py build
-#  displayName: dxtbx build
-#  workingDirectory: $(Pipeline.Workspace)
-#
-## Ensure we are using up-to-date testing packages.
-## Extract the dials-data version so we can correctly cache regression data.
-#- script: |
-#    call conda_base/Scripts/activate
-#    conda install -y dials-data pytest-azurepipelines pytest-timeout
-#    dials.data info -v
-#    echo "##vso[task.setvariable variable=DIALS_DATA_VERSION_FULL]$(dials.data info -v | grep version.full)"
-#    echo "##vso[task.setvariable variable=DIALS_DATA_VERSION]$(dials.data info -v | grep version.major_minor)"
-#    mkdir -p data
-#  displayName: Install additional packages
-#  workingDirectory: $(Pipeline.Workspace)
+# Extract the dials-data version so we can correctly cache regression data.
+- bash: |
+    # Note: Running directly avoids having to deal with cross bash/cmd conda activation
+    conda_base/Scripts/dials.data-script.py info -v
+
+    echo "##vso[task.setvariable variable=DIALS_DATA_VERSION_FULL]$(conda_base/Scripts/dials.data-script.py info -v | grep version.full)"
+    echo "##vso[task.setvariable variable=DIALS_DATA_VERSION]$(conda_base/Scripts/dials.data-script.py info -v | grep version.major_minor)"
+    mkdir -p data
+  displayName: Determine dials.data version
+  workingDirectory: $(Pipeline.Workspace)
+
+# Build dxtbx
+- script: |
+    call activate conda_base/
+
+    mkdir build
+    cd build
+    cmake ../modules/dxtbx
+    if %errorlevel% neq 0 exit /b %errorlevel%
+
+    cmake --build . --config Release
+    if %errorlevel% neq 0 exit /b %errorlevel%
+
+    cmake --install . --config Release
+    if %errorlevel% neq 0 exit /b %errorlevel%
+
+    pip install ../modules/dxtbx
+    if %errorlevel% neq 0 exit /b %errorlevel%
+
+  displayName: Build dxtbx
+  workingDirectory: $(Pipeline.Workspace)
+
+# Retrieve the regression data from cache if possible
+# The cache allows day-to-day incremental updates, which is relevant only if
+# tests are added that refer to datasets in dials-data that were not previously
+# referred to.
+# New versions of dials-data also lead to cache updates, kick-started from the
+# previous cache version.
+# The cache is shared across operating systems and python versions, and flushed
+# once a week and for dials-data major and minor releases (eg. 2.0->2.1).
+- task: Cache@2
+  inputs:
+    key: '"data" | "$(CACHE_VERSION)-$(CURRENT_WEEK)" | "$(DIALS_DATA_VERSION)" | "$(TODAY_ISO)" | "$(DIALS_DATA_VERSION_FULL)"'
+    restoreKeys: |
+      "data" | "$(CACHE_VERSION)-$(CURRENT_WEEK)" | "$(DIALS_DATA_VERSION)" | "$(TODAY_ISO)"
+      "data" | "$(CACHE_VERSION)-$(CURRENT_WEEK)" | "$(DIALS_DATA_VERSION)"
+    path: $(Pipeline.Workspace)/data
+    cacheHitVar: DATA_CACHED
+  displayName: Restore regression data cache
+
+# Run the dxtbx regression suite
+- script: |
+    call activate conda_base/
+    SET PYTHONDEVMODE=1
+    SET DIALS_DATA=$(Pipeline.Workspace)/data
+    pytest -v -ra modules/dxtbx/tests --regression --basetemp="$(Pipeline.Workspace)/tests" --durations=10
+    if %errorlevel% neq 0 exit /b %errorlevel%
+  displayName: Run Tests
+  workingDirectory: $(Pipeline.Workspace)
+
+# Recover disk space after testing
+# This is only relevant if we had cache misses, as free disk space is required to create cache archives
+- bash: |
+    echo Disk space usage:
+    df -h
+    du -sh *
+    echo
+    echo Test artefacts:
+    du -h tests
+    rm -rf tests
+  displayName: Recover disk space
+  workingDirectory: $(Pipeline.Workspace)
+  condition: ne(variables.DATA_CACHED, 'true')

--- a/newsfragments/604.misc
+++ b/newsfragments/604.misc
@@ -1,0 +1,1 @@
+Update base prebuilt CCTBX, enable windows builds.


### PR DESCRIPTION
(To merge after https://github.com/cctbx/dxtbx/pull/607)

This updates prebuilt cctbx, and adds Windows to the platforms run by the azure CI. This was previously impossible due to https://github.com/conda-forge/cctbx-base-feedstock/issues/28, and apparently still causing problems as of https://github.com/cctbx/dxtbx/issues/396. Using the CMake build for windows (as well as mac and linux, which already use it) neatly sidesteps the issue.

Windows being the only platform missing has occasionally caused issues through things breaking on the windows build. https://github.com/cctbx/dxtbx/commit/c2706ed02f54985e2fb82dbc0a2ce9024125a1a, https://github.com/cctbx/dxtbx/commit/ec97f03ee1adfcab0ddf4800df8a5004411aa815 and https://github.com/cctbx/dxtbx/pull/607 were explicitly identified as things that were currently breaking, and have been fixed. We should endeavour to have a full-regression-suite running also. 

Fixes #396.