### PR TITLE
Tidy model_ext namespacing and turn on Unity builds

### DIFF
--- a/.azure-pipelines/unix-build.yml
+++ b/.azure-pipelines/unix-build.yml
@@ -38,7 +38,7 @@ steps:
     set -ux
     mkdir build
     cd build
-    cmake ../modules/dxtbx
+    cmake ../modules/dxtbx -DCMAKE_UNITY_BUILD=true
     cmake --build . --target install
     pip install ../modules/dxtbx
   displayName: Build dxtbx

--- a/.azure-pipelines/windows-build.yml
+++ b/.azure-pipelines/windows-build.yml
@@ -51,7 +51,7 @@ steps:
 
     mkdir build
     cd build
-    cmake ../modules/dxtbx
+    cmake ../modules/dxtbx -DCMAKE_UNITY_BUILD=true
     if %errorlevel% neq 0 exit /b %errorlevel%
 
     cmake --build . --config Release

--- a/newsfragments/614.misc
+++ b/newsfragments/614.misc
@@ -1,0 +1,1 @@
+Tidy up dxtbx_model_ext namespacing, so that there are no name clashes when merged.

--- a/src/dxtbx/model/boost_python/beam.cc
+++ b/src/dxtbx/model/boost_python/beam.cc
@@ -19,162 +19,164 @@
 #include <scitbx/array_family/boost_python/flex_wrapper.h>
 
 namespace dxtbx { namespace model { namespace boost_python {
+  namespace beam_detail {
 
-  using namespace boost::python;
-  using scitbx::deg_as_rad;
-  using scitbx::rad_as_deg;
+    using namespace boost::python;
+    using scitbx::deg_as_rad;
+    using scitbx::rad_as_deg;
 
-  std::string beam_to_string(const Beam &beam) {
-    std::stringstream ss;
-    ss << beam;
-    return ss.str();
-  }
-
-  struct BeamPickleSuite : boost::python::pickle_suite {
-    static boost::python::tuple getinitargs(const Beam &obj) {
-      return boost::python::make_tuple(obj.get_sample_to_source_direction(),
-                                       obj.get_wavelength(),
-                                       obj.get_divergence(),
-                                       obj.get_sigma_divergence(),
-                                       obj.get_polarization_normal(),
-                                       obj.get_polarization_fraction(),
-                                       obj.get_flux(),
-                                       obj.get_transmission());
+    std::string beam_to_string(const Beam &beam) {
+      std::stringstream ss;
+      ss << beam;
+      return ss.str();
     }
 
-    static boost::python::tuple getstate(boost::python::object obj) {
-      const Beam &beam = boost::python::extract<const Beam &>(obj)();
-      return boost::python::make_tuple(obj.attr("__dict__"),
-                                       beam.get_s0_at_scan_points());
+    struct BeamPickleSuite : boost::python::pickle_suite {
+      static boost::python::tuple getinitargs(const Beam &obj) {
+        return boost::python::make_tuple(obj.get_sample_to_source_direction(),
+                                         obj.get_wavelength(),
+                                         obj.get_divergence(),
+                                         obj.get_sigma_divergence(),
+                                         obj.get_polarization_normal(),
+                                         obj.get_polarization_fraction(),
+                                         obj.get_flux(),
+                                         obj.get_transmission());
+      }
+
+      static boost::python::tuple getstate(boost::python::object obj) {
+        const Beam &beam = boost::python::extract<const Beam &>(obj)();
+        return boost::python::make_tuple(obj.attr("__dict__"),
+                                         beam.get_s0_at_scan_points());
+      }
+
+      static void setstate(boost::python::object obj, boost::python::tuple state) {
+        Beam &beam = boost::python::extract<Beam &>(obj)();
+        DXTBX_ASSERT(boost::python::len(state) == 2);
+
+        // restore the object's __dict__
+        boost::python::dict d =
+          boost::python::extract<boost::python::dict>(obj.attr("__dict__"))();
+        d.update(state[0]);
+
+        // restore the internal state of the C++ object
+        scitbx::af::const_ref<vec3<double> > s0_list =
+          boost::python::extract<scitbx::af::const_ref<vec3<double> > >(state[1]);
+        beam.set_s0_at_scan_points(s0_list);
+      }
+
+      static bool getstate_manages_dict() {
+        return true;
+      }
+    };
+
+    static Beam *make_beam(vec3<double> sample_to_source,
+                           double wavelength,
+                           double divergence,
+                           double sigma_divergence,
+                           bool deg) {
+      Beam *beam = NULL;
+      if (deg) {
+        beam = new Beam(sample_to_source,
+                        wavelength,
+                        deg_as_rad(divergence),
+                        deg_as_rad(sigma_divergence));
+      } else {
+        beam = new Beam(sample_to_source, wavelength, divergence, sigma_divergence);
+      }
+      return beam;
     }
 
-    static void setstate(boost::python::object obj, boost::python::tuple state) {
-      Beam &beam = boost::python::extract<Beam &>(obj)();
-      DXTBX_ASSERT(boost::python::len(state) == 2);
-
-      // restore the object's __dict__
-      boost::python::dict d =
-        boost::python::extract<boost::python::dict>(obj.attr("__dict__"))();
-      d.update(state[0]);
-
-      // restore the internal state of the C++ object
-      scitbx::af::const_ref<vec3<double> > s0_list =
-        boost::python::extract<scitbx::af::const_ref<vec3<double> > >(state[1]);
-      beam.set_s0_at_scan_points(s0_list);
+    static Beam *make_beam_w_s0(vec3<double> s0,
+                                double divergence,
+                                double sigma_divergence,
+                                bool deg) {
+      Beam *beam = NULL;
+      if (deg) {
+        beam = new Beam(s0, deg_as_rad(divergence), deg_as_rad(sigma_divergence));
+      } else {
+        beam = new Beam(s0, divergence, sigma_divergence);
+      }
+      return beam;
     }
 
-    static bool getstate_manages_dict() {
-      return true;
+    static Beam *make_beam_w_all(vec3<double> sample_to_source,
+                                 double wavelength,
+                                 double divergence,
+                                 double sigma_divergence,
+                                 vec3<double> polarization_normal,
+                                 double polarization_fraction,
+                                 double flux,
+                                 double transmission,
+                                 bool deg) {
+      Beam *beam = NULL;
+      if (deg) {
+        beam = new Beam(sample_to_source,
+                        wavelength,
+                        deg_as_rad(divergence),
+                        deg_as_rad(sigma_divergence),
+                        polarization_normal,
+                        polarization_fraction,
+                        flux,
+                        transmission);
+      } else {
+        beam = new Beam(sample_to_source,
+                        wavelength,
+                        divergence,
+                        sigma_divergence,
+                        polarization_normal,
+                        polarization_fraction,
+                        flux,
+                        transmission);
+      }
+      return beam;
     }
-  };
 
-  static Beam *make_beam(vec3<double> sample_to_source,
-                         double wavelength,
-                         double divergence,
-                         double sigma_divergence,
-                         bool deg) {
-    Beam *beam = NULL;
-    if (deg) {
-      beam = new Beam(sample_to_source,
-                      wavelength,
-                      deg_as_rad(divergence),
-                      deg_as_rad(sigma_divergence));
-    } else {
-      beam = new Beam(sample_to_source, wavelength, divergence, sigma_divergence);
+    static double get_divergence(const Beam &beam, bool deg) {
+      double divergence = beam.get_divergence();
+      return deg ? rad_as_deg(divergence) : divergence;
     }
-    return beam;
-  }
 
-  static Beam *make_beam_w_s0(vec3<double> s0,
-                              double divergence,
-                              double sigma_divergence,
-                              bool deg) {
-    Beam *beam = NULL;
-    if (deg) {
-      beam = new Beam(s0, deg_as_rad(divergence), deg_as_rad(sigma_divergence));
-    } else {
-      beam = new Beam(s0, divergence, sigma_divergence);
+    static double get_sigma_divergence(const Beam &beam, bool deg) {
+      double sigma_divergence = beam.get_sigma_divergence();
+      return deg ? rad_as_deg(sigma_divergence) : sigma_divergence;
     }
-    return beam;
-  }
 
-  static Beam *make_beam_w_all(vec3<double> sample_to_source,
-                               double wavelength,
-                               double divergence,
-                               double sigma_divergence,
-                               vec3<double> polarization_normal,
-                               double polarization_fraction,
-                               double flux,
-                               double transmission,
-                               bool deg) {
-    Beam *beam = NULL;
-    if (deg) {
-      beam = new Beam(sample_to_source,
-                      wavelength,
-                      deg_as_rad(divergence),
-                      deg_as_rad(sigma_divergence),
-                      polarization_normal,
-                      polarization_fraction,
-                      flux,
-                      transmission);
-    } else {
-      beam = new Beam(sample_to_source,
-                      wavelength,
-                      divergence,
-                      sigma_divergence,
-                      polarization_normal,
-                      polarization_fraction,
-                      flux,
-                      transmission);
+    static void set_divergence(Beam &beam, double divergence, bool deg) {
+      beam.set_divergence(deg ? deg_as_rad(divergence) : divergence);
     }
-    return beam;
-  }
 
-  static double get_divergence(const Beam &beam, bool deg) {
-    double divergence = beam.get_divergence();
-    return deg ? rad_as_deg(divergence) : divergence;
-  }
-
-  static double get_sigma_divergence(const Beam &beam, bool deg) {
-    double sigma_divergence = beam.get_sigma_divergence();
-    return deg ? rad_as_deg(sigma_divergence) : sigma_divergence;
-  }
-
-  static void set_divergence(Beam &beam, double divergence, bool deg) {
-    beam.set_divergence(deg ? deg_as_rad(divergence) : divergence);
-  }
-
-  static void set_sigma_divergence(Beam &beam, double sigma_divergence, bool deg) {
-    beam.set_sigma_divergence(deg ? deg_as_rad(sigma_divergence) : sigma_divergence);
-  }
-
-  static void rotate_around_origin(Beam &beam,
-                                   vec3<double> axis,
-                                   double angle,
-                                   bool deg) {
-    double angle_rad = deg ? deg_as_rad(angle) : angle;
-    beam.rotate_around_origin(axis, angle_rad);
-  }
-
-  static void Beam_set_s0_at_scan_points_from_tuple(Beam &beam,
-                                                    boost::python::tuple l) {
-    scitbx::af::shared<vec3<double> > s0_list;
-    for (std::size_t i = 0; i < boost::python::len(l); ++i) {
-      vec3<double> s0 = boost::python::extract<vec3<double> >(l[i]);
-      s0_list.push_back(s0);
+    static void set_sigma_divergence(Beam &beam, double sigma_divergence, bool deg) {
+      beam.set_sigma_divergence(deg ? deg_as_rad(sigma_divergence) : sigma_divergence);
     }
-    beam.set_s0_at_scan_points(s0_list.const_ref());
-  }
 
-  static void Beam_set_s0_at_scan_points_from_list(Beam &beam, boost::python::list l) {
-    scitbx::af::shared<vec3<double> > s0_list;
-    for (std::size_t i = 0; i < boost::python::len(l); ++i) {
-      vec3<double> s0 = boost::python::extract<vec3<double> >(l[i]);
-      s0_list.push_back(s0);
+    static void rotate_around_origin(Beam &beam,
+                                     vec3<double> axis,
+                                     double angle,
+                                     bool deg) {
+      double angle_rad = deg ? deg_as_rad(angle) : angle;
+      beam.rotate_around_origin(axis, angle_rad);
     }
-    beam.set_s0_at_scan_points(s0_list.const_ref());
-  }
 
+    static void Beam_set_s0_at_scan_points_from_tuple(Beam &beam,
+                                                      boost::python::tuple l) {
+      scitbx::af::shared<vec3<double> > s0_list;
+      for (std::size_t i = 0; i < boost::python::len(l); ++i) {
+        vec3<double> s0 = boost::python::extract<vec3<double> >(l[i]);
+        s0_list.push_back(s0);
+      }
+      beam.set_s0_at_scan_points(s0_list.const_ref());
+    }
+
+    static void Beam_set_s0_at_scan_points_from_list(Beam &beam,
+                                                     boost::python::list l) {
+      scitbx::af::shared<vec3<double> > s0_list;
+      for (std::size_t i = 0; i < boost::python::len(l); ++i) {
+        vec3<double> s0 = boost::python::extract<vec3<double> >(l[i]);
+        s0_list.push_back(s0);
+      }
+      beam.set_s0_at_scan_points(s0_list.const_ref());
+    }
+  }  // namespace beam_detail
   template <>
   boost::python::dict to_dict<Beam>(const Beam &obj) {
     boost::python::dict result;
@@ -214,13 +216,14 @@ namespace dxtbx { namespace model { namespace boost_python {
     if (obj.has_key("s0_at_scan_points")) {
       boost::python::list s0_at_scan_points =
         boost::python::extract<boost::python::list>(obj["s0_at_scan_points"]);
-      Beam_set_s0_at_scan_points_from_list(*b, s0_at_scan_points);
+      beam_detail::Beam_set_s0_at_scan_points_from_list(*b, s0_at_scan_points);
     }
     return b;
   }
 
   void export_beam() {
-    // Export BeamBase
+    using namespace beam_detail;
+
     class_<BeamBase, boost::noncopyable>("BeamBase", no_init)
       .def("get_sample_to_source_direction", &BeamBase::get_sample_to_source_direction)
       .def("set_direction", &BeamBase::set_direction)

--- a/src/dxtbx/model/boost_python/multi_axis_goniometer.cc
+++ b/src/dxtbx/model/boost_python/multi_axis_goniometer.cc
@@ -15,6 +15,7 @@
 #include <sstream>
 #include <dxtbx/model/goniometer.h>
 #include <dxtbx/model/multi_axis_goniometer.h>
+#include <dxtbx/model/boost_python/to_from_dict.h>
 
 namespace dxtbx { namespace model { namespace boost_python {
   namespace multi_axis_goniometer_detail {
@@ -61,6 +62,7 @@ namespace dxtbx { namespace model { namespace boost_python {
       }
     };
   }  // namespace multi_axis_goniometer_detail
+  template <>
   boost::python::dict to_dict(const MultiAxisGoniometer &obj) {
     boost::python::dict result;
     result["axes"] = boost::python::list(obj.get_axes());
@@ -83,6 +85,7 @@ namespace dxtbx { namespace model { namespace boost_python {
     return result;
   };
 
+  template <>
   MultiAxisGoniometer *from_dict(boost::python::dict obj) {
     scitbx::af::shared<vec3<double> > axes =
       boost::python::extract<scitbx::af::shared<vec3<double> > >(obj["axes"]);
@@ -119,6 +122,7 @@ namespace dxtbx { namespace model { namespace boost_python {
 
   void export_multi_axis_goniometer() {
     using namespace multi_axis_goniometer_detail;
+
     class_<MultiAxisGoniometer, bases<Goniometer> >("MultiAxisGoniometer")
       .def(
         init<const scitbx::af::const_ref<vec3<double> > &,
@@ -133,8 +137,10 @@ namespace dxtbx { namespace model { namespace boost_python {
       .def("get_names", &MultiAxisGoniometer::get_names)
       .def("get_scan_axis", &MultiAxisGoniometer::get_scan_axis)
       .def("__str__", &multi_axis_goniometer_to_string)
-      .def("to_dict", &to_dict)
-      .def("from_dict", &from_dict, return_value_policy<manage_new_object>())
+      .def("to_dict", &to_dict<MultiAxisGoniometer>)
+      .def("from_dict",
+           &from_dict<MultiAxisGoniometer>,
+           return_value_policy<manage_new_object>())
       .staticmethod("from_dict")
       .def_pickle(MultiAxisGoniometerPickleSuite());
   }

--- a/src/dxtbx/model/boost_python/multi_axis_goniometer.cc
+++ b/src/dxtbx/model/boost_python/multi_axis_goniometer.cc
@@ -17,49 +17,50 @@
 #include <dxtbx/model/multi_axis_goniometer.h>
 
 namespace dxtbx { namespace model { namespace boost_python {
+  namespace multi_axis_goniometer_detail {
 
-  using namespace boost::python;
+    using namespace boost::python;
 
-  std::string multi_axis_goniometer_to_string(const MultiAxisGoniometer &goniometer) {
-    std::stringstream ss;
-    ss << goniometer;
-    return ss.str();
-  }
-
-  struct MultiAxisGoniometerPickleSuite : boost::python::pickle_suite {
-    static boost::python::tuple getinitargs(const MultiAxisGoniometer &obj) {
-      return boost::python::make_tuple(
-        obj.get_axes(), obj.get_angles(), obj.get_names(), obj.get_scan_axis());
+    std::string multi_axis_goniometer_to_string(const MultiAxisGoniometer &goniometer) {
+      std::stringstream ss;
+      ss << goniometer;
+      return ss.str();
     }
 
-    static boost::python::tuple getstate(boost::python::object obj) {
-      const MultiAxisGoniometer &goniometer =
-        boost::python::extract<const MultiAxisGoniometer &>(obj)();
-      return boost::python::make_tuple(
-        obj.attr("__dict__"), goniometer.get_setting_rotation_at_scan_points());
-    }
+    struct MultiAxisGoniometerPickleSuite : boost::python::pickle_suite {
+      static boost::python::tuple getinitargs(const MultiAxisGoniometer &obj) {
+        return boost::python::make_tuple(
+          obj.get_axes(), obj.get_angles(), obj.get_names(), obj.get_scan_axis());
+      }
 
-    static void setstate(boost::python::object obj, boost::python::tuple state) {
-      MultiAxisGoniometer &goniometer =
-        boost::python::extract<MultiAxisGoniometer &>(obj)();
-      DXTBX_ASSERT(boost::python::len(state) == 2);
+      static boost::python::tuple getstate(boost::python::object obj) {
+        const MultiAxisGoniometer &goniometer =
+          boost::python::extract<const MultiAxisGoniometer &>(obj)();
+        return boost::python::make_tuple(
+          obj.attr("__dict__"), goniometer.get_setting_rotation_at_scan_points());
+      }
 
-      // restore the object's __dict__
-      boost::python::dict d =
-        boost::python::extract<boost::python::dict>(obj.attr("__dict__"))();
-      d.update(state[0]);
+      static void setstate(boost::python::object obj, boost::python::tuple state) {
+        MultiAxisGoniometer &goniometer =
+          boost::python::extract<MultiAxisGoniometer &>(obj)();
+        DXTBX_ASSERT(boost::python::len(state) == 2);
 
-      // restore the internal state of the C++ object
-      scitbx::af::const_ref<mat3<double> > S_list =
-        boost::python::extract<scitbx::af::const_ref<mat3<double> > >(state[1]);
-      goniometer.set_setting_rotation_at_scan_points(S_list);
-    }
+        // restore the object's __dict__
+        boost::python::dict d =
+          boost::python::extract<boost::python::dict>(obj.attr("__dict__"))();
+        d.update(state[0]);
 
-    static bool getstate_manages_dict() {
-      return true;
-    }
-  };
+        // restore the internal state of the C++ object
+        scitbx::af::const_ref<mat3<double> > S_list =
+          boost::python::extract<scitbx::af::const_ref<mat3<double> > >(state[1]);
+        goniometer.set_setting_rotation_at_scan_points(S_list);
+      }
 
+      static bool getstate_manages_dict() {
+        return true;
+      }
+    };
+  }  // namespace multi_axis_goniometer_detail
   boost::python::dict to_dict(const MultiAxisGoniometer &obj) {
     boost::python::dict result;
     result["axes"] = boost::python::list(obj.get_axes());
@@ -117,6 +118,7 @@ namespace dxtbx { namespace model { namespace boost_python {
   }
 
   void export_multi_axis_goniometer() {
+    using namespace multi_axis_goniometer_detail;
     class_<MultiAxisGoniometer, bases<Goniometer> >("MultiAxisGoniometer")
       .def(
         init<const scitbx::af::const_ref<vec3<double> > &,

--- a/src/dxtbx/model/boost_python/panel.cc
+++ b/src/dxtbx/model/boost_python/panel.cc
@@ -155,59 +155,6 @@ namespace dxtbx { namespace model { namespace boost_python {
       return result;
     }
 
-    Panel *panel_from_dict_with_offset(
-      boost::python::dict obj,
-      scitbx::af::versa<double, scitbx::af::c_grid<2> > dx,
-      scitbx::af::versa<double, scitbx::af::c_grid<2> > dy) {
-      Panel *result = basic_panel_from_dict(obj);
-      DXTBX_ASSERT(dx.accessor()[0] == result->get_image_size()[1]);
-      DXTBX_ASSERT(dx.accessor()[1] == result->get_image_size()[0]);
-      DXTBX_ASSERT(dx.accessor().all_eq(dy.accessor()));
-      if (obj.has_key("px_mm_strategy")) {
-        boost::python::dict st =
-          boost::python::extract<boost::python::dict>(obj["px_mm_strategy"]);
-        std::string name = boost::python::extract<std::string>(st["type"]);
-        if (name == "SimplePxMmStrategy") {
-          std::shared_ptr<PxMmStrategy> strategy(new SimplePxMmStrategy());
-          result->set_px_mm_strategy(strategy);
-        } else if (name == "ParallaxCorrectedPxMmStrategy") {
-          double mu = result->get_mu();
-          double t0 = result->get_thickness();
-          if (st.has_key("mu") && st.has_key("t0")) {
-            mu = boost::python::extract<double>(st["mu"]);
-            t0 = boost::python::extract<double>(st["t0"]);
-            result->set_mu(mu);
-            result->set_thickness(t0);
-          }
-          if (mu > 0 && t0 > 0) {
-            std::shared_ptr<PxMmStrategy> strategy(
-              new ParallaxCorrectedPxMmStrategy(mu, t0));
-            result->set_px_mm_strategy(strategy);
-          }
-        } else if (name == "OffsetPxMmStrategy") {
-          std::shared_ptr<PxMmStrategy> strategy(new OffsetPxMmStrategy(dx, dy));
-          result->set_px_mm_strategy(strategy);
-        } else if (name == "OffsetParallaxCorrectedPxMmStrategy") {
-          double mu = result->get_mu();
-          double t0 = result->get_thickness();
-          if (st.has_key("mu") && st.has_key("t0")) {
-            mu = boost::python::extract<double>(st["mu"]);
-            t0 = boost::python::extract<double>(st["t0"]);
-            result->set_mu(mu);
-            result->set_thickness(t0);
-          }
-          if (mu > 0 && t0 > 0) {
-            std::shared_ptr<PxMmStrategy> strategy(
-              new OffsetParallaxCorrectedPxMmStrategy(mu, t0, dx, dy));
-            result->set_px_mm_strategy(strategy);
-          }
-        } else {
-          DXTBX_ASSERT(false);
-        }
-      }
-      return result;
-    }
-
     Panel *panel_from_dict_with_offset_wrapper(
       boost::python::dict obj,
       scitbx::af::versa<double, scitbx::af::flex_grid<> > dx,
@@ -234,6 +181,60 @@ namespace dxtbx { namespace model { namespace boost_python {
       return panel.pixel_to_millimeter(px);
     }
   }  // namespace panel_detail
+
+  Panel *panel_from_dict_with_offset(
+    boost::python::dict obj,
+    scitbx::af::versa<double, scitbx::af::c_grid<2> > dx,
+    scitbx::af::versa<double, scitbx::af::c_grid<2> > dy) {
+    Panel *result = panel_detail::basic_panel_from_dict(obj);
+    DXTBX_ASSERT(dx.accessor()[0] == result->get_image_size()[1]);
+    DXTBX_ASSERT(dx.accessor()[1] == result->get_image_size()[0]);
+    DXTBX_ASSERT(dx.accessor().all_eq(dy.accessor()));
+    if (obj.has_key("px_mm_strategy")) {
+      boost::python::dict st =
+        boost::python::extract<boost::python::dict>(obj["px_mm_strategy"]);
+      std::string name = boost::python::extract<std::string>(st["type"]);
+      if (name == "SimplePxMmStrategy") {
+        std::shared_ptr<PxMmStrategy> strategy(new SimplePxMmStrategy());
+        result->set_px_mm_strategy(strategy);
+      } else if (name == "ParallaxCorrectedPxMmStrategy") {
+        double mu = result->get_mu();
+        double t0 = result->get_thickness();
+        if (st.has_key("mu") && st.has_key("t0")) {
+          mu = boost::python::extract<double>(st["mu"]);
+          t0 = boost::python::extract<double>(st["t0"]);
+          result->set_mu(mu);
+          result->set_thickness(t0);
+        }
+        if (mu > 0 && t0 > 0) {
+          std::shared_ptr<PxMmStrategy> strategy(
+            new ParallaxCorrectedPxMmStrategy(mu, t0));
+          result->set_px_mm_strategy(strategy);
+        }
+      } else if (name == "OffsetPxMmStrategy") {
+        std::shared_ptr<PxMmStrategy> strategy(new OffsetPxMmStrategy(dx, dy));
+        result->set_px_mm_strategy(strategy);
+      } else if (name == "OffsetParallaxCorrectedPxMmStrategy") {
+        double mu = result->get_mu();
+        double t0 = result->get_thickness();
+        if (st.has_key("mu") && st.has_key("t0")) {
+          mu = boost::python::extract<double>(st["mu"]);
+          t0 = boost::python::extract<double>(st["t0"]);
+          result->set_mu(mu);
+          result->set_thickness(t0);
+        }
+        if (mu > 0 && t0 > 0) {
+          std::shared_ptr<PxMmStrategy> strategy(
+            new OffsetParallaxCorrectedPxMmStrategy(mu, t0, dx, dy));
+          result->set_px_mm_strategy(strategy);
+        }
+      } else {
+        DXTBX_ASSERT(false);
+      }
+    }
+    return result;
+  }
+
   template <>
   boost::python::dict to_dict<VirtualPanel>(const VirtualPanel &obj) {
     boost::python::dict result;

--- a/src/dxtbx/model/boost_python/panel.cc
+++ b/src/dxtbx/model/boost_python/panel.cc
@@ -22,61 +22,218 @@
 #include <dxtbx/model/boost_python/pickle_suite.h>
 
 namespace dxtbx { namespace model { namespace boost_python {
+  namespace panel_detail {
+    using scitbx::deg_as_rad;
 
-  using scitbx::deg_as_rad;
-
-  std::string panel_to_string(const Panel &panel) {
-    std::stringstream ss;
-    ss << panel;
-    return ss.str();
-  }
-
-  static scitbx::af::shared<vec3<double> > get_lab_coord_multiple(
-    const Panel &panel,
-    scitbx::af::flex<vec2<double> >::type const &xy) {
-    scitbx::af::shared<vec3<double> > result((scitbx::af::reserve(xy.size())));
-    for (std::size_t i = 0; i < xy.size(); i++) {
-      result.push_back(panel.get_lab_coord(xy[i]));
+    std::string panel_to_string(const Panel &panel) {
+      std::stringstream ss;
+      ss << panel;
+      return ss.str();
     }
-    return result;
-  }
 
-  static scitbx::af::shared<vec2<double> > pixel_to_millimeter_multiple(
-    const Panel &panel,
-    scitbx::af::flex<vec2<double> >::type const &xy) {
-    scitbx::af::shared<vec2<double> > result((scitbx::af::reserve(xy.size())));
-    for (std::size_t i = 0; i < xy.size(); i++) {
-      result.push_back(panel.pixel_to_millimeter(xy[i]));
+    static scitbx::af::shared<vec3<double> > get_lab_coord_multiple(
+      const Panel &panel,
+      scitbx::af::flex<vec2<double> >::type const &xy) {
+      scitbx::af::shared<vec3<double> > result((scitbx::af::reserve(xy.size())));
+      for (std::size_t i = 0; i < xy.size(); i++) {
+        result.push_back(panel.get_lab_coord(xy[i]));
+      }
+      return result;
     }
-    return result;
-  }
 
-  static scitbx::af::shared<vec2<double> > millimeter_to_pixel_multiple(
-    const Panel &panel,
-    scitbx::af::flex<vec2<double> >::type const &xy) {
-    scitbx::af::shared<vec2<double> > result((scitbx::af::reserve(xy.size())));
-    for (std::size_t i = 0; i < xy.size(); i++) {
-      result.push_back(panel.millimeter_to_pixel(xy[i]));
+    static scitbx::af::shared<vec2<double> > pixel_to_millimeter_multiple(
+      const Panel &panel,
+      scitbx::af::flex<vec2<double> >::type const &xy) {
+      scitbx::af::shared<vec2<double> > result((scitbx::af::reserve(xy.size())));
+      for (std::size_t i = 0; i < xy.size(); i++) {
+        result.push_back(panel.pixel_to_millimeter(xy[i]));
+      }
+      return result;
     }
-    return result;
-  }
 
-  static Panel panel_deepcopy(const Panel &panel, boost::python::object dict) {
-    return Panel(panel);
-  }
+    static scitbx::af::shared<vec2<double> > millimeter_to_pixel_multiple(
+      const Panel &panel,
+      scitbx::af::flex<vec2<double> >::type const &xy) {
+      scitbx::af::shared<vec2<double> > result((scitbx::af::reserve(xy.size())));
+      for (std::size_t i = 0; i < xy.size(); i++) {
+        result.push_back(panel.millimeter_to_pixel(xy[i]));
+      }
+      return result;
+    }
 
-  static bool panel_is(const Panel *lhs, const Panel *rhs) {
-    return lhs == rhs;
-  }
+    static Panel panel_deepcopy(const Panel &panel, boost::python::object dict) {
+      return Panel(panel);
+    }
 
-  static void rotate_around_origin(Panel &panel,
-                                   vec3<double> axis,
-                                   double angle,
-                                   bool deg) {
-    double angle_rad = deg ? deg_as_rad(angle) : angle;
-    panel.rotate_around_origin(axis, angle_rad);
-  }
+    static bool panel_is(const Panel *lhs, const Panel *rhs) {
+      return lhs == rhs;
+    }
 
+    static void rotate_around_origin(Panel &panel,
+                                     vec3<double> axis,
+                                     double angle,
+                                     bool deg) {
+      double angle_rad = deg ? deg_as_rad(angle) : angle;
+      panel.rotate_around_origin(axis, angle_rad);
+    }
+
+    void set_projection_2d(Panel &obj, int4 rotation, int2 translation) {
+      const Projection2D projection_2d = Projection2D{rotation, translation};
+      obj.set_projection_2d(projection_2d);
+    }
+
+    boost::python::tuple projection_2d_to_tuple(const Panel &obj) {
+      boost::optional<Projection2D> panel_projection = obj.get_projection_2d();
+      if (panel_projection) {
+        Projection2D projection = static_cast<Projection2D>(*panel_projection);
+        return boost::python::make_tuple(projection.rotation, projection.translation);
+      } else {
+        return boost::python::make_tuple();
+      }
+    }
+
+    Panel *basic_panel_from_dict(boost::python::dict obj) {
+      Panel *result = new Panel();
+      if (obj.has_key("name")) {
+        result->set_name(boost::python::extract<std::string>(obj["name"]));
+      }
+      if (obj.has_key("type")) {
+        result->set_type(boost::python::extract<std::string>(obj["type"]));
+      }
+      if (obj.has_key("fast_axis") && obj.has_key("slow_axis")
+          && obj.has_key("origin")) {
+        result->set_local_frame(boost::python::extract<vec3<double> >(obj["fast_axis"]),
+                                boost::python::extract<vec3<double> >(obj["slow_axis"]),
+                                boost::python::extract<vec3<double> >(obj["origin"]));
+      }
+      if (obj.has_key("thickness")) {
+        result->set_thickness(boost::python::extract<double>(obj["thickness"]));
+      }
+      if (obj.has_key("material")) {
+        result->set_material(boost::python::extract<std::string>(obj["material"]));
+      }
+      if (obj.has_key("mu")) {
+        result->set_mu(boost::python::extract<double>(obj["mu"]));
+      }
+      if (obj.has_key("identifier")) {
+        result->set_identifier(boost::python::extract<std::string>(obj["identifier"]));
+      }
+      if (obj.has_key("mask")) {
+        scitbx::af::shared<int4> mask =
+          boost::python::extract<scitbx::af::shared<int4> >(
+            boost::python::extract<boost::python::list>(obj["mask"]));
+        result->set_mask(mask.const_ref());
+      }
+      if (obj.has_key("gain")) {
+        result->set_gain(boost::python::extract<double>(obj["gain"]));
+      }
+      if (obj.has_key("pedestal")) {
+        result->set_pedestal(boost::python::extract<double>(obj["pedestal"]));
+      }
+      if (obj.has_key("raw_image_offset")) {
+        result->set_raw_image_offset(
+          boost::python::extract<int2>(obj["raw_image_offset"]));
+      }
+      if (obj.has_key("image_size")) {
+        result->set_image_size(
+          boost::python::extract<tiny<std::size_t, 2> >(obj["image_size"]));
+      }
+      if (obj.has_key("pixel_size")) {
+        result->set_pixel_size(
+          boost::python::extract<tiny<double, 2> >(obj["pixel_size"]));
+      }
+      if (obj.has_key("trusted_range")) {
+        result->set_trusted_range(
+          boost::python::extract<tiny<double, 2> >(obj["trusted_range"]));
+      }
+      if (obj.has_key("projection_2d")) {
+        int4 rotation = boost::python::extract<int4>(obj["projection_2d"][0]);
+        int2 translation = boost::python::extract<int2>(obj["projection_2d"][1]);
+        const Projection2D projection_2d = Projection2D{rotation, translation};
+        result->set_projection_2d(projection_2d);
+      }
+      return result;
+    }
+
+    Panel *panel_from_dict_with_offset(
+      boost::python::dict obj,
+      scitbx::af::versa<double, scitbx::af::c_grid<2> > dx,
+      scitbx::af::versa<double, scitbx::af::c_grid<2> > dy) {
+      Panel *result = basic_panel_from_dict(obj);
+      DXTBX_ASSERT(dx.accessor()[0] == result->get_image_size()[1]);
+      DXTBX_ASSERT(dx.accessor()[1] == result->get_image_size()[0]);
+      DXTBX_ASSERT(dx.accessor().all_eq(dy.accessor()));
+      if (obj.has_key("px_mm_strategy")) {
+        boost::python::dict st =
+          boost::python::extract<boost::python::dict>(obj["px_mm_strategy"]);
+        std::string name = boost::python::extract<std::string>(st["type"]);
+        if (name == "SimplePxMmStrategy") {
+          std::shared_ptr<PxMmStrategy> strategy(new SimplePxMmStrategy());
+          result->set_px_mm_strategy(strategy);
+        } else if (name == "ParallaxCorrectedPxMmStrategy") {
+          double mu = result->get_mu();
+          double t0 = result->get_thickness();
+          if (st.has_key("mu") && st.has_key("t0")) {
+            mu = boost::python::extract<double>(st["mu"]);
+            t0 = boost::python::extract<double>(st["t0"]);
+            result->set_mu(mu);
+            result->set_thickness(t0);
+          }
+          if (mu > 0 && t0 > 0) {
+            std::shared_ptr<PxMmStrategy> strategy(
+              new ParallaxCorrectedPxMmStrategy(mu, t0));
+            result->set_px_mm_strategy(strategy);
+          }
+        } else if (name == "OffsetPxMmStrategy") {
+          std::shared_ptr<PxMmStrategy> strategy(new OffsetPxMmStrategy(dx, dy));
+          result->set_px_mm_strategy(strategy);
+        } else if (name == "OffsetParallaxCorrectedPxMmStrategy") {
+          double mu = result->get_mu();
+          double t0 = result->get_thickness();
+          if (st.has_key("mu") && st.has_key("t0")) {
+            mu = boost::python::extract<double>(st["mu"]);
+            t0 = boost::python::extract<double>(st["t0"]);
+            result->set_mu(mu);
+            result->set_thickness(t0);
+          }
+          if (mu > 0 && t0 > 0) {
+            std::shared_ptr<PxMmStrategy> strategy(
+              new OffsetParallaxCorrectedPxMmStrategy(mu, t0, dx, dy));
+            result->set_px_mm_strategy(strategy);
+          }
+        } else {
+          DXTBX_ASSERT(false);
+        }
+      }
+      return result;
+    }
+
+    Panel *panel_from_dict_with_offset_wrapper(
+      boost::python::dict obj,
+      scitbx::af::versa<double, scitbx::af::flex_grid<> > dx,
+      scitbx::af::versa<double, scitbx::af::flex_grid<> > dy) {
+      DXTBX_ASSERT(dx.accessor().all().size() == 2);
+      DXTBX_ASSERT(dy.accessor().all().size() == 2);
+      DXTBX_ASSERT(dx.accessor().all().all_eq(dy.accessor().all()));
+
+      std::size_t ysize = dx.accessor().all()[0];
+      std::size_t xsize = dx.accessor().all()[1];
+
+      scitbx::af::c_grid<2> grid(ysize, xsize);
+      scitbx::af::versa<double, scitbx::af::c_grid<2> > dx2(dx.handle(), grid);
+      scitbx::af::versa<double, scitbx::af::c_grid<2> > dy2(dy.handle(), grid);
+
+      return panel_from_dict_with_offset(obj, dx2, dy2);
+    }
+
+    vec3<double> get_pixel_lab_coord(Panel &panel, tiny<double, 2> px) {
+      return panel.get_pixel_lab_coord(px);
+    }
+
+    vec2<double> pixel_to_millimeter(Panel &panel, vec2<double> px) {
+      return panel.pixel_to_millimeter(px);
+    }
+  }  // namespace panel_detail
   template <>
   boost::python::dict to_dict<VirtualPanel>(const VirtualPanel &obj) {
     boost::python::dict result;
@@ -113,22 +270,6 @@ namespace dxtbx { namespace model { namespace boost_python {
     result["type"] = name;
     return result;
   }
-
-  void set_projection_2d(Panel &obj, int4 rotation, int2 translation) {
-    const Projection2D projection_2d = Projection2D{rotation, translation};
-    obj.set_projection_2d(projection_2d);
-  }
-
-  boost::python::tuple projection_2d_to_tuple(const Panel &obj) {
-    boost::optional<Projection2D> panel_projection = obj.get_projection_2d();
-    if (panel_projection) {
-      Projection2D projection = static_cast<Projection2D>(*panel_projection);
-      return boost::python::make_tuple(projection.rotation, projection.translation);
-    } else {
-      return boost::python::make_tuple();
-    }
-  }
-
   template <>
   boost::python::dict to_dict<Panel>(const Panel &obj) {
     boost::python::dict result;
@@ -150,75 +291,14 @@ namespace dxtbx { namespace model { namespace boost_python {
     result["pedestal"] = obj.get_pedestal();
     result["px_mm_strategy"] = to_dict(obj.get_px_mm_strategy());
     if (obj.get_projection_2d()) {
-      result["projection_2d"] = projection_2d_to_tuple(obj);
-    }
-    return result;
-  }
-
-  Panel *basic_panel_from_dict(boost::python::dict obj) {
-    Panel *result = new Panel();
-    if (obj.has_key("name")) {
-      result->set_name(boost::python::extract<std::string>(obj["name"]));
-    }
-    if (obj.has_key("type")) {
-      result->set_type(boost::python::extract<std::string>(obj["type"]));
-    }
-    if (obj.has_key("fast_axis") && obj.has_key("slow_axis") && obj.has_key("origin")) {
-      result->set_local_frame(boost::python::extract<vec3<double> >(obj["fast_axis"]),
-                              boost::python::extract<vec3<double> >(obj["slow_axis"]),
-                              boost::python::extract<vec3<double> >(obj["origin"]));
-    }
-    if (obj.has_key("thickness")) {
-      result->set_thickness(boost::python::extract<double>(obj["thickness"]));
-    }
-    if (obj.has_key("material")) {
-      result->set_material(boost::python::extract<std::string>(obj["material"]));
-    }
-    if (obj.has_key("mu")) {
-      result->set_mu(boost::python::extract<double>(obj["mu"]));
-    }
-    if (obj.has_key("identifier")) {
-      result->set_identifier(boost::python::extract<std::string>(obj["identifier"]));
-    }
-    if (obj.has_key("mask")) {
-      scitbx::af::shared<int4> mask = boost::python::extract<scitbx::af::shared<int4> >(
-        boost::python::extract<boost::python::list>(obj["mask"]));
-      result->set_mask(mask.const_ref());
-    }
-    if (obj.has_key("gain")) {
-      result->set_gain(boost::python::extract<double>(obj["gain"]));
-    }
-    if (obj.has_key("pedestal")) {
-      result->set_pedestal(boost::python::extract<double>(obj["pedestal"]));
-    }
-    if (obj.has_key("raw_image_offset")) {
-      result->set_raw_image_offset(
-        boost::python::extract<int2>(obj["raw_image_offset"]));
-    }
-    if (obj.has_key("image_size")) {
-      result->set_image_size(
-        boost::python::extract<tiny<std::size_t, 2> >(obj["image_size"]));
-    }
-    if (obj.has_key("pixel_size")) {
-      result->set_pixel_size(
-        boost::python::extract<tiny<double, 2> >(obj["pixel_size"]));
-    }
-    if (obj.has_key("trusted_range")) {
-      result->set_trusted_range(
-        boost::python::extract<tiny<double, 2> >(obj["trusted_range"]));
-    }
-    if (obj.has_key("projection_2d")) {
-      int4 rotation = boost::python::extract<int4>(obj["projection_2d"][0]);
-      int2 translation = boost::python::extract<int2>(obj["projection_2d"][1]);
-      const Projection2D projection_2d = Projection2D{rotation, translation};
-      result->set_projection_2d(projection_2d);
+      result["projection_2d"] = panel_detail::projection_2d_to_tuple(obj);
     }
     return result;
   }
 
   template <>
   Panel *from_dict<Panel>(boost::python::dict obj) {
-    Panel *result = basic_panel_from_dict(obj);
+    Panel *result = panel_detail::basic_panel_from_dict(obj);
     if (obj.has_key("px_mm_strategy")) {
       boost::python::dict st =
         boost::python::extract<boost::python::dict>(obj["px_mm_strategy"]);
@@ -268,86 +348,8 @@ namespace dxtbx { namespace model { namespace boost_python {
     return result;
   }
 
-  Panel *panel_from_dict_with_offset(
-    boost::python::dict obj,
-    scitbx::af::versa<double, scitbx::af::c_grid<2> > dx,
-    scitbx::af::versa<double, scitbx::af::c_grid<2> > dy) {
-    Panel *result = basic_panel_from_dict(obj);
-    DXTBX_ASSERT(dx.accessor()[0] == result->get_image_size()[1]);
-    DXTBX_ASSERT(dx.accessor()[1] == result->get_image_size()[0]);
-    DXTBX_ASSERT(dx.accessor().all_eq(dy.accessor()));
-    if (obj.has_key("px_mm_strategy")) {
-      boost::python::dict st =
-        boost::python::extract<boost::python::dict>(obj["px_mm_strategy"]);
-      std::string name = boost::python::extract<std::string>(st["type"]);
-      if (name == "SimplePxMmStrategy") {
-        std::shared_ptr<PxMmStrategy> strategy(new SimplePxMmStrategy());
-        result->set_px_mm_strategy(strategy);
-      } else if (name == "ParallaxCorrectedPxMmStrategy") {
-        double mu = result->get_mu();
-        double t0 = result->get_thickness();
-        if (st.has_key("mu") && st.has_key("t0")) {
-          mu = boost::python::extract<double>(st["mu"]);
-          t0 = boost::python::extract<double>(st["t0"]);
-          result->set_mu(mu);
-          result->set_thickness(t0);
-        }
-        if (mu > 0 && t0 > 0) {
-          std::shared_ptr<PxMmStrategy> strategy(
-            new ParallaxCorrectedPxMmStrategy(mu, t0));
-          result->set_px_mm_strategy(strategy);
-        }
-      } else if (name == "OffsetPxMmStrategy") {
-        std::shared_ptr<PxMmStrategy> strategy(new OffsetPxMmStrategy(dx, dy));
-        result->set_px_mm_strategy(strategy);
-      } else if (name == "OffsetParallaxCorrectedPxMmStrategy") {
-        double mu = result->get_mu();
-        double t0 = result->get_thickness();
-        if (st.has_key("mu") && st.has_key("t0")) {
-          mu = boost::python::extract<double>(st["mu"]);
-          t0 = boost::python::extract<double>(st["t0"]);
-          result->set_mu(mu);
-          result->set_thickness(t0);
-        }
-        if (mu > 0 && t0 > 0) {
-          std::shared_ptr<PxMmStrategy> strategy(
-            new OffsetParallaxCorrectedPxMmStrategy(mu, t0, dx, dy));
-          result->set_px_mm_strategy(strategy);
-        }
-      } else {
-        DXTBX_ASSERT(false);
-      }
-    }
-    return result;
-  }
-
-  Panel *panel_from_dict_with_offset_wrapper(
-    boost::python::dict obj,
-    scitbx::af::versa<double, scitbx::af::flex_grid<> > dx,
-    scitbx::af::versa<double, scitbx::af::flex_grid<> > dy) {
-    DXTBX_ASSERT(dx.accessor().all().size() == 2);
-    DXTBX_ASSERT(dy.accessor().all().size() == 2);
-    DXTBX_ASSERT(dx.accessor().all().all_eq(dy.accessor().all()));
-
-    std::size_t ysize = dx.accessor().all()[0];
-    std::size_t xsize = dx.accessor().all()[1];
-
-    scitbx::af::c_grid<2> grid(ysize, xsize);
-    scitbx::af::versa<double, scitbx::af::c_grid<2> > dx2(dx.handle(), grid);
-    scitbx::af::versa<double, scitbx::af::c_grid<2> > dy2(dy.handle(), grid);
-
-    return panel_from_dict_with_offset(obj, dx2, dy2);
-  }
-
-  vec3<double> get_pixel_lab_coord(Panel &panel, tiny<double, 2> px) {
-    return panel.get_pixel_lab_coord(px);
-  }
-
-  vec2<double> pixel_to_millimeter(Panel &panel, vec2<double> px) {
-    return panel.pixel_to_millimeter(px);
-  }
-
   void export_panel() {
+    using namespace panel_detail;
     using namespace boost::python;
 
     class_<VirtualPanelFrame>("VirtualPanelFrame")


### PR DESCRIPTION
Unity builds are when all the sources for a single output object are joined together into a single translation unit before linking. It is a technique that can reduce compile times by preventing re-parsing (at cost of increase memory usage during compile).

I've had to move some of the dxtbx.model declarations into sub-namespaces, because these modules somewhat relied on the ODR not applying to separate, static models.