### PR TITLE
Add polychromatic beam

### DIFF
--- a/newsfragments/XXX.misc
+++ b/newsfragments/XXX.misc
@@ -1,0 +1,1 @@
+Add PolyBeam for polychromatic experiments

--- a/src/dxtbx/dxtbx_model_ext.pyi
+++ b/src/dxtbx/dxtbx_model_ext.pyi
@@ -114,6 +114,35 @@ class Beam(BeamBase):
     def from_dict(data: Dict) -> Beam: ...
     def to_dict(self) -> Dict: ...
 
+class PolyBeam(Beam):
+    @overload
+    def __init__(self, beam: PolyBeam) -> None: ...
+    @overload
+    def __init__(self, direction: Vec3Float) -> None: ...
+    @overload
+    def __init__(
+        self,
+        direction: Vec3Float,
+        divergence: float,
+        sigma_divergence: float,
+        deg: bool = ...,
+    ) -> None: ...
+    @overload
+    def __init__(
+        self,
+        direction: Vec3Float,
+        divergence: float,
+        sigma_divergence: float,
+        polarization_normal: Vec3Float,
+        polarization_fraction: float,
+        flux: float,
+        transmission: float,
+        deg: bool = ...,
+    ) -> None: ...
+    @staticmethod
+    def from_dict(data: Dict) -> PolyBeam: ...
+    def to_dict(self) -> Dict: ...
+
 class CrystalBase:
     @property
     def num_scan_points(self) -> int: ...

--- a/src/dxtbx/model/__init__.py
+++ b/src/dxtbx/model/__init__.py
@@ -44,6 +44,7 @@ try:
         OffsetPxMmStrategy,
         Panel,
         ParallaxCorrectedPxMmStrategy,
+        PolyBeam,
         PxMmStrategy,
         Scan,
         ScanBase,
@@ -79,6 +80,7 @@ except ModuleNotFoundError:
         OffsetPxMmStrategy,
         Panel,
         ParallaxCorrectedPxMmStrategy,
+        PolyBeam,
         PxMmStrategy,
         Scan,
         ScanBase,
