### PR TITLE
Detector format for CHESS ID7B2 Eiger2 16M

### DIFF
--- a/newsfragments/686.feature
+++ b/newsfragments/686.feature
@@ -1,0 +1,4 @@
+Add detector format for CHESS beamline ID7B2 Eiger2 16M
+
+1. The spindle axis is reversed
+2. Detector firmware version is detected, and image dimensions are flipped accordingly

--- a/newsfragments/686.feature
+++ b/newsfragments/686.feature
@@ -1,4 +1,3 @@
 Add detector format for CHESS beamline ID7B2 Eiger2 16M
 
-1. The spindle axis is reversed
-2. Detector firmware version is detected, and image dimensions are flipped accordingly
+Handles the reversed spindle axis.

--- a/src/dxtbx/format/FormatNXmxEigerFilewriterCHESS.py
+++ b/src/dxtbx/format/FormatNXmxEigerFilewriterCHESS.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import re
+
+import h5py
+import nxmx
+from packaging import version
+
+from dxtbx.format.FormatNXmxEigerFilewriter import FormatNXmxEigerFilewriter
+
+DATA_FILE_RE = re.compile(r"data_\d{6}")
+
+
+class FormatNXmxEigerFilewriterCHESS(FormatNXmxEigerFilewriter):
+    _cached_file_handle = None
+
+    @staticmethod
+    def understand(image_file):
+        with h5py.File(image_file) as handle:
+            if "/entry/instrument/detector/detector_number" in handle:
+                if (
+                    handle["/entry/instrument/detector/detector_number"][()]
+                    == b'E-32-0123'
+                ):
+                    return True
+        return False
+
+    def _get_nxmx(self, fh: h5py.File):
+        nxmx_obj = nxmx.NXmx(fh)
+        nxentry = nxmx_obj.entries[0]
+
+        nxdetector = nxentry.instruments[0].detectors[0]
+        if nxdetector.underload_value is None:
+            nxdetector.underload_value = 0
+
+        # older firmware versions had the detector dimensions inverted
+        fw_version_string = (
+            fh["/entry/instrument/detector/detectorSpecific/eiger_fw_version"][()]
+            .decode()
+            .replace("release-", "")
+        )
+        
+        #print(f'detected Eiger firmware version: {fw_version_string}')
+        if version.parse(fw_version_string) < version.parse("2022.1.2"):
+            #print('swapping module size')
+            for module in nxdetector.modules:
+                module.data_size = module.data_size[::-1]
+        return nxmx_obj
+    
+    def _goniometer(self):
+        return self._goniometer_factory.known_axis((-1, 0, 0))

--- a/src/dxtbx/format/FormatNXmxEigerFilewriterCHESS.py
+++ b/src/dxtbx/format/FormatNXmxEigerFilewriterCHESS.py
@@ -1,10 +1,6 @@
 from __future__ import annotations
 
-import re
-
 import h5py
-import nxmx
-from packaging import version
 
 from dxtbx.format.FormatNXmxEigerFilewriter import FormatNXmxEigerFilewriter
 

--- a/src/dxtbx/format/FormatNXmxEigerFilewriterCHESS.py
+++ b/src/dxtbx/format/FormatNXmxEigerFilewriterCHESS.py
@@ -39,13 +39,11 @@ class FormatNXmxEigerFilewriterCHESS(FormatNXmxEigerFilewriter):
             .decode()
             .replace("release-", "")
         )
-        
-        #print(f'detected Eiger firmware version: {fw_version_string}')
+
         if version.parse(fw_version_string) < version.parse("2022.1.2"):
-            #print('swapping module size')
             for module in nxdetector.modules:
                 module.data_size = module.data_size[::-1]
         return nxmx_obj
-    
+
     def _goniometer(self):
         return self._goniometer_factory.known_axis((-1, 0, 0))

--- a/src/dxtbx/format/FormatNXmxEigerFilewriterCHESS.py
+++ b/src/dxtbx/format/FormatNXmxEigerFilewriterCHESS.py
@@ -8,9 +8,6 @@ from packaging import version
 
 from dxtbx.format.FormatNXmxEigerFilewriter import FormatNXmxEigerFilewriter
 
-DATA_FILE_RE = re.compile(r"data_\d{6}")
-
-
 class FormatNXmxEigerFilewriterCHESS(FormatNXmxEigerFilewriter):
     _cached_file_handle = None
 
@@ -24,26 +21,6 @@ class FormatNXmxEigerFilewriterCHESS(FormatNXmxEigerFilewriter):
                 ):
                     return True
         return False
-
-    def _get_nxmx(self, fh: h5py.File):
-        nxmx_obj = nxmx.NXmx(fh)
-        nxentry = nxmx_obj.entries[0]
-
-        nxdetector = nxentry.instruments[0].detectors[0]
-        if nxdetector.underload_value is None:
-            nxdetector.underload_value = 0
-
-        # older firmware versions had the detector dimensions inverted
-        fw_version_string = (
-            fh["/entry/instrument/detector/detectorSpecific/eiger_fw_version"][()]
-            .decode()
-            .replace("release-", "")
-        )
-
-        if version.parse(fw_version_string) < version.parse("2022.1.2"):
-            for module in nxdetector.modules:
-                module.data_size = module.data_size[::-1]
-        return nxmx_obj
 
     def _goniometer(self):
         return self._goniometer_factory.known_axis((-1, 0, 0))


### PR DESCRIPTION
Copied from https://github.com/FlexXBeamline/dials-extensions/blob/main/dials_extensions/FormatNXmxEigerFilewriterCHESS.py

This format addresses two issues with the FormatNXmxEigerFilewriter base class:

1. Recent firmware upgrade for Eiger2 16M which reverses image dimensions (see PR #676)
2. Reversed spindle axis at 7B2