### PR TITLE
Fix Scan.get_property key type.

### DIFF
--- a/newsfragments/XXX.bugfix
+++ b/newsfragments/XXX.bugfix
@@ -1,0 +1,1 @@
+Fix `Scan.get_property` key type.

--- a/src/dxtbx/model/scan.h
+++ b/src/dxtbx/model/scan.h
@@ -205,7 +205,8 @@ namespace dxtbx { namespace model {
     }
 
     template <typename T>
-    scitbx::af::shared<T> get_property(const typename T::key_type &key) const {
+    scitbx::af::shared<T> get_property(
+      const typename flex_table<scan_property_types>::key_type &key) const {
       DXTBX_ASSERT(properties_.contains(key));
       return properties_.get<T>(key);
     }


### PR DESCRIPTION
The key type in `Scan.get_property` was not properly defined, and so it couldn't be used easily from C++. This fixes it so you can do Scan.get_property("property_key"), as you can already in Python.