### PR TITLE
Hit indices

### DIFF
--- a/newsfragments/709.feature
+++ b/newsfragments/709.feature
@@ -1,0 +1,1 @@
+Allows stepping through XTC streams at specific indices provided by a text file

--- a/src/dxtbx/format/FormatXTC.py
+++ b/src/dxtbx/format/FormatXTC.py
@@ -35,7 +35,7 @@ except TypeError:
 locator_str = """
   hits_file = None
     .type = str
-    .help = path to a file where each line is an index in the XTC stream of a crystal hit
+    .help = path to a file where each line is 2 numbers separated by a space, a run index, and an event index in the XTC stream
   experiment = None
     .type = str
     .help = Experiment identifier, e.g. mfxo1916


### PR DESCRIPTION
I originally opened https://github.com/dials/dxtbx/pull/198 , but the base repository was wrong!

So, in summary, this PR is for reprocessing XTC streams when you know the hit indices ahead of time. It works as expected when the psana datasource only includes a single run, but when doing things in multi-run mode, e.g. `ds = psana.Datasource("exp=cxily7829:run=21-26:idx")`, the indexing of events seems to get distorted. There are no "exceptions / code failures" from what I've seen, its just that the retrieved hits no longer correspond to what they were in the single run case. I honestly suspect its an issue with PSANA API not behaving as intended, most likely the bit where we get the event from the index, but it would be nice to trouble shoot for more eyes.

Long term, this could be useful if some preprocessing software or hardware determines the hit indices as data are rolling in from the detector.