### PR TITLE
Tweaks for `dials.modify_experiments`

### DIFF
--- a/newsfragments/xxx.bugfix
+++ b/newsfragments/xxx.bugfix
@@ -1,0 +1,1 @@
+Bug fixes for ``CrystalFactory.from_phil``.

--- a/src/dxtbx/model/crystal.py
+++ b/src/dxtbx/model/crystal.py
@@ -20,7 +20,7 @@ except ModuleNotFoundError:
 crystal_phil_scope = iotbx.phil.parse(
     """
   crystal
-    .expert_level = 1
+    .expert_level = 2
     .short_caption = "Crystal overrides"
   {
     unit_cell = None
@@ -162,7 +162,7 @@ class CrystalFactory:
             params.crystal.space_group,
         ]
         if all_params.count(None) == len(all_params):
-            return None
+            return reference
 
         if reference is None:
             crystal = Crystal((1, 0, 0), (0, 1, 0), (0, 0, 1), "P1")


### PR DESCRIPTION
- Set `expert_level` to 2. This matches the `expert_level` of the other geometry PHIL parameters
- Bug fix: if the PHIL parameters are to do nothing, return the reference crystal model (if present) rather than `None`