### PR TITLE
Add overloads for Detector.get_ray_intersection 

### DIFF
--- a/newsfragments/misc.XXX
+++ b/newsfragments/misc.XXX
@@ -1,0 +1,1 @@
+Add overloads for Detector.get_ray_intersection to allow for arrays of s1 vectors.

--- a/src/dxtbx/model/boost_python/detector.cc
+++ b/src/dxtbx/model/boost_python/detector.cc
@@ -271,11 +271,31 @@ namespace dxtbx { namespace model { namespace boost_python {
     return detector_detail::detector_from_dict(result, obj);
   }
 
+  boost::python::tuple get_ray_intersection_py(const Detector &self,
+                                               scitbx::af::const_ref<vec3<double>> s1) {
+    /**
+     * Wrapper to convert coord_type to Python Tuple
+     */
+
+    scitbx::af::shared<Detector::coord_type> result = self.get_ray_intersection(s1);
+
+    scitbx::af::shared<vec2<double>> xy =
+      scitbx::af::shared<vec2<double>>(result.size());
+    scitbx::af::shared<std::size_t> panel =
+      scitbx::af::shared<std::size_t>(result.size());
+
+    for (std::size_t i = 0; i < result.size(); ++i) {
+      panel[i] = result[i].first;
+      xy[i] = result[i].second;
+    }
+    return boost::python::make_tuple(panel, xy);
+  }
+
   void export_detector() {
     using namespace boost::python;
     using namespace detector_detail;
 
-    class_<Detector::Node, bases<Panel> >("DetectorNode", no_init)
+    class_<Detector::Node, bases<Panel>>("DetectorNode", no_init)
       .def("add_group",
            (Detector::Node::pointer (Detector::Node::*)())&Detector::Node::add_group,
            return_internal_reference<>())
@@ -324,11 +344,11 @@ namespace dxtbx { namespace model { namespace boost_python {
             arg("origin_tolerance") = 1e-6,
             arg("static_only") = false,
             arg("ignore_trusted_range") = false))
-      .def("__iter__", iterator<Detector::Node, return_internal_reference<> >())
-      .def("children", iterator<Detector::Node, return_internal_reference<> >());
+      .def("__iter__", iterator<Detector::Node, return_internal_reference<>>())
+      .def("children", iterator<Detector::Node, return_internal_reference<>>());
 
     // Export a Detector base class
-    class_<Detector, std::shared_ptr<Detector> >("Detector")
+    class_<Detector, std::shared_ptr<Detector>>("Detector")
       .def(init<const Panel &>())
       .def("hierarchy",
            (Detector::node_pointer (Detector::*)())&Detector::root,
@@ -348,7 +368,7 @@ namespace dxtbx { namespace model { namespace boost_python {
       .def("__len__", &Detector::size)
       .def("__setitem__", &detector_set_item)
       .def("__getitem__", &detector_get_item, return_internal_reference<>())
-      .def("__iter__", iterator<Detector, return_internal_reference<> >())
+      .def("__iter__", iterator<Detector, return_internal_reference<>>())
       .def("__eq__", &Detector::operator==)
       .def("__ne__", &Detector::operator!=)
       .def("is_similar_to",
@@ -363,7 +383,17 @@ namespace dxtbx { namespace model { namespace boost_python {
       .def("get_max_inscribed_resolution",
            &Detector::get_max_inscribed_resolution,
            (arg("s0")))
-      .def("get_ray_intersection", &Detector::get_ray_intersection, (arg("s1")))
+      .def("get_ray_intersection",
+           (Detector::coord_type (Detector::*)(vec3<double>) const)
+             & Detector::get_ray_intersection,
+           (arg("s1")))
+      .def("get_ray_intersection", &get_ray_intersection_py, (arg("s1")))
+      .def("get_ray_intersection",
+           (scitbx::af::shared<vec2<double>> (Detector::*)(
+             scitbx::af::const_ref<vec3<double>>, scitbx::af::const_ref<std::size_t>)
+              const)
+             & Detector::get_ray_intersection,
+           (arg("s1"), arg("panel")))
       .def("get_panel_intersection", &Detector::get_panel_intersection, (arg("s1")))
       //.def("do_panels_intersect",
       //  &Detector::do_panels_intersect)
@@ -383,7 +413,7 @@ namespace dxtbx { namespace model { namespace boost_python {
       .staticmethod("from_dict")
       .def_pickle(DetectorPickleSuite());
 
-    boost_adaptbx::std_pair_conversions::to_and_from_tuple<int, vec2<double> >();
+    boost_adaptbx::std_pair_conversions::to_and_from_tuple<int, vec2<double>>();
   }
 
 }}}  // namespace dxtbx::model::boost_python

--- a/src/dxtbx/model/detector.h
+++ b/src/dxtbx/model/detector.h
@@ -49,11 +49,11 @@ namespace dxtbx { namespace model {
      * @param x The set of input points
      * @return The points in the convex hull
      */
-    inline scitbx::af::shared<vec2<double> > convex_hull(
-      const scitbx::af::const_ref<vec2<double> > &x) {
+    inline scitbx::af::shared<vec2<double>> convex_hull(
+      const scitbx::af::const_ref<vec2<double>> &x) {
       DXTBX_ASSERT(x.size() > 2);
 
-      scitbx::af::shared<vec2<double> > result;
+      scitbx::af::shared<vec2<double>> result;
 
       // Find the leftmost point
       std::size_t current = 0;
@@ -446,7 +446,7 @@ namespace dxtbx { namespace model {
       bool is_panel_;
     };
 
-    typedef std::pair<int, vec2<double> > coord_type;
+    typedef std::pair<int, vec2<double>> coord_type;
     typedef Node::pointer node_pointer;
     typedef Node::const_pointer const_node_pointer;
     typedef Panel panel_type;
@@ -668,7 +668,7 @@ namespace dxtbx { namespace model {
       vec3<double> xa = za.cross(ya).normalize();
 
       // Compute the stereographic projection of panel corners
-      scitbx::af::shared<vec2<double> > points;
+      scitbx::af::shared<vec2<double>> points;
       for (std::size_t i = 0; i < size(); ++i) {
         std::size_t width = (*this)[i].get_image_size()[0];
         std::size_t height = (*this)[i].get_image_size()[1];
@@ -688,7 +688,7 @@ namespace dxtbx { namespace model {
       }
 
       // Compute the convex hull of points
-      scitbx::af::shared<vec2<double> > hull = detail::convex_hull(points.const_ref());
+      scitbx::af::shared<vec2<double>> hull = detail::convex_hull(points.const_ref());
       DXTBX_ASSERT(hull.size() >= 4);
 
       // Compute the minimum distance to the line segments
@@ -736,6 +736,30 @@ namespace dxtbx { namespace model {
       // otherwise return the coordinate.
       DXTBX_ASSERT(w_max > 0);
       return pxy;
+    }
+
+    /** Get ray intersection with detector */
+    scitbx::af::shared<coord_type> get_ray_intersection(
+      scitbx::af::const_ref<vec3<double>> s1) const {
+      scitbx::af::shared<coord_type> result = scitbx::af::shared<coord_type>(s1.size());
+
+      for (std::size_t i = 0; i < s1.size(); ++i) {
+        result[i] = get_ray_intersection(s1[i]);
+      }
+      return result;
+    }
+
+    /** Get ray intersection with detector */
+    scitbx::af::shared<vec2<double>> get_ray_intersection(
+      scitbx::af::const_ref<vec3<double>> s1,
+      scitbx::af::const_ref<std::size_t> panel) const {
+      DXTBX_ASSERT(s1.size() == panel.size());
+      scitbx::af::shared<vec2<double>> xy = scitbx::af::shared<vec2<double>>(s1.size());
+
+      for (std::size_t i = 0; i < s1.size(); ++i) {
+        xy[i] = (*this)[panel[i]].get_ray_intersection(s1[i]);
+      }
+      return xy;
     }
 
     /** finds the panel id with which s1 intersects.  Returns -1 if none do. **/


### PR DESCRIPTION
This adds overloads to `Detector.get_ray_intersection` so that you can use it with arrays of s1 vectors.
Usage:

`>>> r = reflection_table.from_msgpack_file("indexed.refl")`

Original behaviour:
```
>>> detector.get_ray_intersection(r["s1"][0])
(0, (41.538954962474804, 161.85078625725504))
```
Using an array of s1 vectors returns a Tuple as the c++ `Detector::coord_type` has no Python converter and this seemed more useful:
```
>>> panel, xy = detector.get_ray_intersection(r["s1"])
>>> panel[0]
0
>>> xy[0]
(41.538954962474804, 161.85078625725504)
```

If you know the panel you can pass this in to only get the xy:

```
>>> xy = detector.get_ray_intersection(r["s1"], r["panel"])
>>> xy[0]
(41.538954962474804, 161.85078625725504)
```

This can be used to construct a vec3 flex array quickly. E.g:

```
>>> x,y = detector.get_ray_intersection(r["s1"], r["panel"]).parts()
>>> flex.vec3_double(x,y,x)
<scitbx_array_family_flex_ext.vec3_double object at 0x7fe016307ce0>
```
