### PR TITLE
Allow ToF experiments to share models.

### DIFF
--- a/newsfragments/XXX.misc
+++ b/newsfragments/XXX.misc
@@ -1,0 +1,1 @@
+Allow time of flight experiments to share models.


### PR DESCRIPTION
This allows a time of flight experiment consisting of different orientations (as separate nexus files) to share models (i.e the beam and detector models).