### PR TITLE
Easier override of panel geometry

### DIFF
--- a/newsfragments/299.bugfix
+++ b/newsfragments/299.bugfix
@@ -1,0 +1,1 @@
+Panel geometry definitions in PHIL are merged by panel id before constructing panels


### PR DESCRIPTION
This is intended to fix #299

Multiple PHIL scope extracts are merged by panel id before panels are constructed, ensuring all overrides for a single panel are contained in the same object.