### PR TITLE
Revert "Pass through `resolve_path` when the path is not accessible"

### DIFF
--- a/newsfragments/772.bugfix
+++ b/newsfragments/772.bugfix
@@ -1,1 +1,0 @@
-Do not try to resolve file paths if they are not accessible.

--- a/src/dxtbx/serialize/filename.py
+++ b/src/dxtbx/serialize/filename.py
@@ -14,15 +14,11 @@ def resolve_path(path, directory=None):
       directory (Optional[str]): The local path to resolve relative links
 
     Returns:
-        str: The absolute path to the file to read if accessible, otherwise
-        return the original path as provided
+        str: The absolute path to the file to read
     """
     if not path:
         return ""
-    trial_path = os.path.expanduser(os.path.expandvars(path))
-    if directory and not os.path.isabs(trial_path):
-        trial_path = os.path.join(directory, trial_path)
-    if os.path.exists(trial_path):
-        return os.path.abspath(trial_path)
-    else:
-        return path
+    path = os.path.expanduser(os.path.expandvars(path))
+    if directory and not os.path.isabs(path):
+        path = os.path.join(directory, path)
+    return os.path.abspath(path)

--- a/tests/serialize/test_filename.py
+++ b/tests/serialize/test_filename.py
@@ -1,30 +1,15 @@
 from __future__ import annotations
 
 import os
-import uuid
 
 from dxtbx.serialize.filename import resolve_path
 
 
 def test_resolve_path(monkeypatch):
-    # Resolve path
-    def alwaystrue(path):
-        return True
-
-    # Set an environment variable
     monkeypatch.setenv("HELLO_WORLD", "EXPANDED")
-
-    # First try a path that does not exist
-    filename = str(uuid.uuid4())
-    new_path = os.path.join("~", "$HELLO_WORLD", filename)
+    new_path = os.path.join("~", "$HELLO_WORLD", "path")
     path = resolve_path(new_path)
-    assert path == new_path
-
-    # Now pretend the path exists
-    monkeypatch.setattr(os.path, "exists", alwaystrue)
+    assert path == os.path.join(os.path.expanduser("~"), "EXPANDED", "path")
+    new_path = os.path.join("$HELLO_WORLD", "path")
     path = resolve_path(new_path)
-    assert path == os.path.join(os.path.expanduser("~"), "EXPANDED", filename)
-
-    new_path = os.path.join("$HELLO_WORLD", filename)
-    path = resolve_path(new_path)
-    assert path == os.path.abspath(os.path.join("EXPANDED", filename))
+    assert path == os.path.abspath(os.path.join("EXPANDED", "path"))


### PR DESCRIPTION
Reverts cctbx/dxtbx#772

This causes failures on Jenkins