### PR TITLE
Only run actions on pushes to main

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -1,5 +1,7 @@
 on:
   push:
+    branches:
+      - main
   pull_request:
     types:
       - synchronize

--- a/newsfragments/978.misc
+++ b/newsfragments/978.misc
@@ -1,0 +1,1 @@
+Only run actions on push for main branch, to avoid running twice.


### PR DESCRIPTION
This should help avoid double-running when pushing to a PR