@@ -96,6 +98,7 @@ except ModuleNotFoundError:
 __all__ = (
     "Beam",
     "BeamBase",
+    "PolyBeam",
     "BeamFactory",
     "Crystal",
     "CrystalBase",

--- a/src/dxtbx/model/beam.h
+++ b/src/dxtbx/model/beam.h
@@ -418,11 +418,11 @@ namespace dxtbx { namespace model {
     }
 
     /**
-     * @param unit_s0 The incident beam unit vector pointing sample to source
+     * @param direction The beam direction pointing source to sample
      */
-    PolyBeam(vec3<double> unit_s0) {
-      DXTBX_ASSERT(unit_s0.length() > 0);
-      direction_ = -unit_s0.normalize();
+    PolyBeam(vec3<double> direction) {
+      DXTBX_ASSERT(direction.length() > 0);
+      direction_ = direction.normalize();
       set_divergence(0.0);
       set_sigma_divergence(0.0);
       set_polarization_normal(vec3<double>(0.0, 1.0, 0.0));
@@ -432,13 +432,13 @@ namespace dxtbx { namespace model {
     }
 
     /**
-     * @param unit_s0 The incident beam unit vector pointing sample to source
+     * @param direction The beam direction pointing source to sample
      * @param divergence The beam divergence
      * @param sigma_divergence The standard deviation of the beam divergence
      */
-    PolyBeam(vec3<double> unit_s0, double divergence, double sigma_divergence) {
-      DXTBX_ASSERT(unit_s0.length() > 0);
-      direction_ = -unit_s0.normalize();
+    PolyBeam(vec3<double> direction, double divergence, double sigma_divergence) {
+      DXTBX_ASSERT(direction.length() > 0);
+      direction_ = direction.normalize();
       set_divergence(divergence);
       set_sigma_divergence(sigma_divergence);
       set_polarization_normal(vec3<double>(0.0, 1.0, 0.0));
@@ -448,7 +448,7 @@ namespace dxtbx { namespace model {
     }
 
     /**
-     * @param unit_s0 The incident beam unit vector pointing sample to source
+     * @param direction The beam direction pointing source to sample
      * @param divergence The beam divergence
      * @param sigma_divergence The standard deviation of the beam divergence
      * @param polarization_normal The polarization plane
@@ -456,15 +456,15 @@ namespace dxtbx { namespace model {
      * @param flux The beam flux
      * @param transmission The beam transmission
      */
-    PolyBeam(vec3<double> unit_s0,
+    PolyBeam(vec3<double> direction,
              double divergence,
              double sigma_divergence,
              vec3<double> polarization_normal,
              double polarization_fraction,
              double flux,
              double transmission) {
-      DXTBX_ASSERT(unit_s0.length() > 0);
-      direction_ = -unit_s0.normalize();
+      DXTBX_ASSERT(direction.length() > 0);
+      direction_ = direction.normalize();
       set_divergence(divergence);
       set_sigma_divergence(sigma_divergence);
       set_polarization_normal(polarization_normal);

--- a/src/dxtbx/model/beam.py
+++ b/src/dxtbx/model/beam.py
@@ -1,15 +1,18 @@
 from __future__ import annotations
 
 import math
+from typing import Dict, Tuple, Union
 
 import pycbf
 
 import libtbx.phil
 
 try:
-    from ..dxtbx_model_ext import Beam
+    from ..dxtbx_model_ext import Beam, PolyBeam
 except ModuleNotFoundError:
-    from dxtbx_model_ext import Beam  # type: ignore
+    from dxtbx_model_ext import Beam, PolyBeam  # type: ignore
+
+Vec3Float = Tuple[float, float, float]
 
 beam_phil_scope = libtbx.phil.parse(
     """
@@ -17,6 +20,10 @@ beam_phil_scope = libtbx.phil.parse(
     .expert_level = 1
     .short_caption = "Beam overrides"
   {
+    type = *monochromatic polychromatic
+      .type = choice
+      .help = "Override the beam type"
+      .short_caption = "beam_type"
 
     wavelength = None
       .type = float
@@ -26,6 +33,14 @@ beam_phil_scope = libtbx.phil.parse(
       .type = floats(size=3)
       .help = "Override the sample to source direction"
       .short_caption = "Sample to source direction"
+
+    divergence = None
+        .type = float
+        .help = "Override the beam divergence"
+
+    sigma_divergence = None
+        .type = float
+        .help = "Override the beam sigma divergence"
 
     polarization_normal = None
       .type = floats(size=3)
@@ -57,61 +72,74 @@ class BeamFactory:
     will be used, otherwise simplified descriptions can be applied."""
 
     @staticmethod
-    def from_phil(params, reference=None):
+    def from_phil(
+        params: libtbx.phil.scope_extract, reference: Union[Beam, PolyBeam] = None
+    ) -> Union[Beam, PolyBeam]:
         """
         Convert the phil parameters into a beam model
-
         """
+
         # Check the input
         if reference is None:
-            beam = Beam()
+            beam = PolyBeam() if params.beam.type == "polychromatic" else Beam()
         else:
             beam = reference
 
         # Set the parameters
-        if params.beam.wavelength is not None:
-            beam.set_wavelength(params.beam.wavelength)
-        elif reference is None:
-            raise RuntimeError("No wavelength set")
+        if params.beam.type == "monochromatic":
+            if params.beam.wavelength is not None:
+                beam.set_wavelength(params.beam.wavelength)
+            elif reference is None:
+                raise RuntimeError("No wavelength set")
         if params.beam.direction is not None:
             beam.set_direction(params.beam.direction)
         elif reference is None:
             raise RuntimeError("No beam direction set")
+
+        if params.beam.divergence is not None:
+            beam.set_divergence(params.beam.divergence)
+        if params.beam.sigma_divergence is not None:
+            beam.set_sigma_divergence(params.beam.sigma_divergence)
         if params.beam.polarization_normal is not None:
             beam.set_polarization_normal(params.beam.polarization_normal)
         if params.beam.polarization_fraction is not None:
             beam.set_polarization_fraction(params.beam.polarization_fraction)
+        if params.beam.transmission is not None:
+            beam.set_transmission(params.beam.transmission)
+        if params.beam.flux is not None:
+            beam.set_flux(params.beam.flux)
 
         return beam
 
     @staticmethod
-    def from_dict(d, t=None):
-        """Convert the dictionary to a beam model
+    def from_dict(dict: Dict, template: Dict = None) -> Union[Beam, PolyBeam]:
+        """Convert the dictionary to a beam model"""
 
-        Params:
-            d The dictionary of parameters
-            t The template dictionary to use
+        if template is not None:
+            if "__id__" in dict and "__id__" in template:
+                assert (
+                    dict["__id__"] == template["__id__"]
+                ), "Beam and template dictionaries are not the same type."
 
-        Returns:
-            The beam model
-        """
-        if d is None and t is None:
+        if dict is None and template is None:
             return None
-        joint = t.copy() if t else {}
-        joint.update(d)
+        joint = template.copy() if template else {}
+        joint.update(dict)
 
         # Create the model from the joint dictionary
+        if "__id__" in joint and joint["__id__"] == "polychromatic":
+            return PolyBeam.from_dict(joint)
         return Beam.from_dict(joint)
 
     @staticmethod
     def make_beam(
-        sample_to_source=None,
-        wavelength=None,
-        s0=None,
-        unit_s0=None,
-        divergence=None,
-        sigma_divergence=None,
-    ):
+        sample_to_source: Vec3Float = None,
+        wavelength: float = None,
+        s0: Vec3Float = None,
+        unit_s0: Vec3Float = None,
+        divergence: float = None,
+        sigma_divergence: float = None,
+    ) -> Beam:
 
         if divergence is None or sigma_divergence is None:
             divergence = 0.0
@@ -138,18 +166,41 @@ class BeamFactory:
             return Beam(tuple(map(float, s0)))
 
     @staticmethod
+    def make_polybeam(
+        direction: Vec3Float,
+        divergence: float = 0.0,
+        sigma_divergence: float = 0.0,
+        polarization_normal: Vec3Float = (0.0, 1.0, 0.0),
+        polarization_fraction: float = 0.999,
+        flux: float = 0.0,
+        transmission: float = 1.0,
+        deg: bool = True,
+    ) -> PolyBeam:
+
+        return PolyBeam(
+            tuple(map(float, direction)),
+            float(divergence),
+            float(sigma_divergence),
+            tuple(map(float, polarization_normal)),
+            float(polarization_fraction),
+            float(flux),
+            float(transmission),
+            bool(deg),
+        )
+
+    @staticmethod
     def make_polarized_beam(
-        sample_to_source=None,
-        wavelength=None,
-        s0=None,
-        unit_s0=None,
-        polarization=None,
-        polarization_fraction=None,
-        divergence=None,
-        sigma_divergence=None,
-        flux=None,
-        transmission=None,
-    ):
+        sample_to_source: Vec3Float = None,
+        wavelength: float = None,
+        s0: Vec3Float = None,
+        unit_s0: Vec3Float = None,
+        polarization: Vec3Float = None,
+        polarization_fraction: float = None,
+        divergence: float = None,
+        sigma_divergence: float = None,
+        flux: float = None,
+        transmission: float = None,
+    ) -> Beam:
         assert polarization
         assert 0.0 <= polarization_fraction <= 1.0
 
@@ -199,7 +250,7 @@ class BeamFactory:
             )
 
     @staticmethod
-    def simple(wavelength):
+    def simple(wavelength: float) -> Beam:
         """Construct a beam object on the principle that the beam is aligned
         with the +z axis, as is quite normal. Also assume the beam has
         polarization fraction 0.999 and is polarized in the x-z plane, unless
@@ -219,7 +270,7 @@ class BeamFactory:
             )
 
     @staticmethod
-    def simple_directional(sample_to_source, wavelength):
+    def simple_directional(sample_to_source: Vec3Float, wavelength: float) -> Beam:
         """Construct a beam with direction and wavelength."""
 
         if wavelength > 0.05:
@@ -236,8 +287,11 @@ class BeamFactory:
 
     @staticmethod
     def complex(
-        sample_to_source, polarization_fraction, polarization_plane_normal, wavelength
-    ):
+        sample_to_source: Vec3Float,
+        polarization_fraction: float,
+        polarization_plane_normal: Vec3Float,
+        wavelength: float,
+    ) -> Beam:
         """Full access to the constructor for cases where we do know everything
         that we need..."""
 
@@ -249,7 +303,7 @@ class BeamFactory:
         )
 
     @staticmethod
-    def imgCIF(cif_file):
+    def imgCIF(cif_file: str) -> Beam:
         """Initialize a detector model from an imgCIF file. N.B. the
         definition of the polarization plane is not completely helpful
         in this - it is the angle between the polarization plane and the
@@ -263,7 +317,7 @@ class BeamFactory:
         return result
 
     @staticmethod
-    def imgCIF_H(cbf_handle):
+    def imgCIF_H(cbf_handle: pycbf.cbf_handle_struct) -> Beam:
         """Initialize a detector model from an imgCIF file. N.B. the
         definition of the polarization plane is not completely helpful
         in this - it is the angle between the polarization plane and the

--- a/src/dxtbx/model/boost_python/beam.cc
+++ b/src/dxtbx/model/boost_python/beam.cc
@@ -25,6 +25,8 @@ namespace dxtbx { namespace model { namespace boost_python {
     using scitbx::deg_as_rad;
     using scitbx::rad_as_deg;
 
+    // Beam
+
     std::string beam_to_string(const Beam &beam) {
       std::stringstream ss;
       ss << beam;
@@ -221,6 +223,94 @@ namespace dxtbx { namespace model { namespace boost_python {
     return b;
   }
 
+  // PolyBeam
+
+  struct PolyBeamPickleSuite : boost::python::pickle_suite {
+    static boost::python::tuple getinitargs(const PolyBeam &obj) {
+      return boost::python::make_tuple(obj.get_sample_to_source_direction(),
+                                       obj.get_divergence(),
+                                       obj.get_sigma_divergence(),
+                                       obj.get_polarization_normal(),
+                                       obj.get_polarization_fraction(),
+                                       obj.get_flux(),
+                                       obj.get_transmission());
+    }
+  };
+
+  static PolyBeam *make_polybeam(vec3<double> direction) {
+    return new PolyBeam(direction);
+  }
+
+  static PolyBeam *make_polybeam_w_divergence(vec3<double> direction,
+                                              double divergence,
+                                              double sigma_divergence,
+                                              bool deg) {
+    PolyBeam *beam = NULL;
+    if (deg) {
+      beam =
+        new PolyBeam(direction, deg_as_rad(divergence), deg_as_rad(sigma_divergence));
+    } else {
+      beam = new PolyBeam(direction, divergence, sigma_divergence);
+    }
+    return beam;
+  }
+
+  static PolyBeam *make_polybeam_w_all(vec3<double> direction,
+                                       double divergence,
+                                       double sigma_divergence,
+                                       vec3<double> polarization_normal,
+                                       double polarization_fraction,
+                                       double flux,
+                                       double transmission,
+                                       bool deg) {
+    PolyBeam *beam = NULL;
+    if (deg) {
+      beam = new PolyBeam(direction,
+                          deg_as_rad(divergence),
+                          deg_as_rad(sigma_divergence),
+                          polarization_normal,
+                          polarization_fraction,
+                          flux,
+                          transmission);
+    } else {
+      beam = new PolyBeam(direction,
+                          divergence,
+                          sigma_divergence,
+                          polarization_normal,
+                          polarization_fraction,
+                          flux,
+                          transmission);
+    }
+    return beam;
+  }
+
+  template <>
+  boost::python::dict to_dict<PolyBeam>(const PolyBeam &obj) {
+    boost::python::dict result;
+    result["direction"] = obj.get_sample_to_source_direction();
+    result["divergence"] = rad_as_deg(obj.get_divergence());
+    result["sigma_divergence"] = rad_as_deg(obj.get_sigma_divergence());
+    result["polarization_normal"] = obj.get_polarization_normal();
+    result["polarization_fraction"] = obj.get_polarization_fraction();
+    result["flux"] = obj.get_flux();
+    result["transmission"] = obj.get_transmission();
+    return result;
+  }
+
+  template <>
+  PolyBeam *from_dict<PolyBeam>(boost::python::dict obj) {
+    PolyBeam *b = new PolyBeam(
+      boost::python::extract<vec3<double> >(obj["direction"]),
+      deg_as_rad(boost::python::extract<double>(obj.get("divergence", 0.0))),
+      deg_as_rad(boost::python::extract<double>(obj.get("sigma_divergence", 0.0))),
+      boost::python::extract<vec3<double> >(
+        obj.get("polarization_normal", vec3<double>(0.0, 1.0, 0.0))),
+      boost::python::extract<double>(obj.get("polarization_fraction", 0.999)),
+      boost::python::extract<double>(obj.get("flux", 0)),
+      boost::python::extract<double>(obj.get("transmission", 1)));
+    return b;
+  }
+
   void export_beam() {
     using namespace beam_detail;
 
@@ -304,6 +394,34 @@ namespace dxtbx { namespace model { namespace boost_python {
       .def("from_dict", &from_dict<Beam>, return_value_policy<manage_new_object>())
       .staticmethod("from_dict")
       .def_pickle(BeamPickleSuite());
+
+    class_<PolyBeam, std::shared_ptr<PolyBeam>, bases<Beam> >("PolyBeam")
+      .def(
+        "__init__",
+        make_constructor(&make_polybeam, default_call_policies(), (arg("direction"))))
+      .def("__init__",
+           make_constructor(&make_polybeam_w_divergence,
+                            default_call_policies(),
+                            (arg("direction"),
+                             arg("divergence"),
+                             arg("sigma_divergence"),
+                             arg("deg") = true)))
+      .def("__init__",
+           make_constructor(&make_polybeam_w_all,
+                            default_call_policies(),
+                            (arg("direction"),
+                             arg("divergence"),
+                             arg("sigma_divergence"),
+                             arg("polarization_normal"),
+                             arg("polarization_fraction"),
+                             arg("flux"),
+                             arg("transmission"),
+                             arg("deg") = true)))
+      .def("__str__", &beam_to_string)
+      .def("to_dict", &to_dict<PolyBeam>)
+      .def("from_dict", &from_dict<PolyBeam>, return_value_policy<manage_new_object>())
+      .staticmethod("from_dict")
+      .def_pickle(PolyBeamPickleSuite());
 
     scitbx::af::boost_python::flex_wrapper<Beam>::plain("flex_Beam");
   }

--- a/src/dxtbx/model/boost_python/beam.cc
+++ b/src/dxtbx/model/boost_python/beam.cc
@@ -182,6 +182,7 @@ namespace dxtbx { namespace model { namespace boost_python {
   template <>
   boost::python::dict to_dict<Beam>(const Beam &obj) {
     boost::python::dict result;
+    result["__id__"] = "monochromatic";
     result["direction"] = obj.get_sample_to_source_direction();
     result["wavelength"] = obj.get_wavelength();
     result["divergence"] = rad_as_deg(obj.get_divergence());
@@ -224,6 +225,12 @@ namespace dxtbx { namespace model { namespace boost_python {
   }
 
   // PolyBeam
+
+  std::string polybeam_to_string(const PolyBeam &beam) {
+    std::stringstream ss;
+    ss << beam;
+    return ss.str();
+  }
 
   struct PolyBeamPickleSuite : boost::python::pickle_suite {
     static boost::python::tuple getinitargs(const PolyBeam &obj) {
@@ -287,6 +294,7 @@ namespace dxtbx { namespace model { namespace boost_python {
   template <>
   boost::python::dict to_dict<PolyBeam>(const PolyBeam &obj) {
     boost::python::dict result;
+    result["__id__"] = "polychromatic";
     result["direction"] = obj.get_sample_to_source_direction();
     result["divergence"] = rad_as_deg(obj.get_divergence());
     result["sigma_divergence"] = rad_as_deg(obj.get_sigma_divergence());
@@ -417,7 +425,7 @@ namespace dxtbx { namespace model { namespace boost_python {
                              arg("flux"),
                              arg("transmission"),
                              arg("deg") = true)))
-      .def("__str__", &beam_to_string)
+      .def("__str__", &polybeam_to_string)
       .def("to_dict", &to_dict<PolyBeam>)
       .def("from_dict", &from_dict<PolyBeam>, return_value_policy<manage_new_object>())
       .staticmethod("from_dict")

--- a/tests/model/test_beam.py
+++ b/tests/model/test_beam.py
@@ -5,7 +5,7 @@ import pytest
 from libtbx.phil import parse
 from scitbx import matrix
 
-from dxtbx.model import Beam
+from dxtbx.model import Beam, PolyBeam
 from dxtbx.model.beam import BeamFactory, beam_phil_scope
 
 
@@ -176,3 +176,95 @@ def test_beam_object_comparison():
 def test_beam_self_serialization():
     beam = Beam()
     assert beam == BeamFactory.from_dict(beam.to_dict())
+
+
+def test_polybeam_from_phil():
+    params = beam_phil_scope.fetch(
+        parse(
+            """
+    beam {
+      type = polychromatic
+      direction = (0., 0., 1.)
+      divergence = 0.2
+      sigma_divergence = 0.3
+      polarization_normal = (0., -1., 0.)
+      polarization_fraction = .65
+      transmission = .5
+      flux = .75
+    }
+    """
+        )
+    ).extract()
+
+    beam = BeamFactory.from_phil(params)
+    assert isinstance(beam, PolyBeam)
+
+    assert beam.get_sample_to_source_direction() == pytest.approx((0.0, 0.0, 1.0))
+    assert beam.get_divergence() == pytest.approx(0.2)
+    assert beam.get_sigma_divergence() == pytest.approx(0.3)
+    assert beam.get_polarization_normal() == pytest.approx((0.0, -1.0, 0.0))
+    assert beam.get_polarization_fraction() == pytest.approx(0.65)
+    assert beam.get_transmission() == pytest.approx(0.5)
+    assert beam.get_flux() == pytest.approx(0.75)
+
+
+def test_polybeam_from_dict():
+    beam = PolyBeam()
+    assert beam == BeamFactory.from_dict(beam.to_dict())
+
+
+def test_make_polybeam():
+
+    direction = (0.0, 0.0, 1.0)
+    divergence = 0.2
+    sigma_divergence = 0.3
+    polarization_normal = (0.0, -1.0, 0.0)
+    polarization_fraction = 0.65
+    transmission = 0.5
+    flux = 0.75
+
+    beam = BeamFactory.make_polybeam(
+        direction=direction,
+        divergence=divergence,
+        sigma_divergence=sigma_divergence,
+        polarization_normal=polarization_normal,
+        polarization_fraction=polarization_fraction,
+        transmission=transmission,
+        flux=flux,
+    )
+
+    assert beam.get_sample_to_source_direction() == pytest.approx((0.0, 0.0, 1.0))
+    assert beam.get_divergence() == pytest.approx(0.2)
+    assert beam.get_sigma_divergence() == pytest.approx(0.3)
+    assert beam.get_polarization_normal() == pytest.approx((0.0, -1.0, 0.0))
+    assert beam.get_polarization_fraction() == pytest.approx(0.65)
+    assert beam.get_transmission() == pytest.approx(0.5)
+    assert beam.get_flux() == pytest.approx(0.75)
+
+
+def test_polybeam_wavelength_guards():
+    beam = PolyBeam()
+    with pytest.raises(RuntimeError):
+        _ = beam.get_wavelength()
+    with pytest.raises(RuntimeError):
+        _ = beam.get_s0()
+    with pytest.raises(RuntimeError):
+        _ = beam.get_num_scan_points()
+    with pytest.raises(RuntimeError):
+        _ = beam.get_s0_at_scan_points()
+    with pytest.raises(RuntimeError):
+        _ = beam.get_s0_at_scan_point(0)
+    with pytest.raises(RuntimeError):
+        beam.reset_scan_points()
+    with pytest.raises(RuntimeError):
+        beam.set_wavelength(1.0)
+    with pytest.raises(RuntimeError):
+        beam.set_s0((0.0, 0.0, 0.1))
+
+
+def test_polybeam_str():
+    beam = PolyBeam()
+    assert (
+        beam.__str__()
+        == "Beam:\n    sample to source direction : {0,0,1}\n    divergence: 0\n    sigma divergence: 0\n    polarization normal: {0,1,0}\n    polarization fraction: 0.999\n    flux: 0\n    transmission: 1\n"
+    )


### PR DESCRIPTION
This adds a minimal polychromatic beam. All this is is a Beam with guards against using anything to do with a fixed wavelength. This feels like the least worst way to still conform to the set of `BeamBase` methods without resorting a lot of casting. The motivation is to ensure no logic involving fixed wavelengths is used for polychromatic experiments. In the time-of-flight case, wavelengths are only ever assigned to individual reflections. 

The only outward difference of this PR is beams in `.expt` files now have an `__id__` param to identify it as monochromatic or polychromatic.

This also tidies up some of the beam code with type hints / some typos in comments.