### PR TITLE
Avoid reading h5 imagesets as having a single image, when a format class is not available.

### DIFF
--- a/newsfragments/XXX.bugfix
+++ b/newsfragments/XXX.bugfix
@@ -1,0 +1,1 @@
+Avoid reading h5 imagesets as having a single image, when a format class is not available

--- a/src/dxtbx/imageset.py
+++ b/src/dxtbx/imageset.py
@@ -450,6 +450,10 @@ class ImageSetFactory:
         if not check_format:
             assert not check_headers
 
+        # Import here as Format and Imageset have cyclic dependencies
+        from dxtbx.format.Format import Format
+        from dxtbx.format.FormatMultiImage import FormatMultiImage
+
         # Check the template is valid
         if "#" in template:
             # Get the template image range
@@ -459,23 +463,28 @@ class ImageSetFactory:
             # Set the image range
             indices = range(image_range[0], image_range[1] + 1)
             filenames = _expand_template_to_sorted_filenames(template, indices)
+            if check_format:
+                format_class = dxtbx.format.Registry.get_format_class_for_file(
+                    filenames[0]
+                )
+            else:
+                format_class = Format
         else:
             if "master" not in template:
                 raise ValueError("Invalid template")
             filenames = [template]
-
-        # Import here as Format and Imageset have cyclic dependencies
-        from dxtbx.format.Format import Format
-
-        # Get the format class
-        if check_format:
-            format_class = dxtbx.format.Registry.get_format_class_for_file(filenames[0])
-        else:
-            format_class = Format
+            indices = range(image_range[0], image_range[1] + 1)
+            if check_format:
+                format_class = dxtbx.format.Registry.get_format_class_for_file(
+                    filenames[0]
+                )
+            else:
+                format_class = FormatMultiImage
 
         # Create the sequence object
         sequence = format_class.get_imageset(
             filenames,
+            single_file_indices=indices,
             template=template,
             as_sequence=True,
             beam=beam,
@@ -571,29 +580,36 @@ class ImageSetFactory:
         """Create a sequence"""
         indices = sorted(indices)
 
+        # Import here as Format and Imageset have cyclic dependencies
+        from dxtbx.format.Format import Format
+        from dxtbx.format.FormatMultiImage import FormatMultiImage
+
         # Get the template format
         if "#" in template:
             filenames = _expand_template_to_sorted_filenames(template, indices)
+            # Get the format object and reader
+            if format_class is None:
+                if check_format:
+                    format_class = dxtbx.format.Registry.get_format_class_for_file(
+                        filenames[0]
+                    )
+                else:
+                    format_class = Format
         else:
             filenames = [template]
+            if format_class is None:
+                if check_format:
+                    format_class = dxtbx.format.Registry.get_format_class_for_file(
+                        filenames[0]
+                    )
+                else:
+                    format_class = FormatMultiImage
 
         # Set the image range
         array_range = (min(indices) - 1, max(indices))
         if scan is not None:
             assert array_range == scan.get_array_range()
             scan.set_batch_offset(array_range[0])
-
-        # Get the format object and reader
-        if format_class is None:
-            # Import here as Format and Imageset have cyclic dependencies
-            from dxtbx.format.Format import Format
-
-            if check_format:
-                format_class = dxtbx.format.Registry.get_format_class_for_file(
-                    filenames[0]
-                )
-            else:
-                format_class = Format
 
         return format_class.get_imageset(
             filenames,


### PR DESCRIPTION
Attempt to fix an issue described in https://github.com/dials/dials/issues/2944

I will try to create a minimal reproducer of the issue, but my basic understanding of the underlying cause is that these parts of the code should not always be defaulting to use `Format` when the true format class is not known (as we can't pass an image range to set up the 'Reader' correctly). That is appropriate for a e.g. cbf template but not data from a master.h5. Rather we need a `FormatMultiImage` in these cases. This kind of pattern seems to happen in other functions in this file, and I guess it is not a common code path for imageset creation as we usually know the format.

The dxtbx tests and dials command line tests all seem to pass still.