### PR TITLE
DIALS 3.24.1

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.24.0
+current_version = 3.24.1
 commit = True
 tag = False
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<release>[a-z]+)?(?P<patch>\d+)?

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,12 @@
+DIALS 3.24.1 (2025-05-13)
+=========================
+
+Bugfixes
+--------
+
+- ``dxtbx.install_format``: Fix for modern setuptools versions which drop legacy ``setup.py`` features. (`#808 <https://github.com/cctbx/dxtbx/issues/808>`_)
+
+
 dxtbx 3.24.0 (2025-04-29)
 =========================
 

--- a/newsfragments/808.bugfix
+++ b/newsfragments/808.bugfix
@@ -1,1 +1,0 @@
-``dxtbx.install_format``: Fix for modern setuptools versions which drop legacy ``setup.py`` features.

--- a/newsfragments/808.bugfix
+++ b/newsfragments/808.bugfix
@@ -1,0 +1,1 @@
+``dxtbx.install_format``: Fix for modern setuptools versions which drop legacy ``setup.py`` features.

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from build import build
 
 # Static version number which is updated by bump2version
 # Do not change this manually - use 'bump2version <major/minor/patch/release>'
-__version_tag__ = "3.24.0"
+__version_tag__ = "3.24.1"
 
 setup_kwargs = {
     "name": "dxtbx",

--- a/src/dxtbx/command_line/install_format.py
+++ b/src/dxtbx/command_line/install_format.py
@@ -97,7 +97,7 @@ setup(
     if not custom_folder.exists():
         os.symlink(home_location, custom_folder)
     subprocess.run(
-        ["libtbx.python", str(home_location / "setup.py"), "develop", "--user"],
+        [sys.executable, "-m", "pip", "install", "-e", "--user", str(home_location)],
         cwd=home_location,
         capture_output=True,
         check=True,


### PR DESCRIPTION
Bugfixes
--------

- ``dxtbx.install_format``: Fix for modern setuptools versions which drop legacy ``setup.py`` features. (#808)