### PR TITLE
Fix windows libtbx-build compilation for modern C++

### DIFF
--- a/SConscript
+++ b/SConscript
@@ -129,6 +129,11 @@ if not env_etc.no_boost_python and hasattr(env_etc, "boost_adaptbx_include"):
         LIBPATH=env_etc.dxtbx_lib_paths + env_etc.dxtbx_hdf5_lib_paths,
     )
 
+    # Fix the build environment so that it doesn't break on modern C++
+    for path in list(env["CPPPATH"]):
+        if "msvc9.0_include" in path:
+            env["CPPPATH"].remove(path)
+
     if env_etc.clang_version:
         wd = ["-Wno-unused-function"]
         env.Append(CCFLAGS=wd)

--- a/newsfragments/XXX.misc
+++ b/newsfragments/XXX.misc
@@ -1,0 +1,1 @@
+Fix libtbx-build compilation for modern C++ on windows.


### PR DESCRIPTION
libtbx-build built-in paths were overriding the system-provided standard library with custom versions of - at least - stdint.h. This caused failures when trying to use C++14, but possibly some features of C++11 also.

This mainly seems to have been an issue with the MS-provided standard library on windows, but we don't want this to happen on any platform.

This should fix the root causes of at least https://github.com/dials/dials/pull/2310 and https://github.com/dials/dials/pull/2319 (which will probably need to repeat the procedure for dials)