### PR TITLE
Fix for nxmx import overwritten by local variable

### DIFF
--- a/src/dxtbx/command_line/dlsnxs2cbf.py
+++ b/src/dxtbx/command_line/dlsnxs2cbf.py
@@ -2,7 +2,7 @@
 Convert a NXmx-format NeXus file to a set of CBF-format image files.
 
 Note that this tool does not produce full imgCIF-format files, only
-Dectris-style mini-CBF files consisting of a plain text simplified
+DECTRIS-style mini-CBF files consisting of a plain text simplified
 header and the binary compressed image data.  The simplified header
 does not contain a full description of the experiment geometry and some
 metadata, including the detector orientation, are unspecified.  As
@@ -18,7 +18,7 @@ from pathlib import Path
 
 import dxtbx.util.dlsnxs2cbf
 
-parser = argparse.ArgumentParser(description=__doc__)
+parser = argparse.ArgumentParser(description=__doc__, prog="dxtbx.dlsnxs2cbf")
 parser.add_argument(
     "nexus_file", metavar="nexus-file", help="Input NeXus file.", type=Path
 )

--- a/src/dxtbx/util/dlsnxs2cbf.py
+++ b/src/dxtbx/util/dlsnxs2cbf.py
@@ -12,11 +12,12 @@ import pint
 from tqdm import tqdm
 
 import dxtbx.model
+import dxtbx.nexus
 from dxtbx.ext import compress
 
 
-def compute_cbf_header(nxmx: nxmx.NXmx, nn: int):
-    nxentry = nxmx.entries[0]
+def compute_cbf_header(nxmx_obj: nxmx.NXmx, nn: int):
+    nxentry = nxmx_obj.entries[0]
     nxsample = nxentry.samples[0]
     nxinstrument = nxentry.instruments[0]
     nxdetector = nxinstrument.detectors[0]
@@ -145,11 +146,11 @@ def make_cbf(
     with h5py.File(in_name) as f:
         start_tag = binascii.unhexlify("0c1a04d5")
 
-        nxmx = nxmx.NXmx(f)
-        nxsample = nxmx.entries[0].samples[0]
-        nxinstrument = nxmx.entries[0].instruments[0]
+        nxmx_obj = nxmx.NXmx(f)
+        nxsample = nxmx_obj.entries[0].samples[0]
+        nxinstrument = nxmx_obj.entries[0].instruments[0]
         nxdetector = nxinstrument.detectors[0]
-        nxdata = nxmx.entries[0].data[0]
+        nxdata = nxmx_obj.entries[0].data[0]
 
         dependency_chain = nxmx.get_dependency_chain(nxsample.depends_on)
         scan_axis = None
@@ -183,7 +184,7 @@ def make_cbf(
 
         print(f"Writing images to {template}{'#' * num_digits}.cbf:")
         for j in tqdm(range(num_images), unit=" images"):
-            header = compute_cbf_header(nxmx, j)
+            header = compute_cbf_header(nxmx_obj, j)
             (data,) = dxtbx.nexus.get_raw_data(nxdata, nxdetector, j)
             if bit_depth_readout:
                 # if 32 bit then it is a signed int, I think if 8, 16 then it is

--- a/tests/command_line/test_dlsnxs2cbf.py
+++ b/tests/command_line/test_dlsnxs2cbf.py
@@ -69,10 +69,9 @@ def test_dlsnxs2cbf_deleted_axis(dials_data, tmp_path, remove_axis):
     make_cbf(tmp_path / master, template=str(tmp_path / "image_%04d.cbf"))
 
 
-@pytest.mark.xfail(reason="Broken for old data while collecting new data")
 def test_dlsnxs2cbf_help(capsys):
     with pytest.raises(SystemExit):
         run(["-h"])
     captured = capsys.readouterr()
-    assert parser.description in captured.out
-    assert "Template cbf output name e.g. 'image_%04d.cbf'" in captured.out
+    assert parser.description.splitlines()[0] in captured.out
+    assert "usage: dxtbx.dlsnxs2cbf" in captured.out


### PR DESCRIPTION
Introduced by #597

Another case were bugs have crept in through lack of tests (see #470)

Unbreak help test by explicitly setting program name