### PR TITLE
Add Laue experiment type

### DIFF
--- a/newsfragments/XXX.misc
+++ b/newsfragments/XXX.misc
@@ -1,0 +1,1 @@
+Add Laue experiment type.

--- a/src/dxtbx/model/boost_python/experiment.cc
+++ b/src/dxtbx/model/boost_python/experiment.cc
@@ -77,7 +77,8 @@ namespace dxtbx { namespace model { namespace boost_python {
     enum_<ExperimentType>("ExperimentType")
       .value("STILL", STILL)
       .value("ROTATION", ROTATION)
-      .value("TOF", TOF);
+      .value("TOF", TOF)
+      .value("LAUE", LAUE);
 
     class_<Experiment>("Experiment")
       .def(init<std::shared_ptr<BeamBase>,

--- a/src/dxtbx/model/experiment.h
+++ b/src/dxtbx/model/experiment.h
@@ -28,7 +28,7 @@
 
 namespace dxtbx { namespace model {
 
-  enum ExperimentType { ROTATION = 1, STILL = 2, TOF = 3 };
+  enum ExperimentType { ROTATION = 1, STILL = 2, TOF = 3, LAUE = 4 };
 
   /**
    * A class to represent what's in an experiment.
@@ -156,6 +156,13 @@ namespace dxtbx { namespace model {
       if (scan_ && scan_->contains("time_of_flight")) {
         return TOF;
       }
+
+      dxtbx::model::BeamBase &beam_base_ref = *beam_;
+      PolychromaticBeam *beam = dynamic_cast<PolychromaticBeam *>(&beam_base_ref);
+      if (beam != nullptr) {
+        return LAUE;
+      }
+
       if (!goniometer_ || !scan_ || scan_->is_still()) {
         return STILL;
       } else {

--- a/tests/model/test_experiment_list.py
+++ b/tests/model/test_experiment_list.py
@@ -17,6 +17,7 @@ from dxtbx.format.Format import Format
 from dxtbx.imageset import ImageSetFactory
 from dxtbx.model import (
     Beam,
+    BeamFactory,
     Crystal,
     Detector,
     Experiment,
@@ -26,6 +27,11 @@ from dxtbx.model import (
     Scan,
     ScanFactory,
 )
+
+try:
+    from ..dxtbx_model_ext import Probe
+except ModuleNotFoundError:
+    from dxtbx_model_ext import Probe  # type: ignore
 from dxtbx.model.experiment_list import ExperimentListDict, ExperimentListFactory
 
 
@@ -786,10 +792,22 @@ def test_experiment_type():
     # Specifically test the bug from dxtbx#4 triggered by ending on 0°
     experiment.scan = Scan((1, 1800), (-90, 0.05))
     assert experiment.get_type() == ExperimentType.ROTATION
+
+    experiment.beam = BeamFactory.make_polychromatic_beam(
+        direction=(0, 0, -1),
+        sample_to_source_distance=(100),
+        probe=Probe.xray,
+        wavelength_range=(1, 10),
+    )
+
+    assert experiment.get_type() == ExperimentType.LAUE
+
     experiment.scan = ScanFactory.make_scan_from_properties(
         (1, 10), properties={"time_of_flight": list(range(10))}
     )
     assert experiment.get_type() == ExperimentType.TOF
+
+    experiment.beam = Beam()
     experiment.scan = ScanFactory.make_scan_from_properties(
         (1, 10), properties={"other_property": list(range(10))}
     )


### PR DESCRIPTION
This adds `LAUE` as a type from `experiment.get_type()`. Defined as any experiment with a `PolychromaticBeam`